### PR TITLE
[codex] restore compiler release-please manifest entry

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "packages/codegen": "0.1.4",
+  "packages/compiler": "1.9.0",
   "packages/core": "2.8.0",
   "packages/host": "2.5.0",
   "packages/sdk": "2.3.0",


### PR DESCRIPTION
## Summary
- restore the missing `packages/compiler` entry in `.release-please-manifest.json`
- pin it to the current published compiler version `1.9.0`
- prevent release-please from regenerating bogus `compiler 1.0.0` release PRs

## Why
Concurrent release processing surfaced that the manifest no longer tracks compiler, so release-please falls back to an incorrect baseline and keeps opening stale `compiler 1.0.0` PRs.

## Validation
- parsed `.release-please-manifest.json` successfully with `node -e "JSON.parse(...)"`
- observed repeated stale compiler release PR regeneration before this fix
