### PR TITLE
[codex] fix release backfill workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.backfill == 'true' }}
     steps:
-      - name: Release Please (github-release)
+      - name: Release Please (release only)
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          command: github-release
+          skip-github-pull-request: true
 
   publish:
     name: Publish to npm


### PR DESCRIPTION
## What changed
- fixes the `workflow_dispatch` backfill path in `.github/workflows/release.yml`
- replaces the unsupported `command: github-release` input with the supported v4 release-only mode, `skip-github-pull-request: true`
- renames the backfill step to match what it now does

## Why
The current backfill job is broken with `googleapis/release-please-action@v4`.

When we ran the recovery workflow on April 2, 2026, the action logged:
- `Unexpected input(s) 'command'`
- `There are untagged, merged release PRs outstanding - aborting`

That meant `backfill=true` silently fell back to the normal release-please flow instead of creating missing GitHub releases for already-merged release PRs.

## Impact
- future backfill runs should create missing GitHub releases/tags without trying to open or evaluate release PRs again
- this prevents the same manual recovery we had to do for release PR #361

## Validation
- inspected the failing workflow run and confirmed the invalid-input root cause
- updated the workflow to use the supported v4 input
- ran `git diff --check`
