### PR TITLE
Evaluate computed values at genesis snapshot (READY-8)

### DIFF
--- a/packages/app/docs/APP-SPEC-v2.3.0.md
+++ b/packages/app/docs/APP-SPEC-v2.3.0.md
@@ -7,6 +7,7 @@
 > **Authors:** Manifesto Team
 > **License:** MIT
 > **Changelog:**
+> - **v2.3.0 (2026-02-08):** READY-8 — Genesis snapshot evaluates computed values from schema defaults
 > - **v2.3.0 (2026-02-07):** READY-7 — Genesis snapshot applies schema field defaults (`schema defaults < config.initialData`)
 > - **v2.3.0 (2026-02-05):** World owns persistence (ADR-003) — `worldStore` removed from AppConfig; `world?: ManifestoWorld` added (optional, default: internal World with InMemoryWorldStore).
 > - **v2.2.0 (2026-02-05):** `createApp()` DX simplified — `effects` REQUIRED; `host`/`compiler` removed from public AppConfig; schema compatibility validates against `effects`.
@@ -646,11 +647,12 @@ The `ready()` method MUST:
 3. Cache the resolved DomainSchema
 4. Emit `domain:resolved` hook
 5. Create genesis snapshot with schema field defaults applied (see READY-7)
-6. Initialize Domain Runtime with user schema
-7. Initialize System Runtime with fixed system schema
-8. Validate effects if `validation.effects='strict'`
-9. Initialize plugins in order
-10. Emit `app:ready` hook
+6. Evaluate computed expressions on genesis snapshot (see READY-8)
+7. Initialize Domain Runtime with user schema
+8. Initialize System Runtime with fixed system schema
+9. Validate effects if `validation.effects='strict'`
+10. Initialize plugins in order
+11. Emit `app:ready` hook
 
 ### 7.3 Lifecycle Rules
 
@@ -666,6 +668,7 @@ The `ready()` method MUST:
 | READY-4 | MUST | If DomainSchema contains `system.*` action types, `ready()` MUST throw `ReservedNamespaceError` |
 | READY-6 | MUST | DomainSchema MUST be resolved and cached BEFORE plugins execute |
 | READY-7 | MUST | Genesis snapshot MUST include `DomainSchema.state.fields[*].default` values; `config.initialData` MUST take precedence over schema defaults |
+| READY-8 | MUST | Genesis snapshot MUST include evaluated computed values derived from initial state |
 
 ---
 

--- a/packages/app/examples/02-todo/main.ts
+++ b/packages/app/examples/02-todo/main.ts
@@ -75,13 +75,15 @@ const app = createApp({
 async function main() {
   await app.ready();
 
-  // Genesis defaults applied — verify initial state
+  // Genesis defaults + computed applied — verify initial state
   const initial = app.getState();
   console.log("Initial state:");
   console.log("  todos:", initial.data.todos);
   console.log("  filterMode:", initial.data.filterMode);
+  console.log("  todoCount:", initial.computed["computed.todoCount"]);
   // → todos: []
   // → filterMode: "all"
+  // → todoCount: 0
 
   // Add todos
   await app.act("addTodo", { title: "Learn Manifesto" }).done();

--- a/packages/app/examples/04-subscriptions/main.ts
+++ b/packages/app/examples/04-subscriptions/main.ts
@@ -39,9 +39,15 @@ const app = createApp({
 async function main() {
   await app.ready();
 
-  // Genesis defaults applied — verify initial state
-  console.log("Initial count:", app.getState().data.count);
-  // → Initial count: 0
+  // Genesis defaults + computed applied — verify initial state
+  const initial = app.getState();
+  console.log("Initial state:");
+  console.log("  count:", initial.data.count);
+  console.log("  doubled:", initial.computed["computed.doubled"]);
+  console.log("  isPositive:", initial.computed["computed.isPositive"]);
+  // → count: 0
+  // → doubled: 0
+  // → isPositive: false
 
   // Subscribe to count changes
   const unsubCount = app.subscribe(

--- a/packages/app/src/__tests__/spec-compliance.test.ts
+++ b/packages/app/src/__tests__/spec-compliance.test.ts
@@ -311,6 +311,56 @@ describe("SPEC §7: State Model", () => {
     });
   });
 
+  describe("§7.2 READY-8: Genesis computed", () => {
+    it("READY-8: computed values are available immediately after ready()", async () => {
+      const schema = createMockSchema({
+        state: {
+          fields: {
+            count: { type: "number", required: true, default: 0 },
+          },
+        },
+        computed: {
+          fields: {
+            "computed.doubled": {
+              deps: ["count"],
+              expr: { kind: "mul", left: { kind: "get", path: "count" }, right: { kind: "lit", value: 2 } },
+            },
+          },
+        },
+      });
+
+      const app = createTestApp(schema);
+      await app.ready();
+
+      const state = app.getState();
+      expect(state.computed["computed.doubled"]).toBe(0);
+    });
+
+    it("READY-8: computed values reflect initialData", async () => {
+      const schema = createMockSchema({
+        state: {
+          fields: {
+            count: { type: "number", required: true, default: 0 },
+          },
+        },
+        computed: {
+          fields: {
+            "computed.doubled": {
+              deps: ["count"],
+              expr: { kind: "mul", left: { kind: "get", path: "count" }, right: { kind: "lit", value: 2 } },
+            },
+          },
+        },
+      });
+
+      const app = createTestApp(schema, { initialData: { count: 5 } });
+      await app.ready();
+
+      const state = app.getState();
+      expect(state.computed["computed.doubled"]).toBe(10);
+    });
+  });
+
   describe("§7.3 Type Safety", () => {
     it("TYPE-1: getState<T>() returns typed data", async () => {
       interface TodoState {


### PR DESCRIPTION
## Summary

- Genesis snapshot now includes evaluated computed values immediately after `ready()`
- Calls `evaluateComputed()` (pure, no side-effects) on the genesis snapshot during bootstrap
- Previously, `getState().computed` was `undefined` until the first `act()` triggered a compute cycle

Closes #94

## Changes

| File | What |
|------|------|
| `packages/app/src/bootstrap/app-bootstrap.ts` | Call `evaluateComputed()` on genesis snapshot (+3 lines) |
| `packages/app/src/__tests__/spec-compliance.test.ts` | 2 new READY-8 tests (defaults-only + initialData) |
| `packages/app/docs/APP-SPEC-v2.3.0.md` | READY-8 rule + ready sequence step 6 |
| `packages/app/examples/02-todo/main.ts` | Show initial `todoCount: 0` |
| `packages/app/examples/04-subscriptions/main.ts` | Show initial `doubled: 0`, `isPositive: false` |

## Test plan

- [x] App: 513 tests pass (2 new)
- [x] All 4 examples verified with initial computed output

🤖 Generated with [Claude Code](https://claude.com/claude-code)