### PR TITLE
chore(release): sync app 2.5.0 and release-please tracking

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,9 +1,12 @@
 {
+  "packages/app": "2.5.0",
+  "packages/codegen": "0.1.0",
   "packages/compiler": "1.6.1",
-  "packages/app": "2.4.0",
   "packages/core": "2.4.0",
   "packages/intent-ir": "0.3.1",
   "packages/host": "2.3.1",
+  "packages/runtime": "0.1.0",
+  "packages/sdk": "0.1.0",
   "packages/translator/core": "0.2.1",
   "packages/world": "2.3.0",
   "skills": "0.1.1"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifesto-ai/app",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Manifesto App - Facade and orchestration layer over the Manifesto protocol stack",
   "author": "eggplantiny <eggplantiny@gmail.com>",
   "license": "MIT",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,6 +26,10 @@
       "package-name": "@manifesto-ai/app",
       "changelog-path": "CHANGELOG.md"
     },
+    "packages/codegen": {
+      "package-name": "@manifesto-ai/codegen",
+      "changelog-path": "CHANGELOG.md"
+    },
     "packages/compiler": {
       "package-name": "@manifesto-ai/compiler",
       "changelog-path": "CHANGELOG.md"
@@ -40,6 +44,14 @@
     },
     "packages/intent-ir": {
       "package-name": "@manifesto-ai/intent-ir",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/runtime": {
+      "package-name": "@manifesto-ai/runtime",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/sdk": {
+      "package-name": "@manifesto-ai/sdk",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/translator/core": {


### PR DESCRIPTION
## Summary
- sync `@manifesto-ai/app` package version to `2.5.0` after npm publish
- align release-please manifest with `app/codegen/runtime/sdk` published versions
- add `codegen/runtime/sdk` packages to release-please config tracking
- keep translator adapter/target packages excluded as requested

## Files
- `.release-please-manifest.json`
- `packages/app/package.json`
- `release-please-config.json`
