### PR TITLE
docs: add semantic space model as foundational concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,34 @@ Intent → Core (compute) → Patches + Effects → Host (execute) → New Snaps
 
 ---
 
+## The Foundational Insight
+
+Manifesto is built on a single powerful idea: **your domain state is a coordinate in a semantic space**.
+
+| Concept | In Manifesto |
+|---------|--------------|
+| **Domain Schema** | Defines the semantic space (dimensions, valid regions, navigation rules) |
+| **Snapshot** | A coordinate — one point in that space |
+| **Intent** | A navigation command — where to move in the space |
+| **Computation** | Coordinate calculation — finding the next valid position |
+
+```
+compute(schema, snapshot, intent) → snapshot'
+        ↓        ↓         ↓           ↓
+      space   current   navigation    next
+      defn    coord     command       coord
+```
+
+Traditional state management asks: *"How do I mutate this data?"*
+Manifesto asks: *"What is the next valid position in semantic space?"*
+
+This shift is why Manifesto guarantees:
+- **Determinism** — Same coordinate + same navigation = same destination
+- **Accountability** — Every coordinate transition is recorded (lineage)
+- **Explainability** — Every position can trace its derivation path
+
+---
+
 ## What This Is NOT
 
 | Manifesto is NOT... | Instead, it is... |

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -91,7 +91,27 @@
 - Runtime — Core is a subset of runtime functionality
 - Engine — Core does not "run" anything; it computes
 
-**See also:** [Host](#host), [Snapshot](#snapshot)
+**See also:** [Host](#host), [Snapshot](#snapshot), [Semantic Space](#semantic-space)
+
+---
+
+### Coordinate
+
+**Definition:** A single point in a semantic space, represented by a Snapshot. The complete state of a domain at a specific moment in time.
+
+**Key insight:** Traditional state management treats state as data to mutate. Manifesto treats state as a coordinate to navigate.
+
+**See also:** [Semantic Space](#semantic-space), [Snapshot](#snapshot)
+
+---
+
+### Coordinate Calculation
+
+**Definition:** The process by which Core determines the next valid position in semantic space given current position and navigation intent. This is the fundamental operation of Manifesto.
+
+**Equation:** `compute(schema, snapshot, intent) → snapshot'`
+
+**See also:** [Core](#core), [Coordinate](#coordinate)
 
 ---
 
@@ -314,9 +334,25 @@
 
 ## S
 
+### Semantic Space
+
+**Definition:** The mathematical space defined by a DomainSchema. Each dimension corresponds to a state field or computed field. Valid regions are constrained by types and invariants. Navigation rules are defined by actions.
+
+**The foundational model:**
+- Schema = space definition (dimensions, constraints, rules)
+- Snapshot = coordinate (current position)
+- Intent = navigation command (where to go)
+- Computation = coordinate calculation (finding next position)
+
+**Key insight:** Traditional state management asks "How do I mutate this data?" Manifesto asks "What is the next valid position in semantic space?"
+
+**See also:** [Coordinate](#coordinate), [DomainSchema](#domainschema), [Snapshot](#snapshot)
+
+---
+
 ### Snapshot
 
-**Definition:** The complete state of a system at a point in time. Snapshot is the single source of truth and the only communication channel between Core and Host.
+**Definition:** The complete state of a system at a point in time. In the semantic space model, a Snapshot is a coordinate—one point in the space defined by the schema. Snapshot is the single source of truth and the only communication channel between Core and Host.
 
 **Structure:**
 - `data` — Domain state
@@ -371,6 +407,8 @@
 | Bridge | Two-way binding between UI and domain |
 | Builder | Type-safe domain authoring DSL |
 | Computed | Derived values from state |
+| **Coordinate** | A point in semantic space (Snapshot) |
+| **Coordinate Calculation** | Finding the next valid position in semantic space |
 | Core | Pure computation layer |
 | Decision Record | Immutable audit of judgment |
 | DomainModule | Output of defineDomain() |
@@ -387,7 +425,8 @@
 | Projection | Routes SourceEvent to IntentBody |
 | Proposal | Accountability envelope for Intent |
 | Requirement | Pending Effect to execute |
-| Snapshot | Complete state at a point in time |
+| **Semantic Space** | Mathematical space defined by DomainSchema |
+| Snapshot | Complete state at a point in time (a coordinate) |
 | SourceEvent | External event from UI/API/Agent |
 | World | Immutable committed Snapshot |
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -21,6 +21,39 @@ This is not API documentation. This is structural understanding.
 
 ---
 
+## The Semantic Space Model
+
+Before understanding the layers and components, grasp the foundational model that drives all of Manifesto's architecture:
+
+**Manifesto treats domain state as coordinates in a semantic space.**
+
+| Concept | In Manifesto |
+|---------|--------------|
+| **Schema** | Defines the semantic space — dimensions, valid regions, navigation rules |
+| **Snapshot** | A coordinate — one point in that space |
+| **Intent** | A navigation command — where to move in the space |
+| **Computation** | Coordinate calculation — finding the next valid position |
+
+```
+compute(schema, snapshot, intent) → snapshot'
+        ↓        ↓         ↓           ↓
+      space   current   navigation    next
+      defn    coord     command       coord
+```
+
+This model explains **why** Manifesto guarantees:
+
+- **Determinism**: Same coordinate + same navigation = same destination. Always.
+- **Accountability**: Every coordinate transition is recorded in the lineage DAG.
+- **Explainability**: Every position can trace its derivation path through semantic space.
+
+Traditional state management asks: *"How do I mutate this data?"*
+Manifesto asks: *"What is the next valid position in semantic space?"*
+
+This shift from data mutation to coordinate calculation is the foundational insight that enables all other guarantees.
+
+---
+
 ## The Core Architectural Principles
 
 ### Principle 1: Separation of Concerns

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -14,6 +14,35 @@ Core Concepts are the fundamental building blocks of Manifesto's mental model. U
 
 ---
 
+## The Foundational Model: Semantic Space
+
+Before understanding individual concepts, grasp the underlying model:
+
+**A domain is a semantic space.** The schema defines its dimensions—what properties exist, what values are valid, what computations derive new values. Every possible state is a point in this space.
+
+**A snapshot is a coordinate.** At any moment, your application occupies exactly one point in semantic space. The snapshot captures this position completely.
+
+**Computation is coordinate calculation.** When an intent arrives, Core calculates: "Given where we are and where we want to go, what is the next valid coordinate?"
+
+```
+compute(schema, snapshot, intent) → snapshot'
+        ↓        ↓         ↓           ↓
+      space   current   navigation    next
+      defn    coord     command       coord
+```
+
+This is why Manifesto is called a "semantic calculator"—it computes positions in meaning-space, not just data transformations.
+
+All six concepts below derive from this foundational model:
+- **Snapshot** is the coordinate representation
+- **Intent** is the navigation command
+- **Effect** is a required external operation to reach the destination
+- **Flow** describes the calculation procedure
+- **Host** performs the physical work of moving to the new coordinate
+- **World** governs which navigation commands are permitted
+
+---
+
 ## The Six Core Concepts
 
 ### 1. [Snapshot](./snapshot)

--- a/docs/rationale/core-fdr.md
+++ b/docs/rationale/core-fdr.md
@@ -9,7 +9,8 @@
 ## Table of Contents
 
 1. [Purpose of This Document](#1-purpose-of-this-document)
-2. [FDR-001: Core as Calculator](#fdr-001-core-as-calculator)
+2. [FDR-000: Semantic Space Foundation](#fdr-000-semantic-space-foundation)
+3. [FDR-001: Core as Calculator](#fdr-001-core-as-calculator)
 3. [FDR-002: Snapshot as Only Medium](#fdr-002-snapshot-as-only-medium)
 4. [FDR-003: No Pause/Resume](#fdr-003-no-pauseresume)
 5. [FDR-004: Effects as Declarations](#fdr-004-effects-as-declarations)
@@ -43,6 +44,82 @@ For each decision, we document:
 | **Consequences** | What this enables and constrains |
 
 These decisions are **constitutional** — they define what Manifesto IS and IS NOT.
+
+---
+
+## FDR-000: Semantic Space Foundation
+
+### Decision
+
+Manifesto treats **domain state as coordinates in a semantic space** defined by schema.
+
+### Context
+
+State management systems traditionally focus on **data mutation**:
+
+```typescript
+// Traditional approach
+state.count = state.count + 1;
+state.items.push(newItem);
+```
+
+This leads to:
+- **Non-deterministic behavior**: Order-dependent updates produce different results
+- **Untraceable changes**: No history of how we arrived at current state
+- **Unexplainable values**: Cannot answer "why is this the current state?"
+
+### The Semantic Space Model
+
+| Concept | Role in Manifesto |
+|---------|-------------------|
+| **DomainSchema** | Defines the semantic space — dimensions (fields), valid regions (types), navigation rules (actions) |
+| **Snapshot** | A coordinate — one point in that space |
+| **Intent** | A navigation command — where to move in the space |
+| **Computation** | Coordinate calculation — finding the next valid position |
+
+```
+compute(schema, snapshot, intent, context) → (snapshot', requirements, trace)
+        ↓        ↓         ↓        ↓              ↓           ↓          ↓
+      space   current   navigation  env        next coord   effects   path taken
+      defn    coord     command
+```
+
+### Rationale
+
+By modeling state as a semantic space:
+
+1. **Determinism**: Same coordinate + same navigation = same destination. Always.
+2. **Accountability**: Every coordinate transition is recorded (lineage DAG).
+3. **Explainability**: Every position can trace its derivation path through semantic space.
+
+The key insight:
+
+> Traditional state management asks: *"How do I mutate this data?"*
+> Manifesto asks: *"What is the next valid position in semantic space?"*
+
+This shift from data mutation to coordinate calculation is what enables all other guarantees.
+
+### Consequences
+
+| Enables | Constrains |
+|---------|------------|
+| Complete state tracking | Schema must be defined upfront |
+| Reproducible computation | All state must be serializable |
+| Path-based explanation | Requires coordinate-aware tooling |
+| Semantic versioning | Schema evolution must be managed |
+
+### Why This Is FDR-000
+
+This decision is numbered 000 because it is the **foundational insight** upon which all other design decisions build. Every subsequent FDR can be understood as a consequence of this spatial model:
+
+- FDR-001 (Core as Calculator): Core computes coordinate transitions
+- FDR-002 (Snapshot as Only Medium): Snapshot is the coordinate representation
+- FDR-003 (No Pause/Resume): Each computation is a single coordinate calculation
+- FDR-004 (Effects as Declarations): Effects are requirements to reach a destination
+
+### Canonical Statement
+
+> **Domain state is a coordinate in semantic space. Computation is navigation.**
 
 ---
 
@@ -1013,39 +1090,39 @@ This equation is:
 ## Appendix: Decision Dependency Graph
 
 ```
-FDR-001 (Core as Calculator)
+FDR-000 (Semantic Space Foundation)
     │
-    ├─► FDR-002 (Snapshot as Only Medium)
+    ├─► FDR-001 (Core as Calculator)
     │       │
-    │       ├─► FDR-003 (No Pause/Resume)
+    │       ├─► FDR-002 (Snapshot as Only Medium)
+    │       │       │
+    │       │       ├─► FDR-003 (No Pause/Resume)
+    │       │       │
+    │       │       ├─► FDR-007 (No Value Binding)
+    │       │       │
+    │       │       └─► FDR-008 (Call Without Arguments)
     │       │
-    │       ├─► FDR-007 (No Value Binding)
+    │       ├─► FDR-004 (Effects as Declarations)
+    │       │       │
+    │       │       └─► FDR-013 (Host Responsibility Boundary)
     │       │
-    │       └─► FDR-008 (Call Without Arguments)
-    │
-    ├─► FDR-004 (Effects as Declarations)
+    │       ├─► FDR-005 (Errors as Values)
     │       │
-    │       └─► FDR-013 (Host Responsibility Boundary)
+    │       └─► FDR-006 (Flow Not Turing-Complete)
     │
-    ├─► FDR-005 (Errors as Values)
-    │
-    └─► FDR-006 (Flow Not Turing-Complete)
-
-FDR-009 (Schema-First)
-    │
-    ├─► FDR-010 (Canonical Form)
-    │
-    └─► FDR-011 (Computed as DAG)
+    └─► FDR-009 (Schema-First)
+            │
+            ├─► FDR-010 (Canonical Form)
+            │
+            └─► FDR-011 (Computed as DAG)
 
 FDR-012 (Three Patch Operations)
     │
     └─► FDR-015 (Static Patch Paths)
-
-FDR-015 (Static Patch Paths)
-    │
-    ├─► Depends on FDR-001 (Core is pure, no execution in apply)
-    ├─► Depends on FDR-002 (All info through Snapshot)
-    └─► Depends on FDR-004 (Dynamic values = IO = Effects)
+            │
+            ├─► Depends on FDR-001 (Core is pure, no execution in apply)
+            ├─► Depends on FDR-002 (All info through Snapshot)
+            └─► Depends on FDR-004 (Dynamic values = IO = Effects)
 ```
 
 ---

--- a/docs/specifications/builder-spec.md
+++ b/docs/specifications/builder-spec.md
@@ -32,6 +32,8 @@
 
 `@manifesto-ai/builder` is the **DX layer** for Manifesto.
 
+Builder provides a type-safe DSL for **defining semantic spaces**. Each schema you create establishes the dimensions (state fields), constraints (types), and navigation rules (actions) of your domain's semantic space.
+
 It provides:
 
 - `defineDomain` to author `DomainSchema` with **Zod-first typing**

--- a/docs/specifications/core-spec.md
+++ b/docs/specifications/core-spec.md
@@ -101,7 +101,36 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### 3.3 The Snapshot Principle
+### 3.3 The Semantic Space Model
+
+Manifesto operates on the foundational principle that **domain state forms a semantic space**:
+
+| Concept | Role in Manifesto |
+|---------|-------------------|
+| **DomainSchema** | Defines the semantic space — dimensions (fields), valid regions (types), navigation rules (actions) |
+| **Snapshot** | A coordinate — one point in that space |
+| **Intent** | A navigation command — where to move in the space |
+| **Computation** | Coordinate calculation — finding the next valid position |
+
+```
+compute(schema, snapshot, intent, context) → (snapshot', requirements, trace)
+        ↓        ↓         ↓        ↓              ↓           ↓          ↓
+      space   current   navigation  env        next coord   effects   path taken
+      defn    coord     command
+```
+
+**Why this model matters:**
+
+- **Determinism**: Same coordinate + same navigation = same destination. Always.
+- **Accountability**: Every coordinate transition is recorded (lineage).
+- **Explainability**: Every position can trace its derivation path through semantic space.
+
+Traditional state management asks: *"How do I mutate this data?"*
+Manifesto asks: *"What is the next valid position in semantic space?"*
+
+This shift from data mutation to coordinate calculation is what enables all other guarantees.
+
+### 3.4 The Snapshot Principle
 
 > **All communication happens through Snapshot. There is no other channel.**
 
@@ -121,7 +150,7 @@ RIGHT:  effect('api:call')             // Declares requirement
         if snapshot.api.result.ok then ...
 ```
 
-### 3.4 Computation Model
+### 3.5 Computation Model
 
 Each `compute()` call is **complete and independent**:
 

--- a/docs/specifications/host-spec.md
+++ b/docs/specifications/host-spec.md
@@ -1,10 +1,21 @@
 # Host Contract SPEC v1.1 Patch Document (Rev.5)
 
-> **Patch Target:** Host Contract SPEC v1.0 → v1.1  
-> **Status:** Draft for Review (Rev.5)  
-> **Date:** 2026-01-04  
-> **Revision:** All GO-Blocking issues resolved (including snapshot.data, boolean-only condition)  
+> **Patch Target:** Host Contract SPEC v1.0 → v1.1
+> **Status:** Draft for Review (Rev.5)
+> **Date:** 2026-01-04
+> **Revision:** All GO-Blocking issues resolved (including snapshot.data, boolean-only condition)
 > **Depends On:** MEL SPEC v0.4.0
+
+---
+
+## Overview
+
+Host is the **execution layer** that realizes coordinate transitions calculated by Core. In Manifesto's semantic space model:
+
+- **Core** determines: "Where should we be in semantic space?"
+- **Host** handles: "How do we get there in the physical world?"
+
+Host executes effects, applies patches, and orchestrates the compute-effect cycle—transforming the abstract coordinate calculation into concrete state changes.
 
 ---
 

--- a/docs/specifications/world-spec.md
+++ b/docs/specifications/world-spec.md
@@ -33,6 +33,8 @@
 
 This document defines the **Manifesto World Protocol**.
 
+World is the **governance layer** that maintains the complete history of coordinate transitions in Manifesto's semantic space. Every position change is recorded as a Decision in the lineage DAG, ensuring full accountability of how the system navigated through semantic space.
+
 The World Protocol governs:
 - **Who** may propose changes to a world (Actor)
 - **How** proposals are judged (Authority)

--- a/docs/what-is-manifesto/index.md
+++ b/docs/what-is-manifesto/index.md
@@ -16,6 +16,34 @@ This section provides multiple entry points depending on your background and nee
 
 ---
 
+## The Core Insight
+
+Manifesto is built on a single powerful idea: **your domain state is a coordinate in a semantic space**.
+
+| Concept | In Manifesto |
+|---------|--------------|
+| **Domain Schema** | Defines the semantic space (dimensions, constraints, navigation rules) |
+| **Snapshot** | A coordinate (point) in that space |
+| **Intent** | A navigation command (where to move) |
+| **Computation** | Calculating the next valid coordinate |
+
+```
+compute(schema, snapshot, intent) → snapshot'
+        ↓        ↓         ↓           ↓
+      space   current   navigation    next
+      defn    coord     command       coord
+```
+
+Traditional state management asks: *"How do I update this data?"*
+Manifesto asks: *"What is the next valid position in semantic space?"*
+
+This shift enables:
+- **Determinism** — Same coordinate + same navigation = same destination
+- **Accountability** — Every coordinate transition is recorded
+- **Explainability** — Every position can trace its derivation path
+
+---
+
 ## What You'll Learn
 
 ### Quick Understanding


### PR DESCRIPTION
## Summary

- Add "The Foundational Insight" section to root README.md explaining the semantic space model
- Add "The Semantic Space Model" section to architecture overview
- Add "The Foundational Model: Semantic Space" as first concept in core concepts
- Add "The Core Insight" section to what-is-manifesto
- Add section 3.3 "The Semantic Space Model" to core-spec
- Add FDR-000 "Semantic Space Foundation" as the foundational design decision
- Add brief semantic space context to host-spec, world-spec, builder-spec overviews
- Add Semantic Space, Coordinate, Coordinate Calculation terms to glossary

## The Core Insight

This PR establishes the foundational concept that **domain state is a coordinate in a semantic space**:

| Concept | In Manifesto |
|---------|--------------|
| **Domain Schema** | Defines the semantic space (dimensions, valid regions, navigation rules) |
| **Snapshot** | A coordinate — one point in that space |
| **Intent** | A navigation command — where to move in the space |
| **Computation** | Coordinate calculation — finding the next valid position |

```
compute(schema, snapshot, intent) → snapshot'
        ↓        ↓         ↓           ↓
      space   current   navigation    next
      defn    coord     command       coord
```

> Traditional state management asks: *"How do I mutate this data?"*
> Manifesto asks: *"What is the next valid position in semantic space?"*

## Test plan

- [ ] Verify VitePress builds successfully with `pnpm docs:dev`
- [ ] Review all updated documentation pages for consistency
- [ ] Check glossary terms are properly linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)