### PR TITLE
docs: add SDK/Runtime documentation and update App docs for ADR-007

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -136,6 +136,8 @@ export default defineConfig({
           items: [
             { text: 'Overview', link: '/api/' },
             { text: '@manifesto-ai/app', link: '/api/app' },
+            { text: '@manifesto-ai/sdk', link: '/api/sdk' },
+            { text: '@manifesto-ai/runtime', link: '/api/runtime' },
             { text: '@manifesto-ai/core', link: '/api/core' },
             { text: '@manifesto-ai/host', link: '/api/host' },
             { text: '@manifesto-ai/world', link: '/api/world' },
@@ -199,6 +201,9 @@ export default defineConfig({
             { text: 'ADR-002: DX Improvements', link: '/internals/adr/002-dx-improvement-mel-namespace-onceIntent' },
             { text: 'ADR-003: World Owns Persistence', link: '/internals/adr/003-world-owns-persistence' },
             { text: 'ADR-004: App Internal Decomposition', link: '/internals/adr/004-app-package-internal-decomposition' },
+            { text: 'ADR-005: Snapshot Path DSL (Withdrawn)', link: '/internals/adr/005-dx-improvement-snapshot-path-dsl' },
+            { text: 'ADR-006: Runtime Reframing', link: '/internals/adr/006-runtime-reframing' },
+            { text: 'ADR-007: SDK/Runtime Split', link: '/internals/adr/007-sdk-runtime-split-kickoff' },
           ]
         },
         {

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -19,6 +19,33 @@ The App package provides:
 
 ---
 
+## Package Evolution (v2.4.0)
+
+Since v2.4.0, `@manifesto-ai/app` is a **pure re-export facade** over two new packages:
+
+```mermaid
+flowchart TB
+  U["Application Code"] --> APP["@manifesto-ai/app (facade)"]
+
+  APP --> SDK["@manifesto-ai/sdk (public API)"]
+  APP --> RT["@manifesto-ai/runtime (types, errors, internals)"]
+
+  SDK --> RT
+  RT --> C["Core"]
+  RT --> H["Host"]
+  RT --> W["World"]
+```
+
+| Package | Role |
+|---------|------|
+| [`@manifesto-ai/sdk`](/api/sdk) | Public API: `createApp`, `ManifestoApp`, hooks |
+| [`@manifesto-ai/runtime`](/api/runtime) | Internal: types, errors, execution, policy, memory |
+| `@manifesto-ai/app` | Facade: re-exports from both (you are here) |
+
+**No breaking changes.** The same `import { createApp } from "@manifesto-ai/app"` works as before. See [ADR-007](../internals/adr/007-sdk-runtime-split-kickoff) for rationale.
+
+---
+
 ## Architecture
 
 `@manifesto-ai/app` is the facade layer that wires World, Host, Core, and Memory.
@@ -1233,8 +1260,11 @@ These are useful when you need lower-level composition outside the default `crea
 
 ## Related Documentation
 
+- [SDK Package](/api/sdk) - Public developer API layer (createApp, hooks)
+- [Runtime Package](/api/runtime) - Internal execution orchestration engine
 - [Core Package](/api/core) - Domain schema and computation
 - [Host Package](/api/host) - Effect execution specification
 - [World Package](/api/world) - Governance and lineage
 - [Getting Started](/quickstart) - Step-by-step tutorial
 - [Effect Handlers](/guides/effect-handlers) - Detailed effect handler guide
+- [ADR-007](../internals/adr/007-sdk-runtime-split-kickoff) - SDK/Runtime split rationale

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -1,0 +1,181 @@
+# @manifesto-ai/runtime
+
+> Internal execution orchestration engine for the Manifesto protocol stack
+
+> **Internal Package:** This package is not intended for direct consumption. Use `@manifesto-ai/app` or `@manifesto-ai/sdk` instead.
+
+---
+
+## Overview
+
+`@manifesto-ai/runtime` is the internal orchestration layer between SDK and protocol packages.
+
+- 5-stage action execution pipeline
+- All shared type definitions and error hierarchy
+- Policy, memory, branch, and subscription management
+
+---
+
+## Architecture Role
+
+Runtime orchestrates Core, Host, and World. It is consumed by SDK, never directly by end users.
+
+```mermaid
+flowchart TB
+  SDK["SDK (public API)"] --> RT["Runtime"]
+
+  subgraph RT["Runtime (orchestration)"]
+    direction LR
+    BOOT["Bootstrap"] --> EXEC["Executor"]
+    EXEC --> PIPE["Pipeline"]
+    PIPE --> POLICY["Policy"]
+  end
+
+  RT --> C["Core (compute)"]
+  RT --> H["Host (execute)"]
+  RT --> W["World (govern)"]
+```
+
+---
+
+## Main Components
+
+### AppRuntime
+
+Assembled runtime holding all dependencies after bootstrap. Created by `AppBootstrap.assemble()`.
+
+### AppBootstrap
+
+Handles the `created → ready` transition:
+1. Validate actor policy
+2. Compile domain (if MEL text)
+3. Create initial state
+4. Create BranchManager
+5. Create HostExecutor and genesis World
+6. Construct AppRuntime
+
+### AppExecutor
+
+Orchestrates the 5-stage action pipeline.
+
+---
+
+## Execution Pipeline
+
+Every action passes through five stages:
+
+| Stage | Responsibility |
+|-------|---------------|
+| **Prepare** | Validate action type, create Proposal |
+| **Authorize** | Derive ExecutionKey, get Authority approval, validate scope |
+| **Execute** | Restore snapshot, recall memory, freeze context, execute via Host |
+| **Persist** | Seal World, store delta, advance branch head, notify subscribers |
+| **Finalize** | Create ActionResult, emit hooks, clean up |
+
+---
+
+## Key Subsystems
+
+### Policy Service
+
+Configurable execution policies for governance.
+
+| Policy | ExecutionKey | Behavior |
+|--------|-------------|----------|
+| `defaultPolicy` | `proposal:{id}` | Maximum parallelism |
+| `actorSerialPolicy` | `actor:{actorId}` | Per-actor serialization |
+| `globalSerialPolicy` | `global` | Full serialization |
+| `branchSerialPolicy` | `branch:{branchId}` | Per-branch serialization |
+
+### Memory Hub
+
+External memory coordination with deterministic context freezing.
+
+- Provider fan-out for ingest and recall
+- Context freezing (RT-MEM-1) for deterministic replay
+- Graceful degradation on memory failure
+
+### Branch Manager
+
+Branches as named pointers over World lineage.
+
+- Branch creation and switching
+- Schema-changing fork with compatibility validation
+- Head advancement only on completed execution
+
+### System Runtime
+
+Separate runtime for `system.*` meta-operations with independent World lineage.
+
+---
+
+## Exported Types
+
+Runtime defines all shared types used across the stack:
+
+```typescript
+// Core types
+AppStatus, RuntimeKind, ActionPhase, ActionResult, AppState
+
+// Action types
+ActionHandle, ActionUpdate, ExecutionStats
+
+// Configuration
+AppConfig, Effects, AppEffectContext, EffectHandler
+
+// Storage
+WorldStore, WorldDelta, Branch, WorldId
+
+// Policy
+PolicyService, ExecutionKey, ApprovedScope, AuthorityDecision
+
+// Memory
+MemoryProvider, MemoryStore, RecallRequest, RecallResult
+
+// Hooks
+AppHooks, AppRef, HookContext
+```
+
+---
+
+## Error Types
+
+25 error classes extending `ManifestoAppError`:
+
+| Category | Errors |
+|----------|--------|
+| Lifecycle | `AppNotReadyError`, `AppDisposedError` |
+| Action | `ActionRejectedError`, `ActionFailedError`, `ActionTimeoutError`, `ActionNotFoundError` |
+| Hook | `HookMutationError` |
+| Effects | `ReservedEffectTypeError` |
+| System | `SystemActionDisabledError`, `SystemActionRoutingError` |
+| Memory | `MemoryDisabledError` |
+| Branch/World | `BranchNotFoundError`, `WorldNotFoundError`, `WorldSchemaHashMismatchError` |
+| Resume | `SchemaMismatchOnResumeError`, `BranchHeadNotFoundError` |
+
+---
+
+## WorldStore
+
+Runtime provides `InMemoryWorldStore` as the default storage implementation.
+
+```typescript
+import { createInMemoryWorldStore } from "@manifesto-ai/runtime";
+
+const store = createInMemoryWorldStore();
+```
+
+Custom implementations must satisfy the `WorldStore` interface.
+
+---
+
+## Related Packages
+
+| Package | Relationship |
+|---------|--------------|
+| [@manifesto-ai/sdk](./sdk) | Public API layer (consumes Runtime) |
+| [@manifesto-ai/app](./app) | Facade that re-exports Runtime types |
+| [@manifesto-ai/core](./core) | Pure computation (called by Runtime) |
+| [@manifesto-ai/host](./host) | Effect execution (called by Runtime) |
+| [@manifesto-ai/world](./world) | Governance and lineage (called by Runtime) |
+| [@manifesto-ai/compiler](./compiler) | MEL compilation (called by Runtime) |

--- a/docs/api/sdk.md
+++ b/docs/api/sdk.md
@@ -1,0 +1,199 @@
+# @manifesto-ai/sdk
+
+> Public developer API layer for the Manifesto protocol stack
+
+> **Phase 1:** Most users should use `@manifesto-ai/app`, which re-exports all SDK APIs.
+
+---
+
+## Overview
+
+`@manifesto-ai/sdk` is the public API surface for building Manifesto applications.
+
+- `createApp()` — single entry point for app creation
+- `ManifestoApp` — thin facade delegating to Runtime
+- Hook system with re-entrancy guards and deferred execution
+
+---
+
+## Architecture Role
+
+SDK presents the public contract. All orchestration is delegated to Runtime.
+
+```mermaid
+flowchart LR
+  U["Application Code"] --> SDK["SDK (createApp, App, Hooks)"]
+  SDK --> RT["Runtime (orchestration)"]
+  RT --> C["Core"]
+  RT --> H["Host"]
+  RT --> W["World"]
+```
+
+---
+
+## Main Exports
+
+### createApp()
+
+Creates a new Manifesto App instance.
+
+```typescript
+import { createApp } from "@manifesto-ai/sdk";
+
+const app = createApp({
+  schema: domainSchema,
+  effects: {
+    "api.save": async (params, ctx) => [
+      { op: "set", path: "data.savedAt", value: params.timestamp },
+    ],
+  },
+});
+
+await app.ready();
+```
+
+### AppConfig
+
+```typescript
+interface AppConfig {
+  readonly schema: DomainSchema | string;
+  readonly effects: Effects;
+
+  readonly world?: ManifestoWorld;
+  readonly policyService?: PolicyService;
+  readonly executionKeyPolicy?: ExecutionKeyPolicy;
+
+  readonly memoryStore?: MemoryStore;
+  readonly memoryProvider?: MemoryProvider;
+  readonly memory?: false | MemoryHubConfig;
+
+  readonly plugins?: readonly AppPlugin[];
+  readonly hooks?: Partial<AppHooks>;
+  readonly initialData?: unknown;
+  readonly actorPolicy?: ActorPolicyConfig;
+  readonly systemActions?: SystemActionsConfig;
+  readonly validation?: { readonly effects?: "strict" | "warn" | "off" };
+}
+```
+
+### createTestApp()
+
+Minimal app for testing with in-memory defaults.
+
+```typescript
+import { createTestApp } from "@manifesto-ai/sdk";
+
+const app = createTestApp(schema, { effects: {} });
+await app.ready();
+```
+
+---
+
+## App Interface
+
+### Lifecycle
+
+```typescript
+await app.ready();           // Initialize (created → ready)
+await app.dispose();         // Shutdown (ready → disposed)
+app.status;                  // 'created' | 'ready' | 'disposing' | 'disposed'
+```
+
+### Actions
+
+```typescript
+const handle = app.act("increment", { by: 1 });
+await handle.completed();    // Wait for completion
+handle.phase;                // 'queued' | 'executing' | 'completed' | 'rejected' | 'failed'
+```
+
+### State Access
+
+```typescript
+const state = app.getState<MyState>();
+state.data.count;            // Type-safe access
+
+const unsubscribe = app.subscribe(
+  (s) => s.data.count,
+  (count) => console.log("count changed:", count)
+);
+```
+
+### Session
+
+```typescript
+const session = app.session("user-123");
+session.act("increment");    // Actor-scoped action
+```
+
+### Branch Management
+
+```typescript
+const branch = app.currentBranch();
+const branches = app.listBranches();
+const forked = await app.fork({ name: "experiment" });
+await app.switchBranch(forked.id);
+```
+
+---
+
+## Hook System
+
+SDK provides lifecycle hooks with re-entrancy guards.
+
+```typescript
+const app = createApp({
+  schema,
+  effects: {},
+  hooks: {
+    "app:ready": (ctx) => {
+      console.log("App is ready");
+    },
+    "action:completed": (ctx, result) => {
+      // Safe: read-only access via ctx.app
+      const state = ctx.app.getState();
+
+      // Safe: deferred execution (runs after hook completes)
+      ctx.app.enqueueAction("log.action", { result });
+    },
+  },
+});
+```
+
+### AppRef (Read-Only Facade)
+
+Inside hooks, `ctx.app` is an `AppRef` — a read-only facade that prevents re-entrant mutations.
+
+| AppRef Method | Description |
+|---------------|-------------|
+| `status` | Current app status |
+| `getState()` | Read current state |
+| `getDomainSchema()` | Read schema |
+| `getCurrentHead()` | Read current world head |
+| `currentBranch()` | Read current branch |
+| `enqueueAction()` | Deferred action (runs after hook) |
+
+---
+
+## Error Types
+
+SDK re-exports error types from Runtime. Key errors:
+
+| Error | When |
+|-------|------|
+| `AppNotReadyError` | API called before `ready()` |
+| `AppDisposedError` | API called after `dispose()` |
+| `ReservedEffectTypeError` | User tried to override `system.get` |
+| `HookMutationError` | Direct mutation attempted inside hook |
+
+---
+
+## Related Packages
+
+| Package | Relationship |
+|---------|--------------|
+| [@manifesto-ai/app](./app) | Facade that re-exports SDK (canonical entry during Phase 1) |
+| [@manifesto-ai/runtime](./runtime) | Internal orchestration engine (SDK delegates to Runtime) |
+| [@manifesto-ai/core](./core) | Pure computation (used by Runtime) |
+| [@manifesto-ai/host](./host) | Effect execution (used by Runtime) |
+| [@manifesto-ai/world](./world) | Governance and lineage (used by Runtime) |

--- a/packages/app/docs/MIGRATION-GUIDE.md
+++ b/packages/app/docs/MIGRATION-GUIDE.md
@@ -3,9 +3,60 @@
 This guide helps you migrate between major versions of `createApp()` API.
 
 **Version History:**
+- [v2.3.0 → v2.4.0](#v230--v240-sdkruntime-extraction) — SDK/Runtime extraction (ADR-007)
 - [v2.2.0 → v2.3.0](#v220--v230-world-owns-persistence) — World owns persistence (ADR-003)
 - [v2.0.0 → v2.2.0](#v200--v220-effects-first-api) — Effects-first API (ADR-APP-002)
 - [v1.x → v2.0.0](#v1x--v200-injectable-host) — Injectable Host
+
+---
+
+# v2.3.0 → v2.4.0: SDK/Runtime Extraction
+
+> **Breaking Change:** None
+> **Internal Change:** App internals extracted into `@manifesto-ai/sdk` and `@manifesto-ai/runtime`
+
+## Overview
+
+v2.4.0 implements **ADR-007** (SDK/Runtime Split):
+
+| v2.3.0 | v2.4.0 |
+|--------|--------|
+| Monolithic (~14,000 LOC) | Pure re-export facade (328 LOC) |
+| All internals in `app` | Internals in `runtime`, public API in `sdk` |
+| Single package | App re-exports from `sdk` + `runtime` |
+
+## No Migration Needed
+
+**The public API is identical.** No code changes are required.
+
+```typescript
+// This works exactly the same in v2.3.0 and v2.4.0
+import { createApp } from "@manifesto-ai/app";
+
+const app = createApp({
+  schema,
+  effects: { "api.save": handler },
+});
+
+await app.ready();
+```
+
+## Advanced: Direct SDK Import (Preview)
+
+During **Phase 1**, `@manifesto-ai/app` remains the canonical entry point. Direct SDK imports are available as a preview:
+
+```typescript
+// Preview — may change in Phase 2
+import { createApp } from "@manifesto-ai/sdk";
+```
+
+> **Note:** SDK/Runtime packages are kickoff-locked per ADR-007. Requirement IDs (`SDK-*`, `RT-*`) are stable, but the packages are not yet promoted to primary entry points.
+
+## Resources
+
+- [ADR-007: SDK/Runtime Split](../../../docs/internals/adr/007-sdk-runtime-split-kickoff.md)
+- [sdk-SPEC-v0.1.0](../../sdk/docs/sdk-SPEC-v0.1.0.md)
+- [runtime-SPEC-v0.1.0](../../runtime/docs/runtime-SPEC-v0.1.0.md)
 
 ---
 

--- a/packages/app/docs/VERSION-INDEX.md
+++ b/packages/app/docs/VERSION-INDEX.md
@@ -1,16 +1,19 @@
 # Manifesto App Documentation Index
 
 > **Package:** `@manifesto-ai/app`
-> **Last Updated:** 2026-02-08
+> **Last Updated:** 2026-02-15
 
 ---
 
 ## Latest Version
 
+- **Package:** v2.4.0 (facade — re-exports from SDK/Runtime per [ADR-007](../../../docs/internals/adr/007-sdk-runtime-split-kickoff.md))
 - **SPEC:** [v2.3.1](APP-SPEC-v2.3.1-patch.md) (Patch, Base: v2.3.0 — Head Query API delegation)
 - **Architecture:** [APP-ARCHITECTURE-OVERVIEW.md](APP-ARCHITECTURE-OVERVIEW.md)
 
-**Note:** v2.3.1 is a patch on v2.3.0. Read [APP-SPEC-v2.3.0.md](APP-SPEC-v2.3.0.md) first, then apply [APP-SPEC-v2.3.1-patch.md](APP-SPEC-v2.3.1-patch.md). For API rationale, see [ADR-APP-002](ADR-APP-002-v0.2.0.md).
+**Note:** Since v2.4.0, `@manifesto-ai/app` is a pure re-export facade. Implementation now lives in [`@manifesto-ai/sdk`](../../sdk/docs/VERSION-INDEX.md) (public API) and [`@manifesto-ai/runtime`](../../runtime/docs/VERSION-INDEX.md) (internal orchestration). No public API changes — existing imports work identically.
+
+For SPEC details, read [APP-SPEC-v2.3.0.md](APP-SPEC-v2.3.0.md) first, then apply [APP-SPEC-v2.3.1-patch.md](APP-SPEC-v2.3.1-patch.md). For API rationale, see [ADR-APP-002](ADR-APP-002-v0.2.0.md).
 
 ---
 
@@ -18,6 +21,7 @@
 
 | Version | SPEC | FDR | Type | Status |
 |---------|------|-----|------|--------|
+| v2.4.0 | — | [ADR-007](../../../docs/internals/adr/007-sdk-runtime-split-kickoff.md) | Facade (SDK/Runtime split) | Released |
 | v2.3.1 | [SPEC](APP-SPEC-v2.3.1-patch.md) | — | Patch (Base: v2.3.0) | Draft |
 | v2.3.0 | [SPEC](APP-SPEC-v2.3.0.md) | [ADR-APP-002](#adrs) | Full | Ratified |
 | v2.1.0 | [SPEC](APP-SPEC-v2.1.0-patch.md) | — | Patch (Base: v2.0.0) | Draft |
@@ -73,7 +77,18 @@
 
 ---
 
+## Related Packages (ADR-007)
+
+Since v2.4.0, App is a facade over:
+
+| Package | Version | Role |
+|---------|---------|------|
+| [`@manifesto-ai/sdk`](../../sdk/docs/VERSION-INDEX.md) | v0.1.0 | Public developer API |
+| [`@manifesto-ai/runtime`](../../runtime/docs/VERSION-INDEX.md) | v0.1.0 | Internal orchestration engine |
+
+---
+
 ## Additional Documents
 
 - [APP-TEST-SPEC-v2.0.0.md](APP-TEST-SPEC-v2.0.0.md) - Test specification
-- [MIGRATION-GUIDE.md](MIGRATION-GUIDE.md) - Migration guide from v0.4.x to v2.0
+- [MIGRATION-GUIDE.md](MIGRATION-GUIDE.md) - Migration guide from v0.4.x to v2.4

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,0 +1,122 @@
+# @manifesto-ai/runtime
+
+> **Runtime** is the internal execution orchestration engine for the Manifesto protocol stack. It bridges Core, Host, and World through a 5-stage action pipeline.
+
+> **Internal Package:** This package is NOT intended for direct consumption. Use `@manifesto-ai/app` or `@manifesto-ai/sdk` instead.
+
+---
+
+## What is Runtime?
+
+Runtime is the orchestration layer that sits between the SDK (public API) and the protocol layers (Core, Host, World). It implements the execution pipeline, policy system, memory coordination, and branch management.
+
+```
+SDK (public API)
+    |
+    v
+  RUNTIME (orchestration)               <-- you are here
+    |         |         |
+    v         v         v
+  Core      Host      World
+  (compute) (execute) (govern)
+```
+
+---
+
+## What Runtime Does
+
+| Responsibility | Description |
+|----------------|-------------|
+| Action pipeline | 5-stage execution: prepare, authorize, execute, persist, finalize |
+| Type definitions | All shared types (AppConfig, AppState, ActionHandle, etc.) |
+| Error hierarchy | 25 error classes extending ManifestoAppError |
+| Policy system | ExecutionKey derivation, Authority routing, Scope enforcement |
+| Memory coordination | Provider fan-out, context freezing for determinism |
+| Branch management | Named pointers over World lineage |
+| State subscriptions | Selector-based change detection with batching |
+| System runtime | Separate runtime for `system.*` meta-operations |
+| Bootstrap | App assembly sequence (schema → state → world → executor) |
+
+---
+
+## What Runtime Does NOT Do
+
+| NOT Responsible For | Who Is |
+|--------------------|--------|
+| Public API shape | SDK |
+| Pure state computation | Core |
+| Effect execution (IO) | Host |
+| Governance and lineage | World |
+| Lifecycle presentation | SDK |
+
+---
+
+## Installation
+
+> **Do not install this package directly.** It is consumed internally by `@manifesto-ai/sdk`.
+
+```bash
+# Use the App facade instead:
+pnpm add @manifesto-ai/app
+```
+
+---
+
+## Internal Architecture
+
+### 5-Stage Action Pipeline
+
+```
+1. Prepare    → Validate action type, create Proposal
+2. Authorize  → Derive ExecutionKey, get Authority approval, validate scope
+3. Execute    → Restore snapshot, recall memory, freeze context, run Host
+4. Persist    → Seal World, store delta, advance branch head
+5. Finalize   → Create ActionResult, emit hooks, clean up
+```
+
+### Main Components
+
+| Component | Responsibility |
+|-----------|---------------|
+| `AppRuntime` | Assembled runtime holding all dependencies post-bootstrap |
+| `AppBootstrap` | Handles `created → ready` transition |
+| `AppExecutor` | Orchestrates the 5-stage pipeline |
+| `AppHostExecutor` | Bridges Host execution with World persistence |
+| `BranchManager` | Manages branches as named pointers |
+| `MemoryHub` | Memory provider fan-out and context freezing |
+| `DefaultPolicyService` | ExecutionKey and Authority policies |
+| `SystemRuntime` | Separate runtime for system meta-operations |
+| `SubscriptionStore` | State change notifications with selectors |
+
+---
+
+## Relationship with Other Packages
+
+```
+App (facade) -> SDK -> Runtime -> Core / Host / World
+```
+
+| Relationship | Package | How |
+|--------------|---------|-----|
+| Consumed by | `@manifesto-ai/sdk` | SDK delegates all orchestration to Runtime |
+| Re-exported by | `@manifesto-ai/app` | App re-exports Runtime types and errors |
+| Depends on | `@manifesto-ai/core` | Pure computation |
+| Depends on | `@manifesto-ai/host` | Effect execution |
+| Depends on | `@manifesto-ai/world` | Governance and lineage |
+| Depends on | `@manifesto-ai/compiler` | MEL compilation |
+
+---
+
+## Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [runtime-SPEC-v0.1.0.md](docs/runtime-SPEC-v0.1.0.md) | Complete specification |
+| [VERSION-INDEX.md](docs/VERSION-INDEX.md) | Version history and reading guide |
+| [ADR-007](../../docs/internals/adr/007-sdk-runtime-split-kickoff.md) | Split rationale |
+
+---
+
+## License
+
+[MIT](../../LICENSE)

--- a/packages/runtime/docs/VERSION-INDEX.md
+++ b/packages/runtime/docs/VERSION-INDEX.md
@@ -1,0 +1,47 @@
+# Manifesto Runtime Documentation Index
+
+> **Package:** `@manifesto-ai/runtime`
+> **Last Updated:** 2026-02-15
+> **Visibility:** Internal — not intended for direct consumption
+
+---
+
+## Latest Version
+
+- **SPEC:** [v0.1.0](runtime-SPEC-v0.1.0.md) (Draft — kickoff-locked baseline per ADR-007)
+
+**Note:** v0.1.0 is the initial Runtime specification extracted from `@manifesto-ai/app` v2.3.0. Requirement IDs (`RT-*`) are locked and cannot be renamed or removed. Additive clarification is allowed.
+
+---
+
+## All Versions
+
+| Version | SPEC | FDR | Type | Status |
+|---------|------|-----|------|--------|
+| v0.1.0 | [SPEC](runtime-SPEC-v0.1.0.md) | — | Full | Draft (kickoff-locked) |
+
+---
+
+## Reading Guide
+
+### For v0.1.0
+
+1. Read [runtime-SPEC-v0.1.0.md](runtime-SPEC-v0.1.0.md) (complete specification)
+2. For split rationale: [ADR-007](../../../docs/internals/adr/007-sdk-runtime-split-kickoff.md)
+3. For the SDK public API that depends on Runtime: [SDK VERSION-INDEX](../../sdk/docs/VERSION-INDEX.md)
+4. For the App facade that re-exports Runtime types: [App VERSION-INDEX](../../app/docs/VERSION-INDEX.md)
+
+---
+
+## Relationship to Other Packages
+
+Runtime is the internal execution engine consumed by SDK, never directly by end users.
+
+```
+@manifesto-ai/app (facade)
+  └── @manifesto-ai/sdk (public API)
+        └── @manifesto-ai/runtime (internal orchestration) ← you are here
+              └── core, host, world, compiler
+```
+
+See [ADR-007](../../../docs/internals/adr/007-sdk-runtime-split-kickoff.md) for architectural rationale.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,182 @@
+# @manifesto-ai/sdk
+
+> **SDK** is the public developer API layer for Manifesto applications. It presents ergonomic factory functions, lifecycle management, and hook systems while delegating all execution to the Runtime.
+
+> **Phase 1 Notice:** During the current phase, most users should install `@manifesto-ai/app`, which re-exports all SDK APIs. See [ADR-007](../../docs/internals/adr/007-sdk-runtime-split-kickoff.md) for details.
+
+---
+
+## What is SDK?
+
+SDK owns the public contract shape that developers interact with. It provides `createApp()`, the `App` interface, and the hook system — but delegates all orchestration to `@manifesto-ai/runtime`.
+
+```
+Application Code
+      |
+      v
+    SDK (createApp, App, Hooks)       <-- you are here
+      |
+      v
+    Runtime (orchestration, execution)
+      |
+      v
+    Core / Host / World
+```
+
+---
+
+## What SDK Does
+
+| Responsibility | Description |
+|----------------|-------------|
+| App factory | `createApp(config)` — single entry point for creating apps |
+| App interface | `ManifestoApp` — thin facade over Runtime |
+| Lifecycle | `ready()` / `dispose()` with status tracking |
+| Hook system | Observable lifecycle with re-entrancy guards |
+| AppRef | Read-only facade for safe hook access |
+| Job queue | Deferred execution for hook-triggered actions |
+| Test helper | `createTestApp()` — minimal app for testing |
+
+---
+
+## What SDK Does NOT Do
+
+| NOT Responsible For | Who Is |
+|--------------------|--------|
+| Execution orchestration | Runtime |
+| Effect execution | Host (via Runtime) |
+| Pure state computation | Core (via Runtime) |
+| Governance and lineage | World (via Runtime) |
+| Type/error definitions | Runtime |
+
+---
+
+## Installation
+
+During **Phase 1**, use `@manifesto-ai/app` as the canonical entry point:
+
+```bash
+pnpm add @manifesto-ai/app
+```
+
+For direct SDK access (preview):
+
+```bash
+pnpm add @manifesto-ai/sdk
+```
+
+---
+
+## Quick Example
+
+```typescript
+import { createApp } from "@manifesto-ai/sdk";
+
+const app = createApp({
+  schema: counterSchema,
+  effects: {
+    "api.save": async (params, ctx) => [
+      { op: "set", path: "data.savedAt", value: params.timestamp },
+    ],
+  },
+});
+
+await app.ready();
+
+const handle = app.act("increment");
+await handle.completed();
+
+console.log(app.getState().data.count); // 1
+```
+
+---
+
+## Core API
+
+### Factory Functions
+
+```typescript
+function createApp(config: AppConfig): App;
+function createTestApp(domain: DomainSchema | string, opts?: Partial<AppConfig>): App;
+```
+
+### App Interface
+
+```typescript
+interface App {
+  // Lifecycle
+  ready(): Promise<void>;
+  dispose(opts?): Promise<void>;
+  readonly status: AppStatus;
+  readonly hooks: Hookable<AppHooks>;
+
+  // Schema
+  getDomainSchema(): DomainSchema;
+
+  // Actions
+  act(type: string, input?: unknown, opts?): ActionHandle;
+  submitProposal(proposal): Promise<ProposalResult>;
+
+  // State
+  getState<T>(): AppState<T>;
+  subscribe(selector, listener, opts?): () => void;
+  getSnapshot(): Snapshot;
+
+  // Session
+  session(actorId: string, opts?): Session;
+
+  // Branch
+  currentBranch(): Branch;
+  listBranches(): Branch[];
+  switchBranch(branchId): Promise<void>;
+  fork(opts?): Promise<Branch>;
+
+  // World Query
+  getCurrentHead(): WorldId;
+  getWorld(worldId?): World;
+}
+```
+
+> See [sdk-SPEC-v0.1.0.md](docs/sdk-SPEC-v0.1.0.md) for the complete specification.
+
+---
+
+## Relationship with Other Packages
+
+```
+App (facade) -> SDK -> Runtime -> Core / Host / World
+```
+
+| Relationship | Package | How |
+|--------------|---------|-----|
+| Re-exported by | `@manifesto-ai/app` | App re-exports createApp, createTestApp, hooks |
+| Delegates to | `@manifesto-ai/runtime` | All orchestration via AppRuntime |
+| Depends on | `@manifesto-ai/core` | Schema types |
+| Depends on | `@manifesto-ai/world` | World types |
+
+---
+
+## When to Use SDK Directly
+
+**Most users should use `@manifesto-ai/app` during Phase 1.**
+
+Use SDK directly when:
+- Building custom integrations that need only the public API surface
+- Creating framework-specific wrappers (React, Vue, etc.)
+- After Phase 2 transition when SDK becomes the primary entry point
+
+---
+
+## Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [sdk-SPEC-v0.1.0.md](docs/sdk-SPEC-v0.1.0.md) | Complete specification |
+| [VERSION-INDEX.md](docs/VERSION-INDEX.md) | Version history and reading guide |
+| [ADR-007](../../docs/internals/adr/007-sdk-runtime-split-kickoff.md) | Split rationale |
+
+---
+
+## License
+
+[MIT](../../LICENSE)

--- a/packages/sdk/docs/VERSION-INDEX.md
+++ b/packages/sdk/docs/VERSION-INDEX.md
@@ -1,0 +1,43 @@
+# Manifesto SDK Documentation Index
+
+> **Package:** `@manifesto-ai/sdk`
+> **Last Updated:** 2026-02-15
+
+---
+
+## Latest Version
+
+- **SPEC:** [v0.1.0](sdk-SPEC-v0.1.0.md) (Draft — kickoff-locked baseline per ADR-007)
+
+**Note:** v0.1.0 is the initial SDK specification extracted from `@manifesto-ai/app` v2.3.0. Requirement IDs (`SDK-*`) are locked and cannot be renamed or removed. Additive clarification is allowed.
+
+---
+
+## All Versions
+
+| Version | SPEC | FDR | Type | Status |
+|---------|------|-----|------|--------|
+| v0.1.0 | [SPEC](sdk-SPEC-v0.1.0.md) | — | Full | Draft (kickoff-locked) |
+
+---
+
+## Reading Guide
+
+### For v0.1.0
+
+1. Read [sdk-SPEC-v0.1.0.md](sdk-SPEC-v0.1.0.md) (complete specification)
+2. For split rationale: [ADR-007](../../../docs/internals/adr/007-sdk-runtime-split-kickoff.md)
+3. For the App facade that re-exports SDK: [App VERSION-INDEX](../../app/docs/VERSION-INDEX.md)
+
+---
+
+## Relationship to App Package
+
+During **Phase 1 (Kickoff)**, `@manifesto-ai/app` remains the canonical entry point. SDK is an internal/preview package.
+
+| Phase | Entry Point | SDK Status |
+|-------|-------------|------------|
+| Phase 1 (current) | `@manifesto-ai/app` | Internal/Preview |
+| Phase 2 (transition) | `@manifesto-ai/sdk` | Public |
+
+See [ADR-007](../../../docs/internals/adr/007-sdk-runtime-split-kickoff.md) for the two-phase release strategy.


### PR DESCRIPTION
## Overview

This PR adds comprehensive documentation for the SDK and Runtime packages introduced in ADR-007, along with updated App package documentation reflecting the new architecture.

## Changes

### New Documentation
- **docs/api/sdk.md** - Public SDK API reference with `createApp()`, `ManifestoApp`, hooks, and `AppRef`
- **docs/api/runtime.md** - Internal Runtime orchestration engine documentation
- **packages/sdk/README.md** - SDK package overview and quick start
- **packages/sdk/docs/VERSION-INDEX.md** - SDK version history and reading guide
- **packages/runtime/README.md** - Runtime package overview and architecture
- **packages/runtime/docs/VERSION-INDEX.md** - Runtime version history and reading guide

### Updated Documentation
- **docs/.vitepress/config.ts** - Added SDK and Runtime API docs to sidebar; added ADR-005, ADR-006, ADR-007 to internals
- **docs/api/app.md** - Added package evolution section explaining App as facade over SDK/Runtime
- **packages/app/docs/MIGRATION-GUIDE.md** - Added v2.3.0 → v2.4.0 migration section (no breaking changes)
- **packages/app/docs/VERSION-INDEX.md** - Updated to reflect v2.4.0 facade status

## Architecture Summary

Implements ADR-007 (SDK/Runtime Split):
```
App (facade) → SDK (public API) → Runtime (orchestration) → Core/Host/World
```

**No breaking changes.** Existing imports from `@manifesto-ai/app` work identically.

## Related
- ADR-007: SDK/Runtime Split Kickoff
- All requirement IDs are kickoff-locked (stable specification baseline)