### PR TITLE
Align AuthorityKind to include 'tribunal' in app spec and types

### DIFF
--- a/packages/app/docs/APP-SPEC-v2.0.0.md
+++ b/packages/app/docs/APP-SPEC-v2.0.0.md
@@ -217,7 +217,7 @@ type WorldOutcome = 'completed' | 'failed';
 ### 5.6 Authority Types
 
 ```typescript
-type AuthorityKind = 'auto' | 'human' | 'policy' | 'consensus';
+type AuthorityKind = 'auto' | 'human' | 'policy' | 'tribunal';
 
 type AuthorityRef = {
   readonly kind: AuthorityKind;

--- a/packages/app/src/core/types/index.ts
+++ b/packages/app/src/core/types/index.ts
@@ -119,7 +119,7 @@ export type WorldOutcome = "completed" | "failed";
  *
  * @see SPEC v2.0.0 §5.6
  */
-export type AuthorityKind = "auto" | "human" | "policy" | "consensus";
+export type AuthorityKind = "auto" | "human" | "policy" | "tribunal";
 
 /**
  * Authority reference.


### PR DESCRIPTION
### Motivation
- Ensure `AuthorityKind` is consistent with the rest of the codebase/specs by replacing the `consensus` literal with `tribunal`.

### Description
- Update `packages/app/docs/APP-SPEC-v2.0.0.md` to use `type AuthorityKind = 'auto' | 'human' | 'policy' | 'tribunal'`.
- Update `packages/app/src/core/types/index.ts` to export `AuthorityKind` with the `tribunal` literal.

### Testing
- Ran `pnpm --filter @manifesto-ai/app test`; several tests executed and some suites passed, but the overall run failed because Vite could not resolve workspace package entries for `@manifesto-ai/compiler`, `@manifesto-ai/world`, and `@manifesto-ai/core`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982acd43440832b9b13a33c40f7d002)