### PR TITLE
feat: add canonical domain codegen plugin

### DIFF
--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -1,6 +1,6 @@
 # @manifesto-ai/codegen
 
-> **Codegen** generates TypeScript types and Zod schemas from a Manifesto DomainSchema through a deterministic plugin pipeline.
+> **Codegen** generates canonical domain facade types from a Manifesto DomainSchema through a deterministic plugin pipeline.
 
 ---
 
@@ -23,7 +23,8 @@ DomainSchema -> CODEGEN -> Generated Files
 
 | Responsibility | Description |
 |----------------|-------------|
-| Generate TypeScript types | DomainSchema types -> `export interface` / `export type` |
+| Generate canonical domain facades | DomainSchema -> `<domain>.mel.ts` with `state` / `computed` / `actions` |
+| Generate legacy TS/Zod artifacts | Optional low-level `types.ts` / `base.ts` output |
 | Generate Zod schemas | DomainSchema types -> Zod validators with type annotations |
 | Plugin pipeline | Run plugins sequentially with shared artifacts |
 | Path safety | Validate and normalize output file paths |
@@ -58,7 +59,7 @@ npm install @manifesto-ai/codegen
 ## Quick Example
 
 ```typescript
-import { generate, createTsPlugin, createZodPlugin } from "@manifesto-ai/codegen";
+import { generate, createDomainPlugin } from "@manifesto-ai/codegen";
 import type { DomainSchema } from "@manifesto-ai/core";
 
 const schema: DomainSchema = { /* your domain schema */ };
@@ -66,35 +67,35 @@ const schema: DomainSchema = { /* your domain schema */ };
 const result = await generate({
   schema,
   outDir: "./generated",
-  plugins: [createTsPlugin(), createZodPlugin()],
+  sourceId: "src/domain/hello.mel",
+  plugins: [createDomainPlugin()],
 });
 
-// result.files -> [{ path: "types.ts", content: "..." }, { path: "base.ts", content: "..." }]
+// result.files -> [{ path: "src/domain/hello.mel.ts", content: "..." }]
 // result.diagnostics -> [] (empty = no warnings or errors)
 ```
 
-This produces two files:
+This produces a canonical domain facade:
 
-**types.ts** -- TypeScript type definitions:
+**src/domain/hello.mel.ts**
 ```typescript
-export interface Todo {
-  completed: boolean;
-  id: string;
-  title: string;
+export interface HelloDomain {
+  readonly state: {
+    counter: number
+    hello: string
+  }
+  readonly computed: {
+    canDecrement: boolean
+    doubled: number
+  }
+  readonly actions: {
+    decrement: () => void
+    increment: () => void
+  }
 }
 ```
 
-**base.ts** -- Zod schemas with type annotations:
-```typescript
-import { z } from "zod";
-import type { Todo } from "./types";
-
-export const TodoSchema: z.ZodType<Todo> = z.object({
-  completed: z.boolean(),
-  id: z.string(),
-  title: z.string(),
-});
-```
+Legacy `createTsPlugin()` and `createZodPlugin()` remain available, but are deprecated in favor of `createDomainPlugin()`.
 
 > See [GUIDE.md](docs/GUIDE.md) for the full tutorial.
 
@@ -109,7 +110,10 @@ export const TodoSchema: z.ZodType<Todo> = z.object({
 function generate(options: GenerateOptions): Promise<GenerateResult>;
 
 // Built-in plugins
+function createDomainPlugin(options?: DomainPluginOptions): CodegenPlugin;
+/** @deprecated */
 function createTsPlugin(options?: TsPluginOptions): CodegenPlugin;
+/** @deprecated */
 function createZodPlugin(options?: ZodPluginOptions): CodegenPlugin;
 
 // Key types
@@ -141,7 +145,7 @@ type CodegenPlugin = {
 
 ### Plugin Pipeline
 
-Plugins run in array order. Each plugin receives a context containing the schema and artifacts from all previous plugins. The TS plugin publishes type names; the Zod plugin reads them to generate type-annotated schemas.
+Plugins run in array order. Each plugin receives a context containing the schema and artifacts from all previous plugins. The canonical domain plugin is self-contained; the legacy TS plugin publishes type names and the legacy Zod plugin reads them to generate type-annotated schemas.
 
 ### Artifacts
 
@@ -169,6 +173,7 @@ Same DomainSchema always produces byte-identical output files. Fields and types 
 ## When to Use Codegen
 
 Use Codegen when:
+- You want a canonical `<domain>.mel.ts` facade for `createManifesto<T>()`
 - You want type-safe TypeScript interfaces from your DomainSchema
 - You want Zod runtime validators that match your schema types
 - You need deterministic, reproducible code generation in CI

--- a/packages/codegen/docs/GUIDE.md
+++ b/packages/codegen/docs/GUIDE.md
@@ -31,7 +31,7 @@ pnpm add @manifesto-ai/core
 ### Minimal Example
 
 ```typescript
-import { generate, createTsPlugin, createZodPlugin } from "@manifesto-ai/codegen";
+import { generate, createDomainPlugin } from "@manifesto-ai/codegen";
 import type { DomainSchema } from "@manifesto-ai/core";
 
 // 1. Define a schema with one type
@@ -60,69 +60,56 @@ const schema: DomainSchema = {
 const result = await generate({
   schema,
   outDir: "./generated",
-  plugins: [createTsPlugin(), createZodPlugin()],
+  sourceId: "src/domain/hello.mel",
+  plugins: [createDomainPlugin()],
 });
 
 // 3. Check result
 console.log(result.diagnostics); // → [] (no errors)
-console.log(result.files.map(f => f.path)); // → ["types.ts", "base.ts"]
+console.log(result.files.map(f => f.path)); // → ["src/domain/hello.mel.ts"]
 ```
 
-Generated **types.ts**:
+Generated **src/domain/hello.mel.ts**:
 ```typescript
-export interface User {
-  id: string;
-  name: string;
+export interface ExampleDomain {
+  readonly state: {}
+  readonly computed: {}
+  readonly actions: {}
 }
-```
-
-Generated **base.ts**:
-```typescript
-import { z } from "zod";
-import type { User } from "./types";
-
-export const UserSchema: z.ZodType<User> = z.object({
-  id: z.string(),
-  name: z.string(),
-});
 ```
 
 ---
 
 ## Basic Usage
 
-### Use Case 1: TypeScript Types Only
+### Use Case 1: Canonical Domain Facade
 
-**Goal:** Generate only TypeScript type definitions.
+**Goal:** Generate the recommended `<domain>.mel.ts` shape for SDK consumers.
 
 ```typescript
-import { generate, createTsPlugin } from "@manifesto-ai/codegen";
+import { generate, createDomainPlugin } from "@manifesto-ai/codegen";
 
 const result = await generate({
   schema,
   outDir: "./generated",
-  plugins: [createTsPlugin()],
+  sourceId: "src/domain/todo.mel",
+  plugins: [createDomainPlugin()],
 });
 
-// Result: only types.ts is generated
-console.log(result.files.map(f => f.path)); // → ["types.ts"]
+// Result: only src/domain/todo.mel.ts is generated
+console.log(result.files.map(f => f.path)); // → ["src/domain/todo.mel.ts"]
 ```
 
-The TS plugin maps each TypeDefinition kind:
+The domain plugin emits one facade interface with:
+- `readonly state`
+- `readonly computed`
+- `readonly actions`
 
-| TypeDefinition | TypeScript Output |
-|----------------|-------------------|
-| `{ kind: "primitive", type: "string" }` | `string` |
-| `{ kind: "literal", value: "active" }` | `"active"` |
-| `{ kind: "array", element: ... }` | `T[]` |
-| `{ kind: "record", key: ..., value: ... }` | `Record<K, V>` |
-| `{ kind: "object", fields: ... }` | `export interface Name { ... }` |
-| `{ kind: "union", types: [...] }` | `T1 \| T2` |
-| `{ kind: "ref", name: "Other" }` | `Other` |
+Computed values are inferred from Core expression nodes when possible. Unsupported expressions degrade to `unknown` with a warning diagnostic.
 
-### Use Case 2: TypeScript + Zod Together
+### Use Case 2: Legacy TypeScript + Zod Together
 
-**Goal:** Generate Zod schemas that reference TypeScript types.
+**Goal:** Keep the old low-level artifact flow during migration.
 
 ```typescript
 import { generate, createTsPlugin, createZodPlugin } from "@manifesto-ai/codegen";
@@ -136,6 +123,8 @@ const result = await generate({
 // types.ts: TypeScript interfaces
 // base.ts: Zod schemas with z.ZodType<T> annotations
 ```
+
+`createTsPlugin()` and `createZodPlugin()` are deprecated. Prefer `createDomainPlugin()` for new integrations.
 
 When the Zod plugin runs after the TS plugin, it reads the TS plugin's artifacts to:
 - Add `z.ZodType<TypeName>` type annotations

--- a/packages/codegen/src/__tests__/domain-plugin.test.ts
+++ b/packages/codegen/src/__tests__/domain-plugin.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import type { CodegenContext } from "../types.js";
+import { stableHash } from "../stable-hash.js";
+import { createDomainPlugin } from "../plugins/domain-plugin.js";
+import { createTestSchema } from "./helpers/schema-factory.js";
+
+function makeCtx(overrides: Parameters<typeof createTestSchema>[0] = {}): CodegenContext {
+  return {
+    schema: createTestSchema(overrides),
+    sourceId: "src/domain/hello.mel",
+    outDir: "/tmp/out",
+    artifacts: {},
+    helpers: { stableHash },
+  };
+}
+
+describe("createDomainPlugin", () => {
+  it("generates a canonical domain facade next to the source MEL file", () => {
+    const plugin = createDomainPlugin();
+    const out = plugin.generate(
+      makeCtx({
+        meta: { name: "HelloDomain" },
+        state: {
+          fields: {
+            counter: { type: "number", required: true, default: 0 },
+            "$mel.hidden": { type: "string", required: true, default: "" },
+            profile: {
+              type: "object",
+              required: true,
+              fields: {
+                nickname: { type: "string", required: true },
+                tagline: { type: "string", required: false },
+              },
+            },
+          },
+        },
+        computed: {
+          fields: {
+            doubled: {
+              deps: ["counter"],
+              expr: {
+                kind: "mul",
+                left: { kind: "get", path: "counter" },
+                right: { kind: "lit", value: 2 },
+              },
+            },
+            canDecrement: {
+              deps: ["counter"],
+              expr: {
+                kind: "gt",
+                left: { kind: "get", path: "counter" },
+                right: { kind: "lit", value: 0 },
+              },
+            },
+            firstTag: {
+              deps: ["profile"],
+              expr: {
+                kind: "field",
+                object: {
+                  kind: "object",
+                  fields: {
+                    value: { kind: "get", path: "profile.tagline" },
+                  },
+                },
+                property: "value",
+              },
+            },
+          },
+        },
+        actions: {
+          decrement: {
+            flow: { kind: "seq", steps: [] },
+          },
+          rename: {
+            flow: { kind: "seq", steps: [] },
+            input: {
+              type: "object",
+              required: true,
+              fields: {
+                name: { type: "string", required: true },
+                force: { type: "boolean", required: false },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    expect(out.patches).toHaveLength(1);
+    expect(out.patches[0].path).toBe("src/domain/hello.mel.ts");
+    expect(out.patches[0].content).toContain("export interface HelloDomain {");
+    expect(out.patches[0].content).toContain("readonly state: {");
+    expect(out.patches[0].content).toContain("counter: number");
+    expect(out.patches[0].content).toContain("profile: { nickname: string; tagline?: string | null }");
+    expect(out.patches[0].content).not.toContain("$mel.hidden");
+    expect(out.patches[0].content).toContain("readonly computed: {");
+    expect(out.patches[0].content).toContain("doubled: number");
+    expect(out.patches[0].content).toContain("canDecrement: boolean");
+    expect(out.patches[0].content).toContain("firstTag: string | null");
+    expect(out.patches[0].content).toContain("readonly actions: {");
+    expect(out.patches[0].content).toContain("decrement: () => void");
+    expect(out.patches[0].content).toContain("rename: (name: string, force?: boolean | null) => void");
+  });
+
+  it("infers computed references and collection operators", () => {
+    const plugin = createDomainPlugin();
+    const out = plugin.generate(
+      makeCtx({
+        state: {
+          fields: {
+            items: {
+              type: "array",
+              required: true,
+              items: {
+                type: "object",
+                required: true,
+                fields: {
+                  id: { type: "string", required: true },
+                  count: { type: "number", required: true },
+                },
+              },
+            },
+          },
+        },
+        computed: {
+          fields: {
+            firstItem: {
+              deps: ["items"],
+              expr: { kind: "first", array: { kind: "get", path: "items" } },
+            },
+            firstItemCount: {
+              deps: ["firstItem"],
+              expr: { kind: "get", path: "firstItem.count" },
+            },
+            itemIds: {
+              deps: ["items"],
+              expr: {
+                kind: "map",
+                array: { kind: "get", path: "items" },
+                mapper: { kind: "get", path: "$item.id" },
+              },
+            },
+            foundItem: {
+              deps: ["items"],
+              expr: {
+                kind: "find",
+                array: { kind: "get", path: "items" },
+                predicate: {
+                  kind: "gt",
+                  left: { kind: "get", path: "$item.count" },
+                  right: { kind: "lit", value: 0 },
+                },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    expect(out.patches[0].content).toContain("firstItem: { count: number; id: string } | null");
+    expect(out.patches[0].content).toContain("firstItemCount: number");
+    expect(out.patches[0].content).toContain("itemIds: string[]");
+    expect(out.patches[0].content).toContain("foundItem: { count: number; id: string } | null");
+  });
+
+  it("falls back to unknown with a warning for unsupported expressions", () => {
+    const plugin = createDomainPlugin();
+    const out = plugin.generate(
+      makeCtx({
+        computed: {
+          fields: {
+            futureThing: {
+              deps: [],
+              expr: { kind: "future" as never },
+            },
+          },
+        },
+      })
+    );
+
+    expect(out.patches[0].content).toContain("futureThing: unknown");
+    expect(out.diagnostics?.some((diag) => diag.level === "warn")).toBe(true);
+  });
+});

--- a/packages/codegen/src/__tests__/runner.test.ts
+++ b/packages/codegen/src/__tests__/runner.test.ts
@@ -100,6 +100,35 @@ describe("generate()", () => {
     });
   });
 
+  describe("output flushing", () => {
+    it("does not clean outDir by default", async () => {
+      const fs = await import("node:fs/promises");
+      const p = createMockPlugin("ok", {
+        patches: [{ op: "set", path: "a.ts", content: "x" }],
+      });
+
+      await generate({ schema, outDir: "/tmp/out", plugins: [p] });
+      expect(fs.rm).not.toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalled();
+    });
+
+    it("cleans outDir when explicitly requested", async () => {
+      const fs = await import("node:fs/promises");
+      const p = createMockPlugin("ok", {
+        patches: [{ op: "set", path: "a.ts", content: "x" }],
+      });
+
+      await generate({
+        schema,
+        outDir: "/tmp/out",
+        plugins: [p],
+        cleanOutDir: true,
+      });
+
+      expect(fs.rm).toHaveBeenCalledWith("/tmp/out", { recursive: true, force: true });
+    });
+  });
+
   describe("path validation", () => {
     it("errors on invalid paths", async () => {
       const p = createMockPlugin("p", {

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -20,8 +20,17 @@ export type {
 export { generate } from "./runner.js";
 
 // Plugins
-export { createTsPlugin, createZodPlugin } from "./plugins/index.js";
-export type { TsPluginOptions, TsPluginArtifacts, ZodPluginOptions } from "./plugins/index.js";
+export {
+  createDomainPlugin,
+  createTsPlugin,
+  createZodPlugin,
+} from "./plugins/index.js";
+export type {
+  DomainPluginOptions,
+  TsPluginOptions,
+  TsPluginArtifacts,
+  ZodPluginOptions,
+} from "./plugins/index.js";
 
 // Utilities (for custom plugin authors)
 export { validatePath } from "./path-safety.js";

--- a/packages/codegen/src/plugins/domain-plugin.ts
+++ b/packages/codegen/src/plugins/domain-plugin.ts
@@ -1,0 +1,163 @@
+import type { CodegenContext, CodegenOutput, CodegenPlugin, Diagnostic } from "../types.js";
+import type { FieldSpec } from "@manifesto-ai/core";
+import { createInferenceContext, inferComputedType } from "./domain-type-inference.js";
+import {
+  fieldSpecToDomainField,
+  fieldSpecToDomainType,
+  renderDomainType,
+  type DomainTypeField,
+} from "./domain-type-model.js";
+
+const PLUGIN_NAME = "codegen-plugin-domain";
+
+export interface DomainPluginOptions {
+  readonly fileName?: string;
+  readonly interfaceName?: string;
+  readonly includeReservedState?: boolean;
+}
+
+export function createDomainPlugin(options?: DomainPluginOptions): CodegenPlugin {
+  return {
+    name: PLUGIN_NAME,
+    generate(ctx: CodegenContext): CodegenOutput {
+      const diagnostics: Diagnostic[] = [];
+      const inference = createInferenceContext(ctx.schema, diagnostics, PLUGIN_NAME);
+
+      const interfaceName = options?.interfaceName
+        ?? deriveInterfaceName(ctx)
+        ?? "Domain";
+      const fileName = options?.fileName ?? deriveFileName(ctx.sourceId);
+
+      const stateFields = renderFieldBlock(
+        ctx.schema.state.fields,
+        { includeReservedState: options?.includeReservedState ?? false },
+        (_name, spec) => fieldSpecToDomainField(spec)
+      );
+
+      const computedFields = renderFieldBlock(
+        ctx.schema.computed.fields,
+        { includeReservedState: true },
+        (name) => ({
+          type: inferComputedType(name, inference),
+          optional: false,
+        })
+      );
+
+      const actionNames = Object.keys(ctx.schema.actions).sort();
+      const actionLines = actionNames.map((name) => {
+        const action = ctx.schema.actions[name];
+        return `    ${name}: ${renderActionSignature(action.input)}`;
+      });
+
+      const sections = [
+        "export interface " + interfaceName + " {",
+        "  readonly state: {",
+        stateFields,
+        "  }",
+        "  readonly computed: {",
+        computedFields,
+        "  }",
+        "  readonly actions: {",
+        actionLines.join("\n"),
+        "  }",
+        "}",
+      ];
+
+      return {
+        patches: [{ op: "set", path: fileName, content: sections.join("\n") + "\n" }],
+        diagnostics,
+      };
+    },
+  };
+}
+
+function renderFieldBlock<T>(
+  source: Record<string, T>,
+  options: { includeReservedState: boolean },
+  mapField: (name: string, value: T) => DomainTypeField
+): string {
+  const names = Object.keys(source)
+    .filter((name) => options.includeReservedState || !name.startsWith("$"))
+    .sort();
+
+  if (names.length === 0) {
+    return "";
+  }
+
+  return names
+    .map((name) => {
+      const field = mapField(name, source[name]);
+      const optional = field.optional ? "?" : "";
+      return `    ${name}${optional}: ${renderDomainType(field.type)}`;
+    })
+    .join("\n");
+}
+
+function renderActionSignature(input: FieldSpec | undefined): string {
+  if (!input || typeof input !== "object" || !("type" in input)) {
+    return "() => void";
+  }
+
+  if (input.type !== "object" || !input.fields) {
+    return `(input: ${renderDomainType(fieldSpecToDomainType(input))}) => void`;
+  }
+
+  const names = Object.keys(input.fields);
+  if (names.length === 0) {
+    return "() => void";
+  }
+
+  const params = names.map((name) => {
+    const field = fieldSpecToDomainField(input.fields![name]);
+    const optional = field.optional ? "?" : "";
+    return `${name}${optional}: ${renderDomainType(field.type)}`;
+  });
+
+  return `(${params.join(", ")}) => void`;
+}
+
+function deriveInterfaceName(ctx: CodegenContext): string | null {
+  const metaName = ctx.schema.meta?.name?.trim();
+  if (metaName) {
+    return metaName;
+  }
+
+  const basename = basenameWithoutExtension(ctx.sourceId);
+  if (!basename) {
+    return null;
+  }
+
+  const candidate = pascalCase(basename);
+  return candidate.endsWith("Domain") ? candidate : `${candidate}Domain`;
+}
+
+function deriveFileName(sourceId?: string): string {
+  if (!sourceId) {
+    return "domain.ts";
+  }
+
+  const normalized = sourceId.replace(/\\/g, "/");
+  return `${normalized}.ts`;
+}
+
+function basenameWithoutExtension(sourceId?: string): string | null {
+  if (!sourceId) {
+    return null;
+  }
+
+  const normalized = sourceId.replace(/\\/g, "/");
+  const basename = normalized.split("/").pop() ?? "";
+  if (!basename) {
+    return null;
+  }
+
+  return basename.replace(/\.[^.]+$/, "");
+}
+
+function pascalCase(value: string): string {
+  return value
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join("");
+}

--- a/packages/codegen/src/plugins/domain-type-inference.ts
+++ b/packages/codegen/src/plugins/domain-type-inference.ts
@@ -1,0 +1,593 @@
+import type { DomainSchema, ExprNode } from "@manifesto-ai/core";
+import type { Diagnostic } from "../types.js";
+import {
+  arrayType,
+  fieldSpecToDomainType,
+  literalValueToType,
+  objectType,
+  primitiveType,
+  recordType,
+  removeNullType,
+  tupleType,
+  type DomainType,
+  type DomainTypeField,
+  unionOf,
+  unknownType,
+} from "./domain-type-model.js";
+
+type InferenceEnv = ReadonlyMap<string, DomainType>;
+
+type InferenceContext = {
+  readonly schema: DomainSchema;
+  readonly pluginName: string;
+  readonly diagnostics: Diagnostic[];
+  readonly warnedMessages: Set<string>;
+  readonly computedCache: Map<string, DomainType>;
+  readonly computedInFlight: Set<string>;
+};
+
+const META_TYPE = objectType({
+  actionName: { type: primitiveType("string"), optional: false },
+  intentId: { type: primitiveType("string"), optional: false },
+  timestamp: { type: primitiveType("number"), optional: false },
+});
+
+export function createInferenceContext(
+  schema: DomainSchema,
+  diagnostics: Diagnostic[],
+  pluginName: string
+): InferenceContext {
+  return {
+    schema,
+    pluginName,
+    diagnostics,
+    warnedMessages: new Set(),
+    computedCache: new Map(),
+    computedInFlight: new Set(),
+  };
+}
+
+export function inferComputedType(
+  name: string,
+  ctx: InferenceContext
+): DomainType {
+  if (ctx.computedCache.has(name)) {
+    return ctx.computedCache.get(name) ?? unknownType();
+  }
+
+  const spec = ctx.schema.computed.fields[name];
+  if (!spec) {
+    warn(ctx, `Unknown computed field "${name}". Emitting "unknown".`);
+    return unknownType();
+  }
+
+  if (ctx.computedInFlight.has(name)) {
+    warn(ctx, `Recursive computed field "${name}" could not be inferred. Emitting "unknown".`);
+    return unknownType();
+  }
+
+  ctx.computedInFlight.add(name);
+  const inferred = inferExprType(spec.expr, ctx, new Map());
+  ctx.computedInFlight.delete(name);
+  ctx.computedCache.set(name, inferred);
+  return inferred;
+}
+
+export function inferExprType(
+  expr: ExprNode,
+  ctx: InferenceContext,
+  env: InferenceEnv = new Map()
+): DomainType {
+  switch (expr.kind) {
+    case "lit":
+      return literalValueToType(expr.value);
+
+    case "get":
+      return inferPathType(expr.path, ctx, env);
+
+    case "eq":
+    case "neq":
+    case "gt":
+    case "gte":
+    case "lt":
+    case "lte":
+    case "and":
+    case "or":
+    case "not":
+    case "startsWith":
+    case "endsWith":
+    case "strIncludes":
+    case "includes":
+    case "every":
+    case "some":
+    case "hasKey":
+    case "isNull":
+    case "toBoolean":
+      return primitiveType("boolean");
+
+    case "add":
+    case "sub":
+    case "mul":
+    case "div":
+    case "mod":
+    case "min":
+    case "max":
+    case "abs":
+    case "neg":
+    case "floor":
+    case "ceil":
+    case "round":
+    case "sqrt":
+    case "pow":
+    case "sumArray":
+    case "strLen":
+    case "len":
+    case "indexOf":
+    case "toNumber":
+      return primitiveType("number");
+
+    case "concat":
+    case "substring":
+    case "trim":
+    case "toLowerCase":
+    case "toUpperCase":
+    case "replace":
+    case "typeof":
+    case "toString":
+      return primitiveType("string");
+
+    case "if":
+      return unionOf([
+        inferExprType(expr.then, ctx, env),
+        inferExprType(expr.else, ctx, env),
+      ]);
+
+    case "split":
+      return arrayType(primitiveType("string"));
+
+    case "at":
+      return unionOf([inferIndexedAccessType(expr.array, ctx, env), primitiveType("null")]);
+
+    case "first":
+    case "last":
+    case "minArray":
+    case "maxArray":
+      return unionOf([inferCollectionElementType(expr.array, ctx, env), primitiveType("null")]);
+
+    case "slice":
+    case "reverse":
+    case "unique":
+      return inferArrayLikeType(expr.array, ctx, env);
+
+    case "filter": {
+      const elementType = inferCollectionElementType(expr.array, ctx, env);
+      const nextEnv = withCollectionEnv(env, elementType);
+      inferExprType(expr.predicate, ctx, nextEnv);
+      return arrayType(elementType);
+    }
+
+    case "map": {
+      const elementType = inferCollectionElementType(expr.array, ctx, env);
+      const nextEnv = withCollectionEnv(env, elementType);
+      return arrayType(inferExprType(expr.mapper, ctx, nextEnv));
+    }
+
+    case "find": {
+      const elementType = inferCollectionElementType(expr.array, ctx, env);
+      const nextEnv = withCollectionEnv(env, elementType);
+      inferExprType(expr.predicate, ctx, nextEnv);
+      return unionOf([elementType, primitiveType("null")]);
+    }
+
+    case "append": {
+      const baseArray = inferArrayLikeType(expr.array, ctx, env);
+      const baseElement = getArrayElementType(baseArray);
+      const itemTypes = expr.items.map((item) => inferExprType(item, ctx, env));
+      return arrayType(unionOf([baseElement, ...itemTypes]));
+    }
+
+    case "flat":
+      return inferFlatType(expr.array, ctx, env);
+
+    case "object": {
+      const fields: Record<string, DomainTypeField> = {};
+      for (const name of Object.keys(expr.fields)) {
+        fields[name] = {
+          type: inferExprType(expr.fields[name], ctx, env),
+          optional: false,
+        };
+      }
+      return objectType(fields);
+    }
+
+    case "field":
+      return inferFieldType(inferExprType(expr.object, ctx, env), expr.property);
+
+    case "keys":
+      return arrayType(primitiveType("string"));
+
+    case "values":
+      return arrayType(inferObjectValueType(inferExprType(expr.obj, ctx, env)));
+
+    case "entries":
+      return arrayType(
+        tupleType([
+          primitiveType("string"),
+          inferObjectValueType(inferExprType(expr.obj, ctx, env)),
+        ])
+      );
+
+    case "merge":
+      return inferMergeType(
+        expr.objects.map((objectExpr) => inferExprType(objectExpr, ctx, env))
+      );
+
+    case "pick":
+      return inferPickLikeType(expr.obj, expr.keys, false, ctx, env);
+
+    case "omit":
+      return inferPickLikeType(expr.obj, expr.keys, true, ctx, env);
+
+    case "fromEntries":
+      return inferFromEntriesType(expr.entries, ctx, env);
+
+    case "coalesce": {
+      const members = expr.args.flatMap((arg) =>
+        removeNullType(inferExprType(arg, ctx, env))
+      );
+      return members.length === 0 ? primitiveType("null") : unionOf(members);
+    }
+
+    default:
+      warn(ctx, `Unsupported expression kind "${(expr as { kind: string }).kind}". Emitting "unknown".`);
+      return unknownType();
+  }
+}
+
+function inferPathType(
+  path: string,
+  ctx: InferenceContext,
+  env: InferenceEnv
+): DomainType {
+  const [head, ...tail] = path.split(".");
+  if (!head) {
+    warn(ctx, `Empty get() path encountered. Emitting "unknown".`);
+    return unknownType();
+  }
+
+  let base: DomainType | undefined = env.get(head);
+
+  if (!base) {
+    if (head === "meta") {
+      base = META_TYPE;
+    } else if (Object.hasOwn(ctx.schema.state.fields, head)) {
+      base = fieldSpecToDomainType(ctx.schema.state.fields[head]);
+    } else if (Object.hasOwn(ctx.schema.computed.fields, head)) {
+      base = inferComputedType(head, ctx);
+    }
+  }
+
+  if (!base) {
+    warn(ctx, `Unknown get() path "${path}". Emitting "unknown".`);
+    return unknownType();
+  }
+
+  return walkPathType(base, tail);
+}
+
+function walkPathType(base: DomainType, segments: readonly string[]): DomainType {
+  let current = base;
+  for (const segment of segments) {
+    current = accessSegmentType(current, segment);
+  }
+  return current;
+}
+
+function accessSegmentType(
+  base: DomainType,
+  segment: string
+): DomainType {
+  switch (base.kind) {
+    case "object":
+      return Object.hasOwn(base.fields, segment)
+        ? base.fields[segment].type
+        : unknownType();
+    case "record":
+      return unionOf([base.value, primitiveType("null")]);
+    case "array":
+      return isNumericSegment(segment)
+        ? unionOf([base.element, primitiveType("null")])
+        : unknownType();
+    case "tuple":
+      return isNumericSegment(segment)
+        ? base.elements[Number(segment)] ?? unknownType()
+        : unknownType();
+    case "union":
+      return unionIgnoringUnknown(
+        base.types.map((member) => accessSegmentType(member, segment))
+      );
+    default:
+      return unknownType();
+  }
+}
+
+function inferIndexedAccessType(
+  expr: ExprNode,
+  ctx: InferenceContext,
+  env: InferenceEnv
+): DomainType {
+  const base = inferExprType(expr, ctx, env);
+  switch (base.kind) {
+    case "array":
+      return base.element;
+    case "tuple":
+      return unionOf(base.elements);
+    case "record":
+      return base.value;
+    case "union":
+      return unionOf(base.types.map((member) => inferIndexedAccessFromType(member)));
+    default:
+      return unknownType();
+  }
+}
+
+function inferIndexedAccessFromType(type: DomainType): DomainType {
+  switch (type.kind) {
+    case "array":
+      return type.element;
+    case "tuple":
+      return unionOf(type.elements);
+    case "record":
+      return type.value;
+    default:
+      return unknownType();
+  }
+}
+
+function inferCollectionElementType(
+  expr: ExprNode,
+  ctx: InferenceContext,
+  env: InferenceEnv
+): DomainType {
+  return getArrayElementType(inferExprType(expr, ctx, env));
+}
+
+function getArrayElementType(type: DomainType): DomainType {
+  switch (type.kind) {
+    case "array":
+      return type.element;
+    case "tuple":
+      return unionOf(type.elements);
+    case "union":
+      return unionOf(type.types.map((member) => getArrayElementType(member)));
+    default:
+      return unknownType();
+  }
+}
+
+function inferArrayLikeType(
+  expr: ExprNode,
+  ctx: InferenceContext,
+  env: InferenceEnv
+): DomainType {
+  const inferred = inferExprType(expr, ctx, env);
+  switch (inferred.kind) {
+    case "array":
+      return inferred;
+    case "tuple":
+      return arrayType(unionOf(inferred.elements));
+    case "union": {
+      const arrays = inferred.types
+        .map((member) => inferArrayLikeFromType(member))
+        .filter((member): member is DomainType => member.kind !== "unknown");
+      return arrays.length === 0 ? arrayType(unknownType()) : unionOf(arrays);
+    }
+    default:
+      return arrayType(unknownType());
+  }
+}
+
+function inferArrayLikeFromType(type: DomainType): DomainType {
+  switch (type.kind) {
+    case "array":
+      return type;
+    case "tuple":
+      return arrayType(unionOf(type.elements));
+    default:
+      return unknownType();
+  }
+}
+
+function inferFlatType(
+  expr: ExprNode,
+  ctx: InferenceContext,
+  env: InferenceEnv
+): DomainType {
+  const outer = inferArrayLikeType(expr, ctx, env);
+  const outerElement = getArrayElementType(outer);
+
+  switch (outerElement.kind) {
+    case "array":
+      return arrayType(outerElement.element);
+    case "tuple":
+      return arrayType(unionOf(outerElement.elements));
+    case "union": {
+      const flatMembers: DomainType[] = [];
+      for (const member of outerElement.types) {
+        if (member.kind === "array") {
+          flatMembers.push(member.element);
+          continue;
+        }
+        if (member.kind === "tuple") {
+          flatMembers.push(unionOf(member.elements));
+          continue;
+        }
+        flatMembers.push(member);
+      }
+      return arrayType(unionOf(flatMembers));
+    }
+    default:
+      return arrayType(outerElement);
+  }
+}
+
+function inferFieldType(base: DomainType, property: string): DomainType {
+  switch (base.kind) {
+    case "object":
+      return Object.hasOwn(base.fields, property)
+        ? base.fields[property].type
+        : primitiveType("null");
+    case "record":
+      return unionOf([base.value, primitiveType("null")]);
+    case "union":
+      return unionOf(base.types.map((member) => inferFieldType(member, property)));
+    default:
+      return primitiveType("null");
+  }
+}
+
+function inferObjectValueType(type: DomainType): DomainType {
+  switch (type.kind) {
+    case "object": {
+      const values = Object.keys(type.fields).map((name) => type.fields[name].type);
+      return values.length === 0 ? unknownType() : unionOf(values);
+    }
+    case "record":
+      return type.value;
+    case "union":
+      return unionOf(type.types.map((member) => inferObjectValueType(member)));
+    default:
+      return unknownType();
+  }
+}
+
+function inferMergeType(types: readonly DomainType[]): DomainType {
+  const fields: Record<string, DomainTypeField> = {};
+  let sawObject = false;
+
+  for (const type of types) {
+    if (type.kind !== "object") {
+      continue;
+    }
+    sawObject = true;
+    for (const name of Object.keys(type.fields)) {
+      fields[name] = type.fields[name];
+    }
+  }
+
+  return sawObject ? objectType(fields) : objectType({});
+}
+
+function inferPickLikeType(
+  objectExpr: ExprNode,
+  keysExpr: ExprNode,
+  omit: boolean,
+  ctx: InferenceContext,
+  env: InferenceEnv
+): DomainType {
+  const base = inferExprType(objectExpr, ctx, env);
+  if (base.kind !== "object") {
+    return objectType({});
+  }
+
+  const keys = readStringArrayLiteral(keysExpr);
+  if (!keys) {
+    return base;
+  }
+
+  const selected = new Set(keys);
+  const fields: Record<string, DomainTypeField> = {};
+
+  for (const name of Object.keys(base.fields)) {
+    const shouldInclude = omit ? !selected.has(name) : selected.has(name);
+    if (shouldInclude) {
+      fields[name] = base.fields[name];
+    }
+  }
+
+  return objectType(fields);
+}
+
+function inferFromEntriesType(
+  entriesExpr: ExprNode,
+  ctx: InferenceContext,
+  env: InferenceEnv
+): DomainType {
+  const literalEntries = readLiteralEntries(entriesExpr);
+  if (literalEntries) {
+    const valueTypes = literalEntries.map(([, value]) => literalValueToType(value));
+    return recordType(primitiveType("string"), unionOf(valueTypes));
+  }
+
+  const entriesType = inferExprType(entriesExpr, ctx, env);
+  const elementType = getArrayElementType(entriesType);
+
+  if (elementType.kind === "tuple" && elementType.elements.length >= 2) {
+    return recordType(primitiveType("string"), elementType.elements[1]);
+  }
+
+  return recordType(primitiveType("string"), unknownType());
+}
+
+function withCollectionEnv(
+  env: InferenceEnv,
+  itemType: DomainType
+): Map<string, DomainType> {
+  const next = new Map(env);
+  next.set("$index", primitiveType("number"));
+  next.set("$item", itemType);
+  return next;
+}
+
+function readStringArrayLiteral(expr: ExprNode): string[] | null {
+  if (expr.kind !== "lit" || !Array.isArray(expr.value)) {
+    return null;
+  }
+
+  const values: string[] = [];
+  for (const item of expr.value) {
+    if (typeof item !== "string") {
+      return null;
+    }
+    values.push(item);
+  }
+  return values;
+}
+
+function readLiteralEntries(
+  expr: ExprNode
+): Array<[string, unknown]> | null {
+  if (expr.kind !== "lit" || !Array.isArray(expr.value)) {
+    return null;
+  }
+
+  const entries: Array<[string, unknown]> = [];
+  for (const item of expr.value) {
+    if (!Array.isArray(item) || item.length !== 2 || typeof item[0] !== "string") {
+      return null;
+    }
+    entries.push([item[0], item[1]]);
+  }
+  return entries;
+}
+
+function unionIgnoringUnknown(types: readonly DomainType[]): DomainType {
+  const filtered = types.filter((type) => type.kind !== "unknown");
+  return filtered.length === 0 ? unknownType() : unionOf(filtered);
+}
+
+function isNumericSegment(segment: string): boolean {
+  return /^\d+$/.test(segment);
+}
+
+function warn(ctx: InferenceContext, message: string): void {
+  if (ctx.warnedMessages.has(message)) {
+    return;
+  }
+  ctx.warnedMessages.add(message);
+  ctx.diagnostics.push({
+    level: "warn",
+    plugin: ctx.pluginName,
+    message,
+  });
+}

--- a/packages/codegen/src/plugins/domain-type-model.ts
+++ b/packages/codegen/src/plugins/domain-type-model.ts
@@ -1,0 +1,259 @@
+import type { FieldSpec } from "@manifesto-ai/core";
+
+export type DomainPrimitive = "string" | "number" | "boolean" | "null";
+
+export type DomainTypeField = {
+  readonly type: DomainType;
+  readonly optional: boolean;
+};
+
+export type DomainType =
+  | { readonly kind: "unknown" }
+  | { readonly kind: "primitive"; readonly type: DomainPrimitive }
+  | { readonly kind: "literal"; readonly value: string | number | boolean | null }
+  | { readonly kind: "array"; readonly element: DomainType }
+  | { readonly kind: "tuple"; readonly elements: readonly DomainType[] }
+  | { readonly kind: "object"; readonly fields: Readonly<Record<string, DomainTypeField>> }
+  | { readonly kind: "record"; readonly key: DomainType; readonly value: DomainType }
+  | { readonly kind: "union"; readonly types: readonly DomainType[] };
+
+const UNKNOWN_TYPE: DomainType = { kind: "unknown" };
+const NULL_TYPE: DomainType = { kind: "primitive", type: "null" };
+
+export function unknownType(): DomainType {
+  return UNKNOWN_TYPE;
+}
+
+export function primitiveType(type: DomainPrimitive): DomainType {
+  return type === "null" ? NULL_TYPE : { kind: "primitive", type };
+}
+
+export function literalType(
+  value: string | number | boolean | null
+): DomainType {
+  return value === null ? NULL_TYPE : { kind: "literal", value };
+}
+
+export function arrayType(element: DomainType): DomainType {
+  return { kind: "array", element };
+}
+
+export function tupleType(elements: readonly DomainType[]): DomainType {
+  return { kind: "tuple", elements };
+}
+
+export function objectType(fields: Record<string, DomainTypeField>): DomainType {
+  return { kind: "object", fields };
+}
+
+export function recordType(key: DomainType, value: DomainType): DomainType {
+  return { kind: "record", key, value };
+}
+
+export function fieldSpecToDomainField(spec: FieldSpec): DomainTypeField {
+  return {
+    type: fieldSpecToDomainType(spec),
+    optional: !spec.required,
+  };
+}
+
+export function fieldSpecToDomainType(spec: FieldSpec): DomainType {
+  let base: DomainType;
+
+  if (typeof spec.type === "object" && "enum" in spec.type) {
+    base = unionOf(
+      spec.type.enum.map((value) => literalValueToType(value))
+    );
+  } else {
+    switch (spec.type) {
+      case "string":
+        base = primitiveType("string");
+        break;
+      case "number":
+        base = primitiveType("number");
+        break;
+      case "boolean":
+        base = primitiveType("boolean");
+        break;
+      case "null":
+        base = NULL_TYPE;
+        break;
+      case "object":
+        if (spec.fields) {
+          const fields: Record<string, DomainTypeField> = {};
+          for (const name of Object.keys(spec.fields)) {
+            fields[name] = fieldSpecToDomainField(spec.fields[name]);
+          }
+          base = objectType(fields);
+          break;
+        }
+        base = recordType(primitiveType("string"), unknownType());
+        break;
+      case "array":
+        base = arrayType(
+          spec.items ? fieldSpecToDomainType(spec.items) : unknownType()
+        );
+        break;
+      default:
+        base = unknownType();
+        break;
+    }
+  }
+
+  return spec.required ? base : unionOf([base, NULL_TYPE]);
+}
+
+export function literalValueToType(value: unknown): DomainType {
+  if (value === null) {
+    return NULL_TYPE;
+  }
+
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return literalType(value);
+  }
+
+  if (Array.isArray(value)) {
+    return arrayType(
+      value.length === 0
+        ? unknownType()
+        : unionOf(value.map((item) => literalValueToType(item)))
+    );
+  }
+
+  if (isPlainObject(value)) {
+    const fields: Record<string, DomainTypeField> = {};
+    for (const name of Object.keys(value)) {
+      fields[name] = {
+        type: literalValueToType(value[name]),
+        optional: false,
+      };
+    }
+    return objectType(fields);
+  }
+
+  return unknownType();
+}
+
+export function unionOf(types: readonly DomainType[]): DomainType {
+  const flattened: DomainType[] = [];
+
+  for (const type of types) {
+    if (type.kind === "unknown") {
+      return type;
+    }
+    if (type.kind === "union") {
+      flattened.push(...type.types);
+      continue;
+    }
+    flattened.push(type);
+  }
+
+  const unique = new Map<string, DomainType>();
+  for (const type of flattened) {
+    unique.set(stableTypeKey(type), type);
+  }
+
+  const deduped = Array.from(unique.values());
+  if (deduped.length === 0) {
+    return unknownType();
+  }
+  if (deduped.length === 1) {
+    return deduped[0];
+  }
+  return { kind: "union", types: deduped };
+}
+
+export function removeNullType(type: DomainType): DomainType[] {
+  switch (type.kind) {
+    case "primitive":
+      return type.type === "null" ? [] : [type];
+    case "literal":
+      return type.value === null ? [] : [type];
+    case "union":
+      return type.types.flatMap((member) => removeNullType(member));
+    default:
+      return [type];
+  }
+}
+
+export function renderDomainType(type: DomainType): string {
+  switch (type.kind) {
+    case "unknown":
+      return "unknown";
+    case "primitive":
+      return type.type;
+    case "literal":
+      return renderLiteral(type.value);
+    case "array":
+      return `${wrapArrayElement(renderDomainType(type.element), type.element)}[]`;
+    case "tuple":
+      return `[${type.elements.map((element) => renderDomainType(element)).join(", ")}]`;
+    case "object": {
+      const fieldNames = Object.keys(type.fields).sort();
+      if (fieldNames.length === 0) {
+        return "{}";
+      }
+      const parts = fieldNames.map((name) => {
+        const field = type.fields[name];
+        const optional = field.optional ? "?" : "";
+        return `${name}${optional}: ${renderDomainType(field.type)}`;
+      });
+      return `{ ${parts.join("; ")} }`;
+    }
+    case "record":
+      return `Record<${renderDomainType(type.key)}, ${renderDomainType(type.value)}>`;
+    case "union":
+      return type.types.map((member) => renderDomainType(member)).join(" | ");
+  }
+}
+
+function wrapArrayElement(rendered: string, type: DomainType): string {
+  if (type.kind === "union") {
+    return `(${rendered})`;
+  }
+  return rendered;
+}
+
+function renderLiteral(value: string | number | boolean | null): string {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function stableTypeKey(type: DomainType): string {
+  switch (type.kind) {
+    case "unknown":
+      return "unknown";
+    case "primitive":
+      return `primitive:${type.type}`;
+    case "literal":
+      return `literal:${JSON.stringify(type.value)}`;
+    case "array":
+      return `array:${stableTypeKey(type.element)}`;
+    case "tuple":
+      return `tuple:${type.elements.map((element) => stableTypeKey(element)).join(",")}`;
+    case "object": {
+      const keys = Object.keys(type.fields).sort();
+      const fields = keys.map((name) => {
+        const field = type.fields[name];
+        return `${name}:${field.optional ? "?" : ""}${stableTypeKey(field.type)}`;
+      });
+      return `object:${fields.join(",")}`;
+    }
+    case "record":
+      return `record:${stableTypeKey(type.key)}:${stableTypeKey(type.value)}`;
+    case "union":
+      return `union:${type.types.map((member) => stableTypeKey(member)).sort().join("|")}`;
+  }
+}
+
+function isPlainObject(
+  value: unknown
+): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/codegen/src/plugins/index.ts
+++ b/packages/codegen/src/plugins/index.ts
@@ -1,3 +1,5 @@
+export { createDomainPlugin } from "./domain-plugin.js";
+export type { DomainPluginOptions } from "./domain-plugin.js";
 export { createTsPlugin } from "./ts-plugin.js";
 export type { TsPluginOptions, TsPluginArtifacts } from "./ts-plugin.js";
 export { createZodPlugin } from "./zod-plugin.js";

--- a/packages/codegen/src/plugins/ts-plugin.ts
+++ b/packages/codegen/src/plugins/ts-plugin.ts
@@ -14,6 +14,9 @@ import type {
 
 const PLUGIN_NAME = "codegen-plugin-ts";
 
+/**
+ * @deprecated Prefer `createDomainPlugin()` for canonical domain facade output.
+ */
 export interface TsPluginOptions {
   readonly typesFile?: string;
   readonly actionsFile?: string;
@@ -24,6 +27,9 @@ export interface TsPluginArtifacts {
   readonly typeImportPath: string;
 }
 
+/**
+ * @deprecated Prefer `createDomainPlugin()` for canonical domain facade output.
+ */
 export function createTsPlugin(options?: TsPluginOptions): CodegenPlugin {
   const typesFile = options?.typesFile ?? "types.ts";
   const actionsFile = options?.actionsFile ?? "actions.ts";

--- a/packages/codegen/src/plugins/zod-plugin.ts
+++ b/packages/codegen/src/plugins/zod-plugin.ts
@@ -10,10 +10,16 @@ import type { TsPluginArtifacts } from "./ts-plugin.js";
 const PLUGIN_NAME = "codegen-plugin-zod";
 const TS_PLUGIN_NAME = "codegen-plugin-ts";
 
+/**
+ * @deprecated Prefer `createDomainPlugin()` for canonical domain facade output.
+ */
 export interface ZodPluginOptions {
   readonly schemasFile?: string;
 }
 
+/**
+ * @deprecated Prefer `createDomainPlugin()` for canonical domain facade output.
+ */
 export function createZodPlugin(options?: ZodPluginOptions): CodegenPlugin {
   const schemasFile = options?.schemasFile ?? "base.ts";
 

--- a/packages/codegen/src/runner.ts
+++ b/packages/codegen/src/runner.ts
@@ -21,7 +21,7 @@ import { generateHeader } from "./header.js";
  * - Sequential plugin execution (GEN-3, GEN-7)
  * - FilePatch composition with collision detection
  * - Error gating (GEN-5, GEN-8)
- * - outDir clean + file flush (GEN-1)
+ * - Optional outDir clean + file flush
  */
 export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
   const diagnostics: Diagnostic[] = [];
@@ -105,8 +105,9 @@ export async function generate(opts: GenerateOptions): Promise<GenerateResult> {
     return { files, artifacts: allArtifacts, diagnostics };
   }
 
-  // GEN-1: Clean outDir before write
-  await fs.rm(opts.outDir, { recursive: true, force: true });
+  if (opts.cleanOutDir) {
+    await fs.rm(opts.outDir, { recursive: true, force: true });
+  }
 
   // Build header
   const header = generateHeader({

--- a/packages/codegen/src/types.ts
+++ b/packages/codegen/src/types.ts
@@ -41,6 +41,7 @@ export interface GenerateOptions {
   readonly plugins: readonly CodegenPlugin[];
   readonly sourceId?: string;
   readonly stamp?: boolean;
+  readonly cleanOutDir?: boolean;
 }
 
 export interface GenerateResult {


### PR DESCRIPTION
## Summary
- add a canonical `createDomainPlugin()` that generates colocated `<domain>.mel.ts` facade types
- infer `computed` types inside `@manifesto-ai/codegen` with `warning + unknown` fallback for unsupported expressions
- deprecate the legacy TS/Zod plugins in docs and JSDoc, and make `generate()` skip `outDir` cleaning by default so colocated output is safe

## Testing
- `pnpm test`
- `pnpm build`