### PR TITLE
build: group runtime stack releases

### DIFF
--- a/docs/guides/release-hardening.md
+++ b/docs/guides/release-hardening.md
@@ -4,6 +4,15 @@
 
 This guide defines the minimum checks required before publishing the current hard-cut runtime surface. It is not a historical report. It is the tracked release gate for the current line.
 
+## Release PR Model
+
+Release Please runs in workspace mode for this monorepo. Active runtime packages are not released as unrelated per-package PRs.
+
+- `@manifesto-ai/sdk`, `@manifesto-ai/lineage`, and `@manifesto-ai/governance` form the linked runtime stack.
+- Changes touching any package in that stack must be reviewed and merged as a single release train when Release Please proposes them together.
+- Internal workspace dependency updates are handled by the `node-workspace` and `linked-versions` plugins. Do not work around version skew in consumer apps with package-manager overrides unless you are diagnosing a broken publish.
+- Manual publish is for recovery only. Normal releases should flow through the grouped Release Please PR and the publish workflow.
+
 ## Release Gate
 
 Run these commands from the monorepo root:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,8 +5,29 @@
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": true,
   "include-v-in-tag": true,
-  "separate-pull-requests": true,
+  "always-link-local": true,
+  "group-pull-request-title-pattern": "chore: release linked packages",
   "pull-request-title-pattern": "chore: release${component} ${version}",
+  "plugins": [
+    {
+      "type": "node-workspace",
+      "merge": true,
+      "updatePeerDependencies": true
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "runtime stack",
+      "components": [
+        "@manifesto-ai/sdk",
+        "@manifesto-ai/lineage",
+        "@manifesto-ai/governance"
+      ],
+      "merge": true,
+      "specialWords": [
+        "SDK"
+      ]
+    }
+  ],
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
## Summary
- switch release-please from separate per-package PRs to grouped workspace releases
- link `@manifesto-ai/sdk`, `@manifesto-ai/lineage`, and `@manifesto-ai/governance` as a single runtime stack release train
- document the grouped runtime-stack release model in the release hardening guide

## Why
The runtime packages publish exact internal dependency versions, so independent release PRs can produce broken published graphs. Grouping the runtime stack avoids sibling version skew and removes the need to merge multiple release PRs one by one.

## Validation
- `jq . release-please-config.json`
- inspected `origin/main...HEAD` diff to confirm this PR contains only the grouped-release config/doc change
