### PR TITLE
fix: release split protocol packages

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,7 +2,9 @@
   "packages/codegen": "0.1.4",
   "packages/compiler": "1.9.0",
   "packages/core": "2.8.0",
+  "packages/governance": "0.1.0",
   "packages/host": "2.5.0",
+  "packages/lineage": "0.1.0",
   "packages/sdk": "2.3.0",
   "packages/world": "2.7.0",
   "skills": "0.2.2"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -77,8 +77,16 @@
       "package-name": "@manifesto-ai/core",
       "changelog-path": "CHANGELOG.md"
     },
+    "packages/governance": {
+      "package-name": "@manifesto-ai/governance",
+      "changelog-path": "CHANGELOG.md"
+    },
     "packages/host": {
       "package-name": "@manifesto-ai/host",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/lineage": {
+      "package-name": "@manifesto-ai/lineage",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/sdk": {


### PR DESCRIPTION
## Summary

Adds the split protocol packages to the release-please configuration and manifest.

## Why

`@manifesto-ai/world` is currently published with npm dependencies on:
- `@manifesto-ai/governance@0.1.0`
- `@manifesto-ai/lineage@0.1.0`

but those package paths were not included in the repo's release-please configuration, so the release pipeline was not tracking them for ongoing package releases.

## What changed

- added `packages/governance` to `release-please-config.json`
- added `packages/lineage` to `release-please-config.json`
- restored both package paths in `.release-please-manifest.json`

## Notes

I also manually triggered npm publish workflow runs for the current `0.1.0` versions to repair the already-broken published dependency graph:
- lineage publish run: `23774029330`
- governance publish run: `23774097314`

The GitHub workflow logs show both `npm publish` steps completed successfully. Registry visibility/installability may lag briefly while npm propagation catches up.
