### PR TITLE
docs(api): fix dead links in app related docs

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1039,7 +1039,7 @@ interface DevtoolsConfig {
 ## Related Documentation
 
 - [Core Package](/api/core) - Domain schema and computation
-- [Host Contract](/internals/spec/host-contract) - Effect execution specification
-- [World Protocol](/internals/spec/world-protocol) - Governance and lineage
+- [Host Package](/api/host) - Effect execution specification
+- [World Package](/api/world) - Governance and lineage
 - [Getting Started](/quickstart) - Step-by-step tutorial
 - [Effect Handlers](/guides/effect-handlers) - Detailed effect handler guide


### PR DESCRIPTION
## Summary
- fix dead links in `docs/api/app.md` related documentation section
- update Host link to `/api/host`
- update World link to `/api/world`

## Validation
- `pnpm docs:build`