### PR TITLE
fix(ci): restore ci/release workflow parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Guard: no app imports
+      - name: Guard - no app imports
         run: pnpm check:no-app-imports
 
       - name: Build
@@ -73,7 +73,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Guard: no app imports
+      - name: Guard - no app imports
         run: pnpm check:no-app-imports
 
       - name: Type check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,14 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       backfill:
         description: Backfill tags/releases for merged release PRs
         required: false
-        type: boolean
-        default: false
+        default: "false"
 
 permissions:
   contents: write
@@ -35,7 +35,7 @@ jobs:
   backfill:
     name: Release Please (Backfill)
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.backfill == 'true' }}
     steps:
       - name: Release Please (github-release)
         uses: googleapis/release-please-action@v4
@@ -71,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Guard: no app imports
+      - name: Guard - no app imports
         run: pnpm check:no-app-imports
 
       - name: Build


### PR DESCRIPTION
## Summary\n- fix GitHub workflow parsing issue introduced by guard step naming\n- rename guard step labels to avoid parser ambiguity\n- normalize release workflow manual input handling for compatibility\n\n## Validation\n- pnpm check:no-app-imports\n- gh workflow run release.yml --ref codex/release-workflow-parser-fix -f backfill=false (workflow_dispatch recognized, run completes)