### PR TITLE
chore: include component in release-please PR titles

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "separate-pull-requests": true,
-  "pull-request-title-pattern": "chore: release ${version}",
+  "pull-request-title-pattern": "chore: release${component} ${version}",
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
## Summary

- include the release component in release-please PR titles
- keep the existing component-based tag/release naming intact

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issues

- None

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly

## Additional Notes

- This only changes `release-please-config.json` so release PRs become `chore: release <component> <version>` instead of omitting the package identifier.
- I validated the JSON after the edit; I did not run the full test suite for this config-only change.
