### PR TITLE
Align Core/World/App spec contracts (D-001/002/004/005/006)

### DIFF
--- a/packages/app/docs/APP-ARCHITECTURE-OVERVIEW.md
+++ b/packages/app/docs/APP-ARCHITECTURE-OVERVIEW.md
@@ -43,11 +43,13 @@
 
 | FDR | Version | Scope | Core Concepts |
 |-----|---------|-------|---------------|
-| **PUB-001** | v0.2.0 | Execution Model | Tick, Publish Boundary, Scheduler |
-| **RUNTIME-001** | v0.2.1 | Extensibility | Lifecycle, Hooks, Plugins |
-| **INTEGRATION-001** | v0.3.2 | Host↔World | HostExecutor, WorldStore, Maintenance |
-| **POLICY-001** | v0.2.2 | Governance | ExecutionKey, Authority, ApprovedScope |
-| **EXT-001** | v0.3.0 | Memory | MemoryStore, Context Freezing |
+| **PUB-001** | v0.3.0 | Execution Model | Tick, Publish Boundary, Scheduler |
+| **RUNTIME-001** | v0.2.0 | Extensibility | Lifecycle, Hooks, Plugins |
+| **INTEGRATION-001** | v0.4.1 | Host↔World | HostExecutor, WorldStore, Maintenance |
+| **POLICY-001** | v0.2.3 | Governance | ExecutionKey, Authority, ApprovedScope |
+| **EXT-001** | v0.4.0 | Memory | MemoryStore, Context Freezing |
+
+`HostExecutor.abort?()` is an optional capability defined by the World contract; App may implement it as best-effort cancellation.
 
 ---
 
@@ -85,7 +87,7 @@
 │  │  │ HostExecutor │  │  WorldStore  │  │MemoryProvider│        │  │
 │  │  │              │  │              │  │   (Opt)      │        │  │
 │  │  │ • execute()  │  │ • store()    │  │ • recall()   │        │  │
-│  │  │ • abort()    │  │ • restore()  │  │ • remember() │        │  │
+│  │  │ • abort()?   │  │ • restore()  │  │ • remember() │        │  │
 │  │  │              │  │ • compact()  │  │              │        │  │
 │  │  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘        │  │
 │  │         │                 │                 │                 │  │

--- a/packages/app/docs/VERSION-INDEX.md
+++ b/packages/app/docs/VERSION-INDEX.md
@@ -1,16 +1,16 @@
 # Manifesto App Documentation Index
 
 > **Package:** `@manifesto-ai/app`
-> **Last Updated:** 2026-02-05
+> **Last Updated:** 2026-02-06
 
 ---
 
 ## Latest Version
 
-- **SPEC:** [v2.2.0](APP-SPEC-v2.2.0.md) (Full - implements ADR-APP-002)
+- **SPEC:** [v2.3.0](APP-SPEC-v2.3.0.md) (Full - World owns persistence, createApp DX simplification)
 - **Architecture:** [APP-ARCHITECTURE-OVERVIEW.md](APP-ARCHITECTURE-OVERVIEW.md)
 
-**Note:** v2.2.0 is a full specification. For createApp API simplification details, see [ADR-APP-002](ADR-APP-002-v0.1.0.md).
+**Note:** v2.3.0 is the current full specification. For API rationale, see [ADR-APP-002](ADR-APP-002-v0.2.0.md).
 
 ---
 
@@ -18,7 +18,7 @@
 
 | Version | SPEC | FDR | Type | Status |
 |---------|------|-----|------|--------|
-| v2.2.0 | [SPEC](APP-SPEC-v2.2.0.md) | [ADR-APP-002](#adrs) | Full | Draft |
+| v2.3.0 | [SPEC](APP-SPEC-v2.3.0.md) | [ADR-APP-002](#adrs) | Full | Ratified |
 | v2.1.0 | [SPEC](APP-SPEC-v2.1.0-patch.md) | — | Patch (Base: v2.0.0) | Draft |
 | v2.0.0 | [SPEC](APP-SPEC-v2.0.0.md) | [Multiple FDRs](#fdrs) | Full | Accepted |
 
@@ -28,7 +28,7 @@
 
 | ADR | Version | Status | Scope |
 |-----|---------|--------|-------|
-| [ADR-APP-002](ADR-APP-002-v0.1.0.md) | v0.1.0 | Proposed | createApp Public API simplification |
+| [ADR-APP-002](ADR-APP-002-v0.2.0.md) | v0.2.0 | Proposed | createApp Public API simplification |
 
 ---
 
@@ -38,7 +38,7 @@
 |-----|---------|-------|
 | [FDR-APP-PUB-001](FDR-APP-PUB-001-v0.3.0.md) | v0.3.0 | Tick definition, publish boundary |
 | [FDR-APP-RUNTIME-001](FDR-APP-RUNTIME-001-v0.2.0.md) | v0.2.0 | Lifecycle, hooks, plugins |
-| [FDR-APP-INTEGRATION-001](FDR-APP-INTEGRATION-001-v0.4.0.md) | v0.4.0 | HostExecutor, WorldStore, maintenance |
+| [FDR-APP-INTEGRATION-001](FDR-APP-INTEGRATION-001-v0.4.1.md) | v0.4.1 | HostExecutor, WorldStore, maintenance |
 | [FDR-APP-POLICY-001](FDR-APP-POLICY-001-v0.2.3.md) | v0.2.3 | ExecutionKey, authority, scope |
 | [FDR-APP-EXT-001](FDR-APP-EXT-001-v0.4.0.md) | v0.4.0 | MemoryStore, context freezing |
 
@@ -46,10 +46,10 @@
 
 ## Reading Guide
 
-### For Latest (v2.2.0)
+### For Latest (v2.3.0)
 
-1. Read [APP-SPEC-v2.2.0.md](APP-SPEC-v2.2.0.md) (complete specification with createApp DX simplification)
-2. For ADR rationale: [ADR-APP-002](ADR-APP-002-v0.1.0.md)
+1. Read [APP-SPEC-v2.3.0.md](APP-SPEC-v2.3.0.md) (complete specification with ADR-003 + createApp DX simplification)
+2. For ADR rationale: [ADR-APP-002](ADR-APP-002-v0.2.0.md)
 3. For architecture overview: [APP-ARCHITECTURE-OVERVIEW.md](APP-ARCHITECTURE-OVERVIEW.md)
 
 ### For v2.1.0

--- a/packages/core/docs/VERSION-INDEX.md
+++ b/packages/core/docs/VERSION-INDEX.md
@@ -1,13 +1,14 @@
 # Core Documentation Index
 
 > **Package:** `@manifesto-ai/core`
-> **Last Updated:** 2026-01-18
+> **Last Updated:** 2026-02-06
 
 ---
 
 ## Latest Version
 
-- **SPEC:** [v2.0.1](SPEC-v2.0.1-patch.md) (Patch - requires v2.0.0)
+- **SPEC (Full):** [v2.0.0](SPEC-v2.0.0.md)
+- **Patch Addendum:** [v2.0.1](SPEC-v2.0.1-patch.md) (supplemental clarifications)
 - **FDR:** [v2.0.0](FDR-v2.0.0.md) (Full)
 
 ---
@@ -16,6 +17,6 @@
 
 | Version | SPEC | FDR | Type | Status |
 |---------|------|-----|------|--------|
-| v2.0.1 | [SPEC](SPEC-v2.0.1-patch.md) | — | Patch (Base: v2.0.0) | Draft |
 | v2.0.0 | [SPEC](SPEC-v2.0.0.md) | [FDR](FDR-v2.0.0.md) | Full | Draft |
+| v2.0.1 | [SPEC](SPEC-v2.0.1-patch.md) | — | Patch (Base: v2.0.0) | Draft |
 | v1.0.0 | [SPEC](SPEC-v1.0.0.md) | [FDR](FDR-v1.0.0.md) | Full | Superseded |

--- a/packages/world/src/types/host-executor.ts
+++ b/packages/world/src/types/host-executor.ts
@@ -167,6 +167,21 @@ export interface HostExecutor {
     intent: Intent,
     opts?: HostExecutionOptions
   ): Promise<HostExecutionResult>;
+
+  /**
+   * Abort execution for an ExecutionKey (best-effort).
+   *
+   * Ownership:
+   * - Defined by World contract
+   * - Implemented by App adapter (optional capability)
+   *
+   * Semantics:
+   * - If supported, executor SHOULD attempt cancellation promptly.
+   * - Cancellation outcome MUST still converge to a terminal proposal status
+   *   via normal execution result handling (`failed` when aborted).
+   * - This method MUST NOT throw.
+   */
+  abort?(key: ExecutionKey): void;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Implement D-001 in Core runtime: generalize patch validation exceptions from `$host` to all `$`-prefixed platform namespaces.
- Implement D-005 merge semantics in Core runtime: absent merge targets are created as `{}`; non-object merge targets fail deterministically with `TYPE_MISMATCH`.
- Add Core tests for platform namespace patching and merge edge cases.
- Implement D-004 contract ownership in World: add optional `HostExecutor.abort?(ExecutionKey)` to World-owned interface and document terminal convergence semantics.
- Implement D-002 in World docs/FDR: codify `snapshot.input` exclusion from `snapshotHash` as `MUST NOT` with rationale.
- Implement D-006 in App docs: remove `system.get` from System Runtime action catalog and clarify it as a reserved compiler-lowered effect type.
- Refresh version/index/architecture references in App/Core docs.

## Files Changed
- `packages/core/src/core/apply.ts`
- `packages/core/src/__tests__/apply.test.ts`
- `packages/world/src/types/host-executor.ts`
- `packages/core/docs/SPEC-v2.0.0.md`
- `packages/world/docs/world-SPEC-v2.0.3.md`
- `packages/world/docs/world-FDR-v2.0.2.md`
- `packages/app/docs/APP-SPEC-v2.3.0.md`
- `packages/app/docs/APP-ARCHITECTURE-OVERVIEW.md`
- `packages/app/docs/VERSION-INDEX.md`
- `packages/core/docs/VERSION-INDEX.md`

## Validation
- `pnpm --filter @manifesto-ai/core test`
- `pnpm --filter @manifesto-ai/world test`
- `pnpm --filter @manifesto-ai/app test`
- `pnpm --filter @manifesto-ai/core build`
- `pnpm --filter @manifesto-ai/world build`
- `pnpm --filter @manifesto-ai/app build`

## Notes
- No public runtime API breaking change.
- `HostExecutor.abort` is optional and backward compatible.
