### PR TITLE
fix(core,app): ensure deterministic trace timestamps and prevent memory leak

### DIFF
--- a/packages/app/src/execution/host-executor/app-host-executor.ts
+++ b/packages/app/src/execution/host-executor/app-host-executor.ts
@@ -82,12 +82,13 @@ export class AppHostExecutor implements HostExecutor {
       });
 
       // Create abort promise (if signal provided)
+      // Note: Using { once: true } to prevent memory leak - listener auto-removes after firing
       const abortPromise = opts?.signal
         ? new Promise<never>((_, reject) => {
             opts.signal!.addEventListener("abort", () => {
               ctx.aborted = true;
               reject(new ExecutionAbortedError(key));
-            });
+            }, { once: true });
           })
         : null;
 

--- a/packages/core/src/core/compute.ts
+++ b/packages/core/src/core/compute.ts
@@ -73,7 +73,7 @@ export function computeSync(
 
   // 2. Check availability condition
   if (action.available) {
-    const ctx = createContext(currentSnapshot, schema, intent.type, "available", intent.intentId);
+    const ctx = createContext(currentSnapshot, schema, intent.type, "available", intent.intentId, context.now);
     const availResult = evaluateExpr(action.available, ctx);
 
     if (isErr(availResult)) {
@@ -120,7 +120,7 @@ export function computeSync(
   };
 
   // 4. Create evaluation context and flow state
-  const ctx = createContext(preparedSnapshot, schema, intent.type, `actions.${intent.type}.flow`, intent.intentId);
+  const ctx = createContext(preparedSnapshot, schema, intent.type, `actions.${intent.type}.flow`, intent.intentId, context.now);
   const flowState = createFlowState(preparedSnapshot);
 
   // 5. Evaluate the flow

--- a/packages/core/src/evaluator/context.ts
+++ b/packages/core/src/evaluator/context.ts
@@ -51,25 +51,28 @@ export type EvalContext = {
 
 /**
  * Create a new evaluation context
+ *
+ * @param timestampOrTrace - Required timestamp or TraceContext for deterministic tracing.
+ *                           MUST be provided by Host via HostContext.now to ensure determinism.
  */
 export function createContext(
   snapshot: Snapshot,
   schema: DomainSchema,
-  currentAction?: string | null,
-  nodePath?: string,
-  intentId?: string,
-  timestampOrTrace?: number | TraceContext
+  currentAction: string | null,
+  nodePath: string,
+  intentId: string | undefined,
+  timestampOrTrace: number | TraceContext
 ): EvalContext {
   return {
     snapshot,
     schema,
-    currentAction: currentAction ?? null,
-    nodePath: nodePath ?? "",
+    currentAction,
+    nodePath,
     intentId,
     uuidCounter: 0,
     trace: typeof timestampOrTrace === "object"
       ? timestampOrTrace
-      : createTraceContext(timestampOrTrace ?? Date.now()),
+      : createTraceContext(timestampOrTrace),
   };
 }
 


### PR DESCRIPTION
- Remove Date.now() fallback in createContext() to enforce deterministic
  trace timestamps via HostContext.now (SPEC v2.0.0 §16.3 compliance)
- Pass context.now from compute() to createContext() for both availability
  check and flow evaluation contexts
- Add { once: true } to abort signal listener to prevent memory leak
  when execution completes before abort fires

https://claude.ai/code/session_01D9oM6dLy9uhZFEFVt7DTiy