### PR TITLE
docs: rewrite README, unify identity and SEO metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,82 @@
 # Manifesto
 
-**An OS layer for AI-native applications.**
+**Deterministic state management with built-in history, approval, and traceability.**
 
-Manifesto provides the primitives for building systems where AI agents and humans collaborate as first-class actors—with every state change deterministic, traceable, and verifiable.
+Manifesto provides primitives for building systems where multiple actors—humans, AI agents, or automated processes—collaborate on shared state, with every transition deterministic, traceable, and verifiable.
 
 [![npm version](https://img.shields.io/npm/v/@manifesto-ai/core.svg)](https://www.npmjs.com/package/@manifesto-ai/core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
+## Quick Start
+
+```bash
+npm install @manifesto-ai/app
+```
+
+```typescript
+import { createApp } from "@manifesto-ai/app";
+
+const app = createApp({
+  schema: `
+    domain Counter {
+      state { count: number = 0 }
+      action increment() {
+        onceIntent { patch count = add(count, 1) }
+      }
+    }
+  `,
+  effects: {},
+});
+
+await app.ready();
+
+await app.act("increment").done();
+console.log(app.getState().data.count); // 1
+
+await app.act("increment").done();
+console.log(app.getState().data.count); // 2
+```
+
+> See [examples/](./packages/app/examples/) for more: todos, effects, subscriptions.
+
+## Core Equation
+
+All state transitions in Manifesto follow one conceptual equation:
+
+```
+compute(schema, snapshot, intent) -> (snapshot', requirements, trace)
+```
+
+> **Note:** The actual implementation signature is `compute(schema, snapshot, intent, context) -> ComputeResult`, where `context` provides deterministic time and random seeds. See [`packages/core`](./packages/core) for details.
+
+This guarantees:
+
+- **Determinism** — Same inputs always produce same outputs
+- **Accountability** — Every change traced to Actor + Authority + Intent
+- **Explainability** — Complete trace answers "why" for every value
+- **Evolvability** — Schema itself can be modified through the same mechanism
+
 ## Why Manifesto?
 
-When AI agents modify application state, we need answers:
+When multiple actors modify shared state, we need answers:
 
 - **What happened?** — Which changes occurred, and in what order?
 - **Why?** — What intent triggered each change?
 - **Can we trust it?** — Will the same input always produce the same output?
 - **Who authorized it?** — Which actor, with what authority?
 
-Manifesto makes these guarantees possible through a formal semantic layer—not by wrapping existing tools, but by providing new primitives designed for AI-native computation.
+These questions become critical when AI enters the picture. Manifesto was born from a simple idea: **humans and AI should look at the same world model.** When an AI agent modifies application state, we need the same guarantees we'd demand from any actor—determinism, traceability, and governance. Manifesto makes these guarantees structural, not by wrapping existing tools, but by providing new primitives designed from the ground up.
 
 ## What Manifesto Is (and Isn't)
 
 Manifesto is **not** a state management library like Redux or Zustand.
 Manifesto is **not** an AI framework like LangChain or AutoGen.
 
-Manifesto is an **OS layer** that provides:
+Manifesto is a **deterministic state protocol** that provides:
 
 | Primitive | Purpose |
 |-----------|---------|
-| **Actor** | Who performs actions (human or AI) |
+| **Actor** | Who performs actions (human, AI, or system) |
 | **Authority** | What permissions govern the action |
 | **Intent** | What the actor wants to achieve |
 | **Schema** | Domain structure (itself a first-class, evolvable object) |
@@ -37,29 +86,16 @@ Manifesto is an **OS layer** that provides:
 | **Compute** | Pure, deterministic evaluation |
 | **Effect** | Controlled interaction with the outside world |
 
-## Core Equation
+## Actor Model
 
-All state transitions in Manifesto follow one equation:
+Manifesto is **actor-agnostic**. Every actor—human, AI, or automated process—participates through the same interface:
 
-```
-compute(schema, snapshot, intent) → (snapshot', requirements, trace)
-```
+- **Shared World Model** — Humans and AI look at the same Snapshot, reason about the same state
+- **Uniform Interface** — All actors submit intents the same way via `app.act()`
+- **Authority-governed** — Every action is subject to the same governance rules
+- **Verifiable** — Every actor's behavior is traceable and reproducible
 
-This guarantees:
-
-- **Determinism** — Same inputs always produce same outputs
-- **Accountability** — Every change traced to Actor + Authority + Intent
-- **Explainability** — Complete trace answers "why" for every value
-- **Evolvability** — Schema itself can be modified through the same mechanism
-
-## AI-Native by Design
-
-Manifesto treats AI as a first-class participant:
-
-- **AI as Actor** — AI agents submit intents just like humans
-- **AI-evolvable Schema** — AI can propose and execute schema migrations
-- **AI-friendly DSL** — MEL (Manifesto Expression Language) is designed for AI generation
-- **Verifiable AI behavior** — Every AI action is traceable and reproducible
+AI is the reason Manifesto exists, but not the only reason to use it. The same protocol that makes AI actions trustworthy also makes any multi-actor system auditable.
 
 ```mel
 // MEL: designed for both humans and AI to read/write
@@ -81,82 +117,49 @@ domain TaskBoard {
 flowchart TB
     Human[Human Actor]
     AI[AI Actor]
+    System[System Actor]
 
     subgraph AppLayer["@manifesto-ai/app"]
         direction TB
         AppFacade["App Facade<br/><i>createApp(), app.act()</i>"]
     end
 
-    subgraph Manifesto["Manifesto OS Layer"]
-        direction TB
+    subgraph Manifesto["Manifesto Protocol Stack"]
+        direction LR
         World["World<br/><i>governance</i>"]
-        Core["Core<br/><i>compute</i>"]
         Host["Host<br/><i>execute</i>"]
+        Core["Core<br/><i>compute</i>"]
     end
-
-    YourApp[Your Application]
 
     Human --> AppFacade
     AI --> AppFacade
+    System --> AppFacade
     AppFacade --> World
-    World --> Core
-    Core --> Host
-    Host --> YourApp
+    AppFacade --> Host
+    Host --> Core
 
-    Core -.->|"patches"| Host
-    Host -.->|"snapshot"| Core
-    World -.->|"authority"| Core
+    World -.->|"authority"| AppFacade
+    Core -.->|"patches + requirements"| Host
+    Host -.->|"effects + snapshot"| AppFacade
 ```
 
 | Layer | Responsibility |
 |-------|----------------|
-| **@manifesto-ai/app** | User-facing facade. Provides `createApp()`, `app.act()`, subscriptions. |
+| **@manifesto-ai/app** | User-facing facade. Provides `createApp()`, `app.act()`, subscriptions. Orchestrates all layers. |
 | **World** | Governance. Manages actors, authorities, and audit lineage. |
-| **Core** | Pure computation. Evaluates expressions, interprets flows, generates patches. |
-| **Host** | Effect execution. Handles IO, applies patches to external state. |
-
-## Quick Start
-
-```bash
-npm install @manifesto-ai/app @manifesto-ai/compiler
-```
-
-```typescript
-import { createApp } from "@manifesto-ai/app";
-import TaskBoardMel from "./taskboard.mel";
-
-const app = createApp(TaskBoardMel);
-await app.ready();
-
-// Human or AI — same interface
-await app.act("addTask", { title: "Review PR" }).done();
-
-// Full trace available
-console.log(app.getTrace()); // Who, what, when, why
-```
-
-> **Note:** MEL imports require a bundler plugin. See [Quickstart](https://docs.manifesto-ai.dev/quickstart) for setup.
-
-## Research
-
-Manifesto draws from formal linguistics, programming language theory, and AI safety research. The computation model provides formal guarantees suitable for verification, while the Intent IR layer offers semantic representations grounded in linguistic theory.
-
-**Related areas:** AI Safety · Explainable AI · Programming Language Theory · Cognitive Science · Neuro-Symbolic AI
-
-**Research documentation:**
-
-- [Intent IR Theory](./docs/internals/research/intent-ir/theory.md) — Linguistic foundations
-- [Formal Properties](./docs/internals/research/intent-ir/formal.md) — Mathematical definitions
-- [Comparison](./docs/internals/research/intent-ir/comparison.md) — vs AMR, FrameNet, PropBank
+| **Core** | Pure computation. Evaluates expressions, interprets flows, generates patches. Zero IO. |
+| **Host** | Effect execution. Runs the compute-effect-apply loop, handles IO. |
 
 ## When to Use Manifesto
 
 | Scenario | Manifesto? |
 |----------|------------|
 | AI agents that modify application state | Yes |
-| Systems requiring audit trails for AI actions | Yes |
-| Multi-actor collaboration (human + AI) | Yes |
-| Schema evolution driven by AI | Yes |
+| Systems requiring audit trails | Yes |
+| Multi-actor collaboration (human + AI + system) | Yes |
+| Collaborative editing with traceability | Yes |
+| Event-sourced backends with governance | Yes |
+| Schema evolution driven by actors | Yes |
 | Formal verification of state transitions | Yes |
 | Simple UI state | No (use Zustand) |
 | LLM orchestration / prompt chaining | No (use LangChain) |
@@ -179,6 +182,18 @@ Manifesto draws from formal linguistics, programming language theory, and AI saf
 - [MEL Language](https://docs.manifesto-ai.dev/mel/) — Domain definition syntax
 - [API Reference](https://docs.manifesto-ai.dev/api/) — Package APIs
 - [Live Demo](https://taskflow.manifesto-ai.dev) — TaskFlow example
+
+## Research
+
+Manifesto draws from formal linguistics, programming language theory, and AI safety research. The computation model provides formal guarantees suitable for verification, while the Intent IR layer offers semantic representations grounded in linguistic theory.
+
+**Related areas:** AI Safety · Explainable AI · Programming Language Theory · Cognitive Science · Neuro-Symbolic AI
+
+**Research documentation:**
+
+- [Intent IR Theory](./docs/internals/research/intent-ir/theory.md) — Linguistic foundations
+- [Formal Properties](./docs/internals/research/intent-ir/formal.md) — Mathematical definitions
+- [Comparison](./docs/internals/research/intent-ir/comparison.md) — vs AMR, FrameNet, PropBank
 
 ## Development
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -32,7 +32,16 @@ function addMermaidRenderer(md: MarkdownRenderer) {
 
 export default defineConfig({
   title: 'Manifesto',
-  description: 'Accountable state management for AI-powered applications',
+  description: 'Deterministic state protocol for humans and AI — with built-in history, approval, and traceability',
+  head: [
+    ['meta', { property: 'og:title', content: 'Manifesto' }],
+    ['meta', { property: 'og:description', content: 'Deterministic state protocol for humans and AI — with built-in history, approval, and traceability' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:url', content: 'https://docs.manifesto-ai.dev' }],
+    ['meta', { name: 'twitter:card', content: 'summary' }],
+    ['meta', { name: 'twitter:title', content: 'Manifesto' }],
+    ['meta', { name: 'twitter:description', content: 'Deterministic state protocol for humans and AI — with built-in history, approval, and traceability' }],
+  ],
   markdown: {
     languages: markdownLanguages,
     config: (md) => {

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: Manifesto
-  text: Semantic State for AI-Governed Apps
-  tagline: Deterministic computation. Full accountability. Every state change traceable.
+  text: Deterministic State Protocol
+  tagline: One world model for humans and AI. Every state change traceable. Every transition reproducible.
   actions:
     - theme: brand
       text: Quickstart
@@ -23,9 +23,9 @@ features:
   - icon: 🔍
     title: Accountable
     details: Every change traceable to Actor + Authority + Intent.
-  - icon: 🤖
-    title: AI-Native
-    details: Schema-first. LLMs can read, reason, and modify safely.
+  - icon: 👥
+    title: Actor-Agnostic
+    details: Humans, AI agents, and automated processes share the same interface.
   - icon: ⚡
     title: Effect Isolation
     details: Pure computation separated from IO.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,23 @@
   "name": "@manifesto-ai/monorepo",
   "version": "1.0.0",
   "private": true,
+  "description": "Deterministic state management with built-in history, approval, and traceability",
+  "homepage": "https://docs.manifesto-ai.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/manifesto-ai/core.git"
+  },
+  "keywords": [
+    "manifesto",
+    "state-management",
+    "deterministic",
+    "traceable",
+    "semantic",
+    "governance",
+    "audit-trail",
+    "actor-model",
+    "ai"
+  ],
   "type": "module",
   "packageManager": "pnpm@9.15.2",
   "engines": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,8 +18,10 @@
     "state-management",
     "deterministic",
     "semantic",
-    "app",
-    "facade"
+    "traceable",
+    "governance",
+    "audit-trail",
+    "ai"
   ],
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -16,10 +16,12 @@
   "keywords": [
     "manifesto",
     "compiler",
-    "natural-language",
-    "llm",
-    "ai",
-    "schema-generation"
+    "dsl",
+    "semantic",
+    "domain-schema",
+    "deterministic",
+    "schema-generation",
+    "ai"
   ],
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,10 @@
     "manifesto",
     "state-management",
     "deterministic",
-    "semantic"
+    "semantic",
+    "traceable",
+    "immutable",
+    "pure-computation"
   ],
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -17,7 +17,9 @@
     "manifesto",
     "effects",
     "runtime",
-    "state-management"
+    "state-management",
+    "deterministic",
+    "effect-handler"
   ],
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -18,7 +18,9 @@
     "governance",
     "authority",
     "lineage",
-    "ai-agents"
+    "audit-trail",
+    "traceability",
+    "ai"
   ],
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- **README 전면 재작성**: Quick Start를 v2.3 API로 수정 (createApp config), Core Equation 시그니처 보정, 섹션 순서 재배치 (Quick Start 먼저)
- **정체성 통일**: "OS layer for AI-native applications" → "deterministic state protocol for humans and AI"
- **AI 톤 밸런스**: actor-agnostic 프레이밍 + AI를 프로젝트 출발 동기로 자연스럽게 포지셔닝
- **SEO 메타데이터 정비**: VitePress og/twitter tags, root package.json에 description/homepage/repository/keywords 추가
- **패키지 키워드 업데이트**: 모든 패키지에 semantic/ai/traceable 추가, AI-only 용어(ai-agents, llm, natural-language) 정리

## Test plan

- [ ] README Quick Start 코드가 `packages/app/examples/01-counter/main.ts`와 패턴 일치 확인
- [ ] `pnpm docs:dev`로 docs 랜딩 페이지 렌더링 확인
- [ ] og/twitter meta tags가 HTML head에 정상 삽입되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)