### PR TITLE
Normalize release-please titles and recovery doc

### DIFF
--- a/docs/release-recovery.md
+++ b/docs/release-recovery.md
@@ -1,4 +1,4 @@
-# Release Operations
+# Release Recovery
 
 This repository uses Release Please to manage version bumps, tags, GitHub releases,
 and npm publishing for the pnpm monorepo.
@@ -35,6 +35,36 @@ Minimal PAT scopes (fine-grained):
 
 For classic PAT, `repo` is sufficient.
 
+## Root Cause (PR #19)
+
+- Release PR title did not include component/version (`chore: release` only).
+- Release Please could not match `pullRequestTitlePattern`.
+- The release PR merged without tags, triggering:
+  `There are untagged, merged release PRs outstanding - aborting`
+
+## Backfill Performed
+
+Release PR #19 merge commit:
+
+```
+e989329b771f679e65c4b53cc7a9b1222d749c82
+```
+
+Tags and GitHub releases created at that commit:
+
+```
+@manifesto-ai/bridge-v1.2.0
+@manifesto-ai/builder-v1.2.0
+@manifesto-ai/compiler-v1.2.0
+@manifesto-ai/core-v1.2.0
+@manifesto-ai/effect-utils-v1.2.0
+@manifesto-ai/host-v1.2.0
+@manifesto-ai/lab-v1.2.0
+@manifesto-ai/memory-v1.2.0
+@manifesto-ai/react-v1.2.0
+@manifesto-ai/world-v1.2.0
+```
+
 ## Recovery: Release Please Blocked by Untagged Release PRs
 
 If the workflow logs:
@@ -50,7 +80,7 @@ Use this checklist to verify repo state when releases are stuck:
 
 - `.release-please-manifest.json` versions match each `packages/*/package.json`.
 - Tags exist for every package/version in the manifest.
-  - Example: `git tag -l '@manifesto-ai/*-v1.1.0'`
+  - Example: `git tag -l '@manifesto-ai/*-v1.2.0'`
 - GitHub Releases exist for the same tags.
 - npm shows the same version for each package (example):
   - `npm view @manifesto-ai/core version`

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "separate-pull-requests": true,
-  "pull-request-title-pattern": "chore${scope}: release ${component} ${version}",
+  "pull-request-title-pattern": "chore: release ${component} ${version}",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Root cause (3 lines)
- PR #19 merged with title `chore: release`, which did not match the configured `pullRequestTitlePattern`.
- No component tags/releases were created for that merged release PR, so release-please aborted with "untagged, merged release PRs outstanding".
- Merge commits generated conventional-commit parse warnings (noise), but the abort was caused by missing tags.

## Recovery strategy (Backfill)
- Backfilled tags and GitHub releases for PR #19 at merge commit `e989329b771f679e65c4b53cc7a9b1222d749c82`.
- Kept workflow backfill mode (`workflow_dispatch` + `command: github-release`) for future recovery without manual tagging.

## Changes
- `release-please-config.json`
- `docs/release-recovery.md`

## Backfilled tags (PR #19)
- `@manifesto-ai/bridge-v1.2.0`
- `@manifesto-ai/builder-v1.2.0`
- `@manifesto-ai/compiler-v1.2.0`
- `@manifesto-ai/core-v1.2.0`
- `@manifesto-ai/effect-utils-v1.2.0`
- `@manifesto-ai/host-v1.2.0`
- `@manifesto-ai/lab-v1.2.0`
- `@manifesto-ai/memory-v1.2.0`
- `@manifesto-ai/react-v1.2.0`
- `@manifesto-ai/world-v1.2.0`

## Prevention checklist
- [x] PR title pattern fixed to `chore: release <component> <version>`
- [x] Recovery steps documented (`docs/release-recovery.md`)
- [x] Squash merge guidance documented to reduce merge commit warnings

## Testing
- Not run (docs/config-only changes).