### PR TITLE
chore(release): align package versions and publish latest minors

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,12 +1,9 @@
 {
-  "packages/core": "2.1.0",
-  "packages/host": "2.0.1",
-  "packages/world": "2.1.0",
-  "packages/bridge": "1.2.0",
-  "packages/react": "1.2.0",
-  "packages/compiler": "1.4.0",
-  "packages/effect-utils": "1.2.0",
-  "packages/lab": "1.2.0",
-  "packages/memory": "1.2.0",
-  "packages/app": "2.1.0"
+  "packages/app": "2.2.0",
+  "packages/compiler": "1.5.0",
+  "packages/core": "2.2.0",
+  "packages/host": "2.2.0",
+  "packages/intent-ir": "0.3.0",
+  "packages/translator/core": "0.2.0",
+  "packages/world": "2.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "build": "turbo run build --filter=@manifesto-ai/core --filter=@manifesto-ai/host --filter=@manifesto-ai/world --filter=@manifesto-ai/compiler --filter=@manifesto-ai/intent-ir --filter=@manifesto-ai/app",
+    "build": "turbo run build --filter=@manifesto-ai/core --filter=@manifesto-ai/host --filter=@manifesto-ai/world --filter=@manifesto-ai/compiler --filter=@manifesto-ai/intent-ir --filter=@manifesto-ai/translator --filter=@manifesto-ai/app",
     "dev": "turbo run dev",
-    "lint": "turbo run lint --filter=@manifesto-ai/core --filter=@manifesto-ai/host --filter=@manifesto-ai/world --filter=@manifesto-ai/compiler --filter=@manifesto-ai/intent-ir",
-    "test": "turbo run test --filter=@manifesto-ai/core --filter=@manifesto-ai/host --filter=@manifesto-ai/world --filter=@manifesto-ai/compiler --filter=@manifesto-ai/intent-ir",
-    "test:coverage": "turbo run test:coverage --filter=@manifesto-ai/core --filter=@manifesto-ai/host --filter=@manifesto-ai/world --filter=@manifesto-ai/compiler --filter=@manifesto-ai/intent-ir",
+    "lint": "turbo run lint --filter=@manifesto-ai/core --filter=@manifesto-ai/host --filter=@manifesto-ai/world --filter=@manifesto-ai/compiler --filter=@manifesto-ai/intent-ir --filter=@manifesto-ai/translator",
+    "test": "turbo run test --filter=@manifesto-ai/core --filter=@manifesto-ai/host --filter=@manifesto-ai/world --filter=@manifesto-ai/compiler --filter=@manifesto-ai/intent-ir --filter=@manifesto-ai/translator",
+    "test:coverage": "turbo run test:coverage --filter=@manifesto-ai/core --filter=@manifesto-ai/host --filter=@manifesto-ai/world --filter=@manifesto-ai/compiler --filter=@manifesto-ai/intent-ir --filter=@manifesto-ai/translator",
     "bench:core-host-world": "node scripts/bench-core-host-world.mjs",
     "clean": "turbo run clean && rm -rf node_modules",
     "docs:dev": "vitepress dev docs",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifesto-ai/app",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Manifesto App - Facade and orchestration layer over the Manifesto protocol stack",
   "author": "eggplantiny <eggplantiny@gmail.com>",
   "license": "MIT",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifesto-ai/compiler",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Manifesto Compiler - MEL (Manifesto Expression Language) to DomainSchema compiler",
   "author": "eggplantiny <eggplantiny@gmail.com>",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifesto-ai/core",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Manifesto Core - Pure semantic calculator for deterministic state computation",
   "author": "eggplantiny <eggplantiny@gmail.com>",
   "license": "MIT",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifesto-ai/host",
-  "version": "2.0.2",
+  "version": "2.2.0",
   "description": "Manifesto Host - Effect execution runtime for @manifesto-ai/core",
   "author": "eggplantiny <eggplantiny@gmail.com>",
   "license": "MIT",

--- a/packages/intent-ir/package.json
+++ b/packages/intent-ir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifesto-ai/intent-ir",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Manifesto Intent IR - Chomskyan LF-based Intermediate Representation for natural language intent",
   "author": "eggplantiny <eggplantiny@gmail.com>",
   "license": "MIT",

--- a/packages/translator/core/package.json
+++ b/packages/translator/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifesto-ai/translator",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Manifesto Translator - Semantic bridge from natural language to Intent Graph",
   "author": "eggplantiny <eggplantiny@gmail.com>",
   "license": "MIT",

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifesto-ai/world",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Manifesto World Protocol - Governance, Authority, and Lineage layer",
   "author": "eggplantiny <eggplantiny@gmail.com>",
   "license": "MIT",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,8 +22,12 @@
     { "type": "ci", "section": "Continuous Integration", "hidden": true }
   ],
   "packages": {
-    "packages/bridge": {
-      "package-name": "@manifesto-ai/bridge",
+    "packages/app": {
+      "package-name": "@manifesto-ai/app",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/compiler": {
+      "package-name": "@manifesto-ai/compiler",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/core": {
@@ -34,36 +38,16 @@
       "package-name": "@manifesto-ai/host",
       "changelog-path": "CHANGELOG.md"
     },
-    "packages/world": {
-      "package-name": "@manifesto-ai/world",
+    "packages/intent-ir": {
+      "package-name": "@manifesto-ai/intent-ir",
       "changelog-path": "CHANGELOG.md"
     },
-    "packages/react": {
-      "package-name": "@manifesto-ai/react",
-      "changelog-path": "CHANGELOG.md"
-    },
-    "packages/compiler": {
-      "package-name": "@manifesto-ai/compiler",
-      "changelog-path": "CHANGELOG.md"
-    },
-    "packages/memory": {
-      "package-name": "@manifesto-ai/memory",
-      "changelog-path": "CHANGELOG.md"
-    },
-    "packages/effect-utils": {
-      "package-name": "@manifesto-ai/effect-utils",
-      "changelog-path": "CHANGELOG.md"
-    },
-    "packages/lab": {
-      "package-name": "@manifesto-ai/lab",
-      "changelog-path": "CHANGELOG.md"
-    },
-    "packages/translator": {
+    "packages/translator/core": {
       "package-name": "@manifesto-ai/translator",
       "changelog-path": "CHANGELOG.md"
     },
-    "packages/app": {
-      "package-name": "@manifesto-ai/app",
+    "packages/world": {
+      "package-name": "@manifesto-ai/world",
       "changelog-path": "CHANGELOG.md"
     }
   }


### PR DESCRIPTION
## Summary
- Align package versions for the current release cycle
- Sync release metadata with actual workspace package layout
- Include translator package in root build/test/lint filters
- Fix translator build issue by replacing CommonJS `require` with ESM imports in pipeline factory
- Improve publish script to resolve release paths to package names before pnpm filtering

## Version updates
- @manifesto-ai/core: 2.1.1 -> 2.2.0
- @manifesto-ai/host: 2.0.2 -> 2.2.0
- @manifesto-ai/world: 2.1.1 -> 2.2.0
- @manifesto-ai/app: 2.1.1 -> 2.2.0
- @manifesto-ai/compiler: 1.4.1 -> 1.5.0
- @manifesto-ai/intent-ir: 0.2.1 -> 0.3.0
- @manifesto-ai/translator: 0.1.1 -> 0.2.0

## Validation
- pnpm install --no-frozen-lockfile
- pnpm build
- pnpm test

## Publish result
Published versions verified on npm:
- @manifesto-ai/core@2.2.0
- @manifesto-ai/host@2.2.0
- @manifesto-ai/world@2.2.0
- @manifesto-ai/app@2.2.0
- @manifesto-ai/compiler@1.5.0
- @manifesto-ai/intent-ir@0.3.0
- @manifesto-ai/translator@0.2.0
