### PR TITLE
fix: remove unused compiler host peer

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -70,7 +70,6 @@
     "@anthropic-ai/sdk": "^0.26.0",
     "@manifesto-ai/codegen": "^0.1.0",
     "@manifesto-ai/core": "^2.0.0",
-    "@manifesto-ai/host": "^2.0.0",
     "openai": "^4.0.0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,9 +101,6 @@ importers:
 
   packages/compiler:
     dependencies:
-      '@manifesto-ai/host':
-        specifier: ^2.0.0
-        version: 2.0.1(@manifesto-ai/core@packages+core)
       ink:
         specifier: ^6.7.0
         version: 6.7.0(@types/react@19.2.14)(react@19.2.4)
@@ -847,11 +844,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@manifesto-ai/host@2.0.1':
-    resolution: {integrity: sha512-9icgBidREsXy4fDNSjpZ08DBBrThgSO2Lx5IKEWvi4TQG5Qw60Vw/10J5qcxxhDQXWH9Wlak18hZ3d9ti7mtzg==}
-    peerDependencies:
-      '@manifesto-ai/core': ^2.0.0
 
   '@mermaid-js/parser@1.0.0':
     resolution: {integrity: sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==}
@@ -3724,10 +3716,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@manifesto-ai/host@2.0.1(@manifesto-ai/core@packages+core)':
-    dependencies:
-      '@manifesto-ai/core': link:packages/core
 
   '@mermaid-js/parser@1.0.0':
     dependencies:


### PR DESCRIPTION
## Summary
- remove the unused `@manifesto-ai/host` peer from `@manifesto-ai/compiler`
- stop `pnpm` from auto-installing the published `@manifesto-ai/host@2.0.1` package into the compiler workspace
- keep compiler/core resolution on workspace links only instead of the mixed `compiler -> host(2.0.1) -> core(workspace)` graph

## Verification
- `pnpm why @manifesto-ai/host -r`
- `pnpm why @manifesto-ai/core -r`
- `pnpm test`

## Notes
- `@manifesto-ai/compiler` does not import `@manifesto-ai/host`, so the peer was only affecting dependency resolution and lockfile shape.