### PR TITLE
Fix release-please backfill and publish filter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      backfill:
+        description: Backfill tags/releases for merged release PRs
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -12,6 +19,7 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       paths_released: ${{ steps.release.outputs.paths_released }}
@@ -20,15 +28,28 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  backfill:
+    name: Release Please (Backfill)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill }}
+    steps:
+      - name: Release Please (github-release)
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          command: github-release
 
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ github.event_name == 'push' && needs.release-please.outputs.releases_created == 'true' }}
     permissions:
       contents: read
       id-token: write
@@ -57,7 +78,7 @@ jobs:
         run: pnpm test
 
       - name: Publish to npm
-        run: pnpm -r publish --access public --no-git-checks
+        run: node scripts/release/publish-packages.mjs '${{ needs.release-please.outputs.paths_released }}'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,61 @@
+# Release Operations
+
+This repository uses Release Please to manage version bumps, tags, GitHub releases,
+and npm publishing for the pnpm monorepo.
+
+## Normal Release Flow
+
+1. Merge conventional-commit PRs into `main`.
+2. Release Please opens release PRs per package.
+3. Merge the release PR(s).
+4. Release Please creates tags and GitHub releases.
+5. The publish job releases only the updated packages to npm.
+
+Release PR titles follow:
+
+```
+chore: release <component> <version>
+```
+
+Tag format (from config):
+
+```
+@manifesto-ai/<package>-v<version>
+```
+
+## Required Secrets
+
+- `NPM_TOKEN`: npm publish token with access to `@manifesto-ai/*`.
+- `RELEASE_PLEASE_TOKEN` (optional): PAT used when `GITHUB_TOKEN` cannot create PRs.
+
+Minimal PAT scopes (fine-grained):
+- Contents: read/write
+- Pull requests: read/write
+- Metadata: read
+
+For classic PAT, `repo` is sufficient.
+
+## Recovery: Release Please Blocked by Untagged Release PRs
+
+If the workflow logs:
+`There are untagged, merged release PRs outstanding - aborting`
+
+1. Run the **Release** workflow manually with `backfill=true`.
+2. Confirm tags and GitHub releases were created.
+3. Re-run the Release workflow or merge a new PR to resume normal flow.
+
+## Consistency Checklist
+
+Use this checklist to verify repo state when releases are stuck:
+
+- `.release-please-manifest.json` versions match each `packages/*/package.json`.
+- Tags exist for every package/version in the manifest.
+  - Example: `git tag -l '@manifesto-ai/*-v1.1.0'`
+- GitHub Releases exist for the same tags.
+- npm shows the same version for each package (example):
+  - `npm view @manifesto-ai/core version`
+
+## Merge Strategy
+
+Merge commits can trigger non-fatal conventional-commit warnings in logs.
+Prefer **squash merge** with a conventional PR title to keep logs clean.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,8 +5,8 @@
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": true,
   "include-v-in-tag": true,
-  "group-pull-request-title-pattern": "chore: release ${version}",
-  "pull-request-title-pattern": "chore: release${component} ${version}",
+  "separate-pull-requests": true,
+  "pull-request-title-pattern": "chore${scope}: release ${component} ${version}",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },

--- a/scripts/release/publish-packages.mjs
+++ b/scripts/release/publish-packages.mjs
@@ -1,0 +1,44 @@
+import { spawnSync } from "node:child_process";
+
+const raw = process.argv[2];
+
+if (!raw || raw === "[]") {
+  console.log("No released package paths provided. Skipping publish.");
+  process.exit(0);
+}
+
+let paths;
+try {
+  paths = JSON.parse(raw);
+} catch (error) {
+  paths = raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+if (!Array.isArray(paths) || paths.length === 0) {
+  console.log("No released packages found. Skipping publish.");
+  process.exit(0);
+}
+
+const filters = paths
+  .map((entry) => String(entry).replace(/\/+$/, ""))
+  .filter((entry) => entry && entry !== ".");
+
+if (filters.length === 0) {
+  console.log("No publishable packages found. Skipping publish.");
+  process.exit(0);
+}
+
+const args = [
+  "-r",
+  ...filters.flatMap((entry) => ["--filter", entry]),
+  "publish",
+  "--access",
+  "public",
+  "--no-git-checks",
+];
+
+const result = spawnSync("pnpm", args, { stdio: "inherit" });
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Root cause (3 lines)
- PR #19 merged with title `chore: release`, which did not match the configured `pullRequestTitlePattern`.
- No component tags/releases were created for that merged release PR, so release-please aborted with "untagged, merged release PRs outstanding".
- Merge commits generated conventional-commit parse warnings (noise), but the abort was caused by missing tags.

## Recovery strategy (Backfill)
- Backfilled tags and GitHub releases for PR #19 at merge commit `e989329b771f679e65c4b53cc7a9b1222d749c82`.
- Added workflow backfill mode (`workflow_dispatch` + `command: github-release`) for future recovery without manual tagging.

## Changes
- `.github/workflows/release.yml`
- `release-please-config.json`
- `scripts/release/publish-packages.mjs`
- `docs/release-recovery.md`

## Tags backfilled (PR #19)
- `@manifesto-ai/bridge-v1.2.0`
- `@manifesto-ai/builder-v1.2.0`
- `@manifesto-ai/compiler-v1.2.0`
- `@manifesto-ai/core-v1.2.0`
- `@manifesto-ai/effect-utils-v1.2.0`
- `@manifesto-ai/host-v1.2.0`
- `@manifesto-ai/lab-v1.2.0`
- `@manifesto-ai/memory-v1.2.0`
- `@manifesto-ai/react-v1.2.0`
- `@manifesto-ai/world-v1.2.0`

## Prevention checklist
- [x] PR title pattern fixed to `chore: release <component> <version>`
- [x] PAT fallback supported via `RELEASE_PLEASE_TOKEN`
- [x] Publish filtered by `paths_released` only
- [x] Recovery steps documented (`docs/release-recovery.md`)
- [x] Squash merge guidance documented to reduce merge commit warnings

## Testing
- Not run (workflow/docs-only changes).