### PR TITLE
docs: rework docs IA around Guide and API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ Manifesto gives you one semantic model for deterministic domain state and toolin
 ## Install
 
 ```bash
-pnpm add @manifesto-ai/sdk @manifesto-ai/compiler
+npx @manifesto-ai/cli init
 ```
+
+That opens the interactive init flow. Prefer pnpm or bun? Use `pnpm dlx @manifesto-ai/cli init` or `bunx @manifesto-ai/cli init`.
+
+Prefer manual setup? Install `@manifesto-ai/sdk` for the app runtime. Install `@manifesto-ai/compiler` directly only when your project imports compiler entrypoints such as `@manifesto-ai/compiler/vite`.
 
 ## Quick Example
 
@@ -39,13 +43,13 @@ console.log(app.getSnapshot().data.count); // 1
 
 ## Start With The Docs
 
-- Build the first app: [Docs Home](./docs/index.md) -> [Quickstart](./docs/quickstart.md) -> [Tutorial](./docs/tutorial/index.md)
+- Build the first app: [Docs Home](./docs/index.md) -> [Guide Introduction](./docs/guide/introduction.md) -> [Quick Start](./docs/guide/quick-start.md)
 - Set up CLI, editor, AI, or Studio workflows: [Developer Tooling](./docs/guides/developer-tooling.md)
 - Add approval, review, or sealed history later: [When You Need Approval or History](./docs/guides/approval-and-history.md)
 - Look up a package you already know: [API Reference](./docs/api/index.md)
 - Go deeper into the model: [Concepts](./docs/concepts/index.md), [Architecture](./docs/architecture/index.md), [Internals](./docs/internals/index.md)
 
-Start with `@manifesto-ai/sdk` and `@manifesto-ai/compiler`. Add Lineage, Governance, or the surrounding DX packages only when the project actually needs them.
+Start with the base SDK runtime. Add compiler entrypoints, Lineage, Governance, or the surrounding DX packages only when the project actually needs them.
 
 ## What Manifesto Is Not
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -138,17 +138,30 @@ export default defineConfig({
 
       '/api/': [
         {
-          text: 'Build An App',
+          text: 'API Reference',
           items: [
             { text: 'Overview', link: '/api/' },
-            { text: '@manifesto-ai/sdk', link: '/api/sdk' },
+            { text: 'Application', link: '/api/application' },
+            { text: 'Runtime Instance', link: '/api/runtime' },
+            { text: 'Actions and Availability', link: '/api/actions-and-availability' },
+            { text: 'Intents', link: '/api/intents' },
+            { text: 'Snapshots and Subscriptions', link: '/api/snapshots-and-subscriptions' },
+            { text: 'Effects', link: '/api/effects' },
+            { text: 'Governed Runtime', link: '/api/governed-runtime' },
+            { text: 'Bundler Adapters', link: '/api/bundler-adapters' },
+            { text: 'Public Surface Inventory', link: '/api/public-surface' },
           ]
         },
         {
-          text: 'Approval And History',
+          text: 'Package Overviews',
           items: [
-            { text: '@manifesto-ai/governance', link: '/api/governance' },
+            { text: '@manifesto-ai/sdk', link: '/api/sdk' },
             { text: '@manifesto-ai/lineage', link: '/api/lineage' },
+            { text: '@manifesto-ai/governance', link: '/api/governance' },
+            { text: '@manifesto-ai/compiler', link: '/api/compiler' },
+            { text: '@manifesto-ai/codegen', link: '/api/codegen' },
+            { text: '@manifesto-ai/core', link: '/api/core' },
+            { text: '@manifesto-ai/host', link: '/api/host' },
           ]
         },
         {
@@ -162,15 +175,6 @@ export default defineConfig({
             { text: '@manifesto-ai/studio-mcp', link: '/api/studio-mcp' },
           ]
         },
-        {
-          text: 'Runtime Internals',
-          items: [
-            { text: '@manifesto-ai/core', link: '/api/core' },
-            { text: '@manifesto-ai/host', link: '/api/host' },
-            { text: '@manifesto-ai/compiler', link: '/api/compiler' },
-            { text: '@manifesto-ai/codegen', link: '/api/codegen' },
-          ]
-        }
       ],
 
       '/internals/': [

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,8 +1,65 @@
 import fs from 'node:fs'
 import { defineConfig } from 'vitepress'
-import type { MarkdownRenderer } from 'vitepress'
+import type { DefaultTheme, MarkdownRenderer } from 'vitepress'
 
 const markdownLanguages = loadMarkdownLanguages()
+const guideSidebar: DefaultTheme.SidebarItem[] = [
+  {
+    text: 'Getting Started',
+    items: [
+      { text: 'Introduction', link: '/guide/introduction' },
+      { text: 'Quick Start', link: '/guide/quick-start' },
+    ]
+  },
+  {
+    text: 'Essentials',
+    items: [
+      { text: 'Creating an App', link: '/guide/essentials/creating-an-app' },
+      { text: 'MEL Domain Basics', link: '/guide/essentials/mel-domain-basics' },
+      { text: 'State', link: '/guide/essentials/state' },
+      { text: 'Computed Values', link: '/guide/essentials/computed-values' },
+      { text: 'Actions and Intents', link: '/guide/essentials/actions-and-intents' },
+      { text: 'Reading Snapshots', link: '/guide/essentials/reading-snapshots' },
+      { text: 'Subscriptions', link: '/guide/essentials/subscriptions' },
+      { text: 'Effects', link: '/guide/essentials/effects' },
+      { text: 'Availability', link: '/guide/essentials/availability' },
+      { text: 'Building a Todo App', link: '/guide/essentials/todo-app' },
+    ]
+  },
+  {
+    text: 'Integrations',
+    items: [
+      { text: 'React', link: '/integration/react' },
+      { text: 'AI Agents', link: '/integration/ai-agents' },
+      { text: 'Tooling', link: '/guides/developer-tooling' },
+      { text: 'Bundler Setup', link: '/guides/bundler-setup' },
+    ]
+  },
+  {
+    text: 'Scaling Up',
+    items: [
+      { text: 'Approval and History', link: '/guides/approval-and-history' },
+      { text: 'Governed Composition', link: '/guides/governed-composition' },
+      { text: 'Sealed History and Review', link: '/tutorial/06-governed-sealing-and-history' },
+    ]
+  },
+  {
+    text: 'In-Depth',
+    items: [
+      { text: 'Shared Semantic Model', link: '/concepts/shared-semantic-model' },
+      { text: 'Snapshot', link: '/concepts/snapshot' },
+      { text: 'Intent', link: '/concepts/intent' },
+      { text: 'Flow', link: '/concepts/flow' },
+      { text: 'Effect Model', link: '/concepts/effect' },
+      { text: 'Determinism', link: '/architecture/determinism' },
+      { text: 'Data Flow', link: '/architecture/data-flow' },
+      { text: 'Failure Model', link: '/architecture/failure-model' },
+      { text: 'Layer Boundaries', link: '/architecture/layers' },
+      { text: 'Re-entry Safety', link: '/guides/reentry-safe-flows' },
+      { text: 'Debugging', link: '/guides/debugging' },
+    ]
+  },
+]
 
 function loadMarkdownLanguages() {
   const languagesDir = new URL('./languages/', import.meta.url)
@@ -51,50 +108,20 @@ export default defineConfig({
 
   themeConfig: {
     nav: [
-      { text: 'Start', link: '/' },
-      { text: 'Learn', link: '/tutorial/' },
-      { text: 'Build', link: '/guides/' },
-      { text: 'Reference', link: '/api/' },
+      { text: 'Guide', link: '/guide/introduction' },
+      { text: 'API', link: '/api/' },
+      { text: 'Reference', link: '/mel/' },
+      { text: 'Internals', link: '/internals/' },
     ],
 
     sidebar: {
-      '/start-here': [],
       '/quickstart': [],
-
-      '/tutorial/': [
-        {
-          text: 'Core Path',
-          items: [
-            { text: 'Overview', link: '/tutorial/' },
-            { text: '1. Your First App', link: '/tutorial/01-your-first-app' },
-            { text: '2. Actions and State', link: '/tutorial/02-actions-and-state' },
-            { text: '3. Working with Effects', link: '/tutorial/03-effects' },
-            { text: '4. Building a Todo App', link: '/tutorial/04-todo-app' },
-          ]
-        },
-        {
-          text: 'Advanced Runtime Later',
-          items: [
-            { text: '5. Approval and History Setup', link: '/tutorial/05-governed-composition' },
-            { text: '6. Sealed History and Review Flow', link: '/tutorial/06-governed-sealing-and-history' },
-          ]
-        },
-      ],
-
-      '/concepts/': [
-        {
-          text: 'Core Concepts',
-          items: [
-            { text: 'Overview', link: '/concepts/' },
-            { text: 'Shared Semantic Model', link: '/concepts/shared-semantic-model' },
-            { text: 'Snapshot', link: '/concepts/snapshot' },
-            { text: 'Intent', link: '/concepts/intent' },
-            { text: 'Flow', link: '/concepts/flow' },
-            { text: 'Effect', link: '/concepts/effect' },
-            { text: 'World', link: '/concepts/world' },
-          ]
-        }
-      ],
+      '/guide/': guideSidebar,
+      '/tutorial/': guideSidebar,
+      '/concepts/': guideSidebar,
+      '/architecture/': guideSidebar,
+      '/integration/': guideSidebar,
+      '/guides/': guideSidebar,
 
       '/mel/': [
         {
@@ -105,46 +132,6 @@ export default defineConfig({
             { text: 'Syntax Cookbook', link: '/mel/SYNTAX' },
             { text: 'Examples', link: '/mel/EXAMPLES' },
             { text: 'Error Guide', link: '/mel/ERROR-GUIDE' },
-          ]
-        }
-      ],
-
-      '/guides/': [
-        {
-          text: 'Build And Debug',
-          items: [
-            { text: 'Overview', link: '/guides/' },
-            { text: 'Bundler Setup', link: '/guides/bundler-setup' },
-            { text: 'Effect Handlers', link: '/guides/effect-handlers' },
-            { text: 'Debugging', link: '/guides/debugging' },
-            { text: 'Code Generation', link: '/guides/code-generation' },
-            { text: 'Developer Tooling', link: '/guides/developer-tooling' },
-            { text: 'Re-entry Safety', link: '/guides/reentry-safe-flows' },
-          ]
-        },
-        {
-          text: 'Advanced Runtime Later',
-          items: [
-            { text: 'When You Need Approval or History', link: '/guides/approval-and-history' },
-            { text: 'Advanced Runtime Assembly', link: '/guides/governed-composition' },
-          ]
-        },
-        {
-          text: 'Maintainers And Operators',
-          items: [
-            { text: 'Release Hardening', link: '/guides/release-hardening' },
-            { text: 'Upgrade To Next Major', link: '/guides/upgrade-next-major' },
-          ]
-        },
-      ],
-
-      '/integration/': [
-        {
-          text: 'Integration',
-          items: [
-            { text: 'Overview', link: '/integration/' },
-            { text: 'React', link: '/integration/react' },
-            { text: 'AI Agents', link: '/integration/ai-agents' },
           ]
         }
       ],
@@ -182,19 +169,6 @@ export default defineConfig({
             { text: '@manifesto-ai/host', link: '/api/host' },
             { text: '@manifesto-ai/compiler', link: '/api/compiler' },
             { text: '@manifesto-ai/codegen', link: '/api/codegen' },
-          ]
-        }
-      ],
-
-      '/architecture/': [
-        {
-          text: 'Architecture',
-          items: [
-            { text: 'Overview', link: '/architecture/' },
-            { text: 'Layer Boundaries', link: '/architecture/layers' },
-            { text: 'Data Flow', link: '/architecture/data-flow' },
-            { text: 'Determinism', link: '/architecture/determinism' },
-            { text: 'Failure Model', link: '/architecture/failure-model' },
           ]
         }
       ],

--- a/docs/api/actions-and-availability.md
+++ b/docs/api/actions-and-availability.md
@@ -1,0 +1,87 @@
+# Actions and Availability
+
+> Runtime availability is a read against the current Snapshot.
+
+## `getAvailableActions()`
+
+Returns action names whose `available when` gate passes in the current visible Snapshot.
+
+```typescript
+const available = app.getAvailableActions();
+
+if (available.includes("clearCompleted")) {
+  // Show a button or expose an agent tool for this step.
+}
+```
+
+Do not cache this value for a long agent loop. Dispatch, approved proposal execution, or restore can change the next availability result.
+
+## `isActionAvailable(name)`
+
+Checks one coarse action-family gate.
+
+```typescript
+if (app.isActionAvailable("decrement")) {
+  await app.dispatchAsync(app.createIntent(app.MEL.actions.decrement));
+}
+```
+
+## `getActionMetadata(name?)`
+
+Reads the public action contract from the activated schema.
+
+```typescript
+const addTodo = app.getActionMetadata("addTodo");
+
+console.log(addTodo.name);
+console.log(addTodo.params);
+console.log(addTodo.input);
+console.log(addTodo.description);
+console.log(addTodo.hasDispatchableGate);
+```
+
+Call without a name to inspect every action.
+
+## Bound-Intent Legality
+
+Availability does not know action input. Use intent explanation APIs when the candidate input matters.
+
+```typescript
+const intent = app.createIntent(app.MEL.actions.spend, { amount: 20 });
+const blockers = app.whyNot(intent);
+
+if (blockers) {
+  console.log(blockers);
+}
+```
+
+Legality order is stable:
+
+1. action availability
+2. input validation
+3. dispatchability
+4. admitted dry-run
+
+## Agent Pattern
+
+Return fresh context after every tool call.
+
+```typescript
+function readAgentContext() {
+  const snapshot = app.getSnapshot();
+
+  return {
+    data: snapshot.data,
+    computed: snapshot.computed,
+    availableActions: app.getAvailableActions().map((name) =>
+      app.getActionMetadata(name),
+    ),
+  };
+}
+```
+
+## Next
+
+- Learn intent binding in [Intents](./intents)
+- Use availability in the [AI Agents guide](/integration/ai-agents)
+- Read MEL action gates in [Availability](/guide/essentials/availability)

--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -1,0 +1,63 @@
+# Application
+
+> Create a composable manifesto, then activate exactly one runtime handle from it.
+
+## `createManifesto(schema, effects)`
+
+`createManifesto()` is the SDK entry point for the base runtime.
+
+```typescript
+import { createManifesto } from "@manifesto-ai/sdk";
+
+import todoMel from "./todo.mel";
+import type { TodoDomain } from "./todo-types";
+
+const manifesto = createManifesto<TodoDomain>(todoMel, {});
+const app = manifesto.activate();
+```
+
+| Parameter | Meaning |
+|-----------|---------|
+| `schema` | A compiled `DomainSchema` or MEL source string |
+| `effects` | A record of SDK effect handlers, keyed by effect type |
+
+`createManifesto()` returns a composable object. Runtime verbs such as `dispatchAsync()` and `getSnapshot()` exist only after `activate()`.
+
+## Activation Boundary
+
+```typescript
+const app = createManifesto(schema, effects).activate();
+```
+
+Activation owns the host loop, Snapshot, subscriptions, action refs, and typed intent creation surface.
+
+Do not activate the same composable more than once. Create a new composable if you need a separate runtime instance.
+
+## Decorate Before Activation
+
+Lineage and Governance wrap the composable before it is activated.
+
+```typescript
+import { createManifesto } from "@manifesto-ai/sdk";
+import { createInMemoryLineageStore, withLineage } from "@manifesto-ai/lineage";
+import { createInMemoryGovernanceStore, withGovernance } from "@manifesto-ai/governance";
+
+const app = withGovernance(
+  withLineage(createManifesto(schema, effects), {
+    store: createInMemoryLineageStore(),
+  }),
+  {
+    governanceStore: createInMemoryGovernanceStore(),
+    bindings,
+    execution,
+  },
+).activate();
+```
+
+The MEL domain stays the same. The activated runtime verbs change with the chosen composition.
+
+## Next
+
+- Inspect the activated handle in [Runtime Instance](./runtime)
+- Dispatch work with [Intents](./intents)
+- Add approval in [Governed Runtime](./governed-runtime)

--- a/docs/api/bundler-adapters.md
+++ b/docs/api/bundler-adapters.md
@@ -1,0 +1,48 @@
+# Bundler Adapters
+
+> Use compiler subpaths when your app imports `.mel` files directly.
+
+The SDK can activate a compiled schema or MEL source string. Bundler adapters are for app code that imports `.mel` modules.
+
+## Vite
+
+```typescript
+import { defineConfig } from "vite";
+import { melPlugin } from "@manifesto-ai/compiler/vite";
+
+export default defineConfig({
+  plugins: [melPlugin()],
+});
+```
+
+Then import the domain:
+
+```typescript
+import counterMel from "./counter.mel";
+```
+
+## Public Adapter Subpaths
+
+| Subpath | Purpose |
+|---------|---------|
+| `@manifesto-ai/compiler/vite` | Vite plugin |
+| `@manifesto-ai/compiler/webpack` | webpack plugin |
+| `@manifesto-ai/compiler/rollup` | Rollup plugin |
+| `@manifesto-ai/compiler/esbuild` | esbuild plugin |
+| `@manifesto-ai/compiler/rspack` | Rspack plugin |
+| `@manifesto-ai/compiler/node-loader` | Node ESM loader hooks for `.mel` files |
+| `@manifesto-ai/compiler/loader` | compatibility alias for the Node loader |
+
+Bundler plugin subpaths export `melPlugin` and the shared MEL plugin option types. The node-loader subpath exports loader hooks.
+
+## Install Note
+
+The runtime package is `@manifesto-ai/sdk`.
+
+Install `@manifesto-ai/compiler` directly when your application imports compiler entrypoints such as `@manifesto-ai/compiler/vite` or `@manifesto-ai/compiler/node-loader`.
+
+## Next
+
+- Start from [Quick Start](/guide/quick-start)
+- Read [@manifesto-ai/compiler](./compiler)
+- Configure tooling with the [CLI](./cli)

--- a/docs/api/effects.md
+++ b/docs/api/effects.md
@@ -1,0 +1,80 @@
+# Effects
+
+> SDK effect handlers fulfill declared MEL effects and return patches.
+
+## Handler Contract
+
+```typescript
+import type { EffectHandler } from "@manifesto-ai/sdk";
+
+type Handler = EffectHandler;
+```
+
+An SDK effect handler receives effect params and a projected Snapshot context.
+
+```typescript
+const effects = {
+  "api.fetchUser": async (params, ctx) => {
+    console.log(params);
+    console.log(ctx.snapshot.data);
+
+    return [];
+  },
+} satisfies Record<string, EffectHandler>;
+```
+
+Register handlers before activation:
+
+```typescript
+const app = createManifesto(schema, effects).activate();
+```
+
+## Return Patches
+
+Handlers return core patches. Patch paths are structured and rooted at domain state.
+
+```typescript
+const effects = {
+  "api.fetchUser": async (params) => {
+    const { id } = params as { id: string };
+    const user = await fetchUser(id);
+
+    return [
+      { op: "set", path: [{ kind: "prop", name: "user" }], value: user },
+      { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
+      { op: "unset", path: [{ kind: "prop", name: "error" }] },
+    ];
+  },
+} satisfies Record<string, EffectHandler>;
+```
+
+| Op | Meaning |
+|----|---------|
+| `set` | Replace the value at path |
+| `unset` | Remove the property at path |
+| `merge` | Shallow-merge object fields at path |
+
+Do not return fetched values directly. Put the result in Snapshot with patches.
+
+## Error Values
+
+Catch recoverable IO errors in the handler and patch domain state.
+
+```typescript
+catch (error) {
+  return [
+    { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
+    {
+      op: "set",
+      path: [{ kind: "prop", name: "error" }],
+      value: error instanceof Error ? error.message : "Unknown error",
+    },
+  ];
+}
+```
+
+## Next
+
+- Learn the Guide version in [Effects](/guide/essentials/effects)
+- Read the deeper guide in [Effect Handlers](/guides/effect-handlers)
+- Review low-level host behavior in [@manifesto-ai/host](./host)

--- a/docs/api/governed-runtime.md
+++ b/docs/api/governed-runtime.md
@@ -1,0 +1,89 @@
+# Governed Runtime
+
+> Compose Lineage and Governance before activation when writes need legitimacy.
+
+## Activate a Governed Runtime
+
+```typescript
+import { createManifesto } from "@manifesto-ai/sdk";
+import { createInMemoryLineageStore, withLineage } from "@manifesto-ai/lineage";
+import {
+  createInMemoryGovernanceStore,
+  withGovernance,
+} from "@manifesto-ai/governance";
+
+const app = withGovernance(
+  withLineage(createManifesto(schema, effects), {
+    store: createInMemoryLineageStore(),
+  }),
+  {
+    governanceStore: createInMemoryGovernanceStore(),
+    bindings,
+    execution,
+  },
+).activate();
+```
+
+Governance requires an explicitly lineage-composed manifesto.
+
+## Write With `proposeAsync(intent)`
+
+Governed runtimes intentionally do not expose `dispatchAsync()` or lineage `commitAsync()`.
+
+```typescript
+const proposal = await app.proposeAsync(
+  app.createIntent(app.MEL.actions.addTodo, "Review this"),
+);
+```
+
+With `auto_approve` policy, a proposal may execute and complete immediately. With `hitl` policy, it usually remains `evaluating`.
+
+## HITL Policy
+
+```typescript
+const binding = {
+  actorId: "actor:agent",
+  authorityId: "authority:reviewer",
+  policy: {
+    mode: "hitl",
+    delegate: {
+      actorId: "actor:human",
+      kind: "human",
+      name: "Human Reviewer",
+    },
+  },
+} as const;
+```
+
+The visible Snapshot does not change while a proposal is waiting for human resolution.
+
+## `approve()` and `reject()`
+
+```typescript
+const pending = await app.proposeAsync(intent);
+
+if (pending.status === "evaluating") {
+  await app.approve(pending.proposalId);
+}
+```
+
+Reject manually:
+
+```typescript
+await app.reject(pending.proposalId, "Needs a smaller scope");
+```
+
+## Query Proposals
+
+```typescript
+const proposals = await app.getProposals();
+const sameProposal = await app.getProposal(proposal.proposalId);
+```
+
+Use lineage queries such as `getLatestHead()`, `getWorldSnapshot(worldId)`, `getBranches()`, and `restore(worldId)` when sealed history matters.
+
+## Next
+
+- Read the decision guide in [When You Need Approval or History](/guides/approval-and-history)
+- Assemble the advanced runtime in [Governed Composition](/guides/governed-composition)
+- See package details in [@manifesto-ai/governance](./governance)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,47 +1,52 @@
 # API Reference
 
-> Lookup surface by job, not reading order.
+> Lookup the app-facing runtime surface first. Drop into package overviews only when you need the owning package boundary.
 
-If you are new, start with [Quickstart](/quickstart) and [Tutorial](/tutorial/) first. Come back here once you know which package you need.
+If you are learning Manifesto for the first time, start with the [Guide](/guide/introduction). Use this section when you know what you want to call.
 
-## Build An App
+## App Runtime APIs
+
+| Area | Start Here |
+|------|------------|
+| Create an app | [Application](./application) |
+| Inspect the activated handle | [Runtime Instance](./runtime) |
+| Show legal actions to UI or agents | [Actions and Availability](./actions-and-availability) |
+| Request a transition | [Intents](./intents) |
+| Read domain state | [Snapshots and Subscriptions](./snapshots-and-subscriptions) |
+| Fulfill external work | [Effects](./effects) |
+| Add approval or HITL | [Governed Runtime](./governed-runtime) |
+| Import `.mel` files | [Bundler Adapters](./bundler-adapters) |
+
+## Public Surface Inventory
+
+[Public Surface Inventory](./public-surface) is generated from first-party package exports. Use it when you need to confirm whether a name is public. Use curated pages above for meaning and examples.
+
+## Package Overviews
 
 | Package | Use When |
 |---------|----------|
-| [@manifesto-ai/sdk](./sdk) | You want the activation-first app path with `createManifesto()` and `activate()` |
-
-## Add Approval And History Later
-
-| Package | Use When |
-|---------|----------|
-| [@manifesto-ai/lineage](./lineage) | You need continuity, restore, branch/head history, or sealing on top of the base runtime |
+| [@manifesto-ai/sdk](./sdk) | You want the activation-first base runtime |
+| [@manifesto-ai/lineage](./lineage) | You need continuity, restore, branch/head history, or sealing |
 | [@manifesto-ai/governance](./governance) | You need proposals, approval flow, decisions, and governance events |
+| [@manifesto-ai/compiler](./compiler) | You need MEL compilation, lowering, or bundler adapters |
+| [@manifesto-ai/codegen](./codegen) | You need schema-driven TypeScript or Zod generation |
+| [@manifesto-ai/core](./core) | You need the pure computation layer |
+| [@manifesto-ai/host](./host) | You need the low-level host orchestration layer |
 
-## Set Up Tooling Around The Runtime
+## Tooling Overviews
 
 | Package | Use When |
 |---------|----------|
 | [@manifesto-ai/cli](./cli) | You want project bootstrap, bundler integration, setup flows, or drift checks |
 | [@manifesto-ai/mel-lsp](./mel-lsp) | You want MEL diagnostics, completion, navigation, rename, and schema introspection |
 | [@manifesto-ai/skills](./skills) | You want current Manifesto guidance loaded into Codex or other AI tools |
-| [@manifesto-ai/studio-cli](./studio-cli) | You want local read-only inspection for findings, graph, snapshot, trace, lineage, or governance |
-| [@manifesto-ai/studio-core](./studio-core) | You want projection-first analysis APIs in your own tooling |
+| [@manifesto-ai/studio-cli](./studio-cli) | You want local read-only inspection from a terminal |
+| [@manifesto-ai/studio-core](./studio-core) | You want projection-first analysis APIs in TypeScript tooling |
 | [@manifesto-ai/studio-mcp](./studio-mcp) | You want an MCP inspection surface for agents or remote clients |
-
-## Work On The Runtime Or Compiler Surface
-
-| Package | Use When |
-|---------|----------|
-| [@manifesto-ai/core](./core) | You need the pure computation layer |
-| [@manifesto-ai/host](./host) | You need effect execution and compute/apply orchestration |
-| [@manifesto-ai/compiler](./compiler) | You need MEL compilation and lowering |
-| [@manifesto-ai/codegen](./codegen) | You need schema-driven TypeScript or Zod generation |
 
 ## Related Docs
 
-- [Quickstart](/quickstart)
-- [Tutorial](/tutorial/)
-- [Guides](/guides/)
-- [Concepts](/concepts/)
-- [Architecture](/architecture/)
+- [Guide](/guide/introduction)
+- [Quick Start](/guide/quick-start)
+- [MEL Reference](/mel/)
 - [Internals](/internals/)

--- a/docs/api/intents.md
+++ b/docs/api/intents.md
@@ -1,0 +1,81 @@
+# Intents
+
+> An intent is a typed request to run one MEL action.
+
+## Action Refs
+
+Use typed action refs from `app.MEL.actions.*`.
+
+```typescript
+const action = app.MEL.actions.addTodo;
+```
+
+Do not use raw action-name strings as your app-facing dispatch contract.
+
+## `createIntent(action, ...input)`
+
+Zero-parameter action:
+
+```typescript
+const intent = app.createIntent(app.MEL.actions.clearCompleted);
+```
+
+Single-parameter action:
+
+```typescript
+const intent = app.createIntent(app.MEL.actions.addTodo, "Write API docs");
+```
+
+Multi-parameter action:
+
+```typescript
+const intent = app.createIntent(
+  app.MEL.actions.moveTodo,
+  "todo-1",
+  "done",
+);
+```
+
+Keyed binding:
+
+```typescript
+const intent = app.createIntent(app.MEL.actions.moveTodo, {
+  id: "todo-1",
+  column: "done",
+});
+```
+
+Keyed binding is useful when parameter order would be hard to read.
+
+## `dispatchAsync(intent)`
+
+Dispatch commits an intent through the base runtime and resolves with the next terminal projected Snapshot.
+
+```typescript
+const snapshot = await app.dispatchAsync(
+  app.createIntent(app.MEL.actions.addTodo, "Write API docs"),
+);
+
+console.log(snapshot.data.todos);
+```
+
+The action result lives in Snapshot. Do not expect a separate business return value from the action.
+
+## Before Dispatch
+
+```typescript
+const intent = app.createIntent(app.MEL.actions.addTodo, "");
+const blockers = app.whyNot(intent);
+
+if (blockers) {
+  console.log("not admitted", blockers);
+} else {
+  await app.dispatchAsync(intent);
+}
+```
+
+## Next
+
+- Read the dispatch result in [Snapshots and Subscriptions](./snapshots-and-subscriptions)
+- Inspect legality in [Actions and Availability](./actions-and-availability)
+- Upgrade writes in [Governed Runtime](./governed-runtime)

--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -1,0 +1,1136 @@
+# Public Surface Inventory
+
+> Generated from package `exports` and source barrels. Do not edit by hand.
+>
+> Run `pnpm docs:api:inventory` to update this page.
+
+This page is a drift guard. Use the curated API reference pages for usage guidance.
+
+## @manifesto-ai/codegen
+
+### @manifesto-ai/codegen
+
+_Source: `packages/codegen/src/index.ts`_
+
+#### Values
+
+- `createCompilerCodegen`
+- `createDomainPlugin`
+- `createTsPlugin`
+- `createZodPlugin`
+- `generate`
+- `generateHeader`
+- `stableHash`
+- `validatePath`
+
+#### Types
+
+- `CodegenContext`
+- `CodegenHelpers`
+- `CodegenOutput`
+- `CodegenPlugin`
+- `CompilerCodegenEmitter`
+- `CompilerCodegenInput`
+- `CompilerCodegenOptions`
+- `Diagnostic`
+- `DomainPluginOptions`
+- `FilePatch`
+- `GenerateOptions`
+- `GenerateResult`
+- `HeaderOptions`
+- `PathValidationResult`
+- `TsPluginArtifacts`
+- `TsPluginOptions`
+- `ZodPluginOptions`
+
+## @manifesto-ai/compiler
+
+### @manifesto-ai/compiler
+
+_Source: `packages/compiler/src/index.ts`_
+
+#### Values
+
+- `analyzeScope`
+- `applyPatchToWorkingSnapshot`
+- `check`
+- `classifyCondition`
+- `compile`
+- `compileMelDomain`
+- `compileMelPatch`
+- `createError`
+- `createEvaluationContext`
+- `createInfo`
+- `createLocation`
+- `createPointLocation`
+- `createPosition`
+- `createToken`
+- `createWarning`
+- `DEFAULT_ACTION_CONTEXT`
+- `DEFAULT_DISPATCHABLE_CONTEXT`
+- `DEFAULT_PATCH_CONTEXT`
+- `DEFAULT_SCHEMA_CONTEXT`
+- `DIAGNOSTIC_CODES`
+- `EFFECT_ARGS_CONTEXT`
+- `evaluateCondition`
+- `evaluateConditionalPatchOps`
+- `evaluateExpr`
+- `evaluatePatches`
+- `evaluatePatchExpressions`
+- `evaluateRuntimePatches`
+- `evaluateRuntimePatchesWithTrace`
+- `extractSchemaGraph`
+- `extractTypeName`
+- `filterBySeverity`
+- `formatDiagnostic`
+- `formatDiagnosticCode`
+- `formatDiagnostics`
+- `generate`
+- `generateCanonical`
+- `getBinaryPrecedence`
+- `getDiagnosticInfo`
+- `getKeywordKind`
+- `hasErrors`
+- `invalidKindForContext`
+- `invalidShape`
+- `invalidSysPath`
+- `isBinaryOp`
+- `isError`
+- `isExprNode`
+- `isKeyword`
+- `isReserved`
+- `isRightAssociative`
+- `isStmtNode`
+- `isUnaryOp`
+- `KEYWORDS`
+- `Lexer`
+- `lowerExprNode`
+- `LoweringError`
+- `lowerPatchFragments`
+- `lowerRuntimePatch`
+- `lowerRuntimePatches`
+- `lowerSystemValues`
+- `mergeLocations`
+- `normalizeExpr`
+- `normalizeFunctionCall`
+- `parse`
+- `Parser`
+- `parseSource`
+- `Precedence`
+- `renderAsDomain`
+- `renderExprNode`
+- `renderFragment`
+- `renderFragments`
+- `renderFragmentsByKind`
+- `renderPatchOp`
+- `renderTypeExpr`
+- `renderTypeField`
+- `renderValue`
+- `RESERVED_KEYWORDS`
+- `Scope`
+- `ScopeAnalyzer`
+- `SemanticValidator`
+- `tokenize`
+- `tokenToBinaryOp`
+- `unknownCallFn`
+- `unknownNodeKind`
+- `unsupportedBase`
+- `validateSemantics`
+
+#### Types
+
+- `ActionNode`
+- `ActionSpec`
+- `AddActionAvailableOp`
+- `AddComputedOp`
+- `AddConstraintOp`
+- `AddFieldOp`
+- `AddTypeOp`
+- `AllowedSysPrefix`
+- `ArrayLiteralExprNode`
+- `ArrayTypeNode`
+- `ASTNode`
+- `BinaryExprNode`
+- `BinaryOperator`
+- `CanonicalDomainSchema`
+- `CompileMelDomainOptions`
+- `CompileMelDomainResult`
+- `CompileMelPatchOptions`
+- `CompileMelPatchResult`
+- `CompileOptions`
+- `CompilerActionSpec`
+- `CompilerComputedFieldSpec`
+- `CompileResult`
+- `CompilerExprNode`
+- `CompilerFlowNode`
+- `CompileTrace`
+- `ComputedFieldSpec`
+- `ComputedNode`
+- `ComputedSpec`
+- `ConditionalPatchOp`
+- `CoreExprNode`
+- `CoreFlowNode`
+- `Diagnostic`
+- `DiagnosticCode`
+- `DiagnosticSeverity`
+- `DomainMember`
+- `DomainModule`
+- `DomainNode`
+- `DomainSchema`
+- `EffectArgNode`
+- `EffectStmtNode`
+- `EvaluatedPatch`
+- `EvaluatedPatchOp`
+- `EvaluationContext`
+- `EvaluationMeta`
+- `EvaluationSnapshot`
+- `ExprLoweringContext`
+- `ExprNode`
+- `FailStmtNode`
+- `FieldSpec`
+- `FieldType`
+- `FlowDeclNode`
+- `FlowStmtNode`
+- `FragmentRenderOptions`
+- `FunctionCallExprNode`
+- `GenerateCanonicalResult`
+- `GenerateResult`
+- `GuardedStmtNode`
+- `IdentifierExprNode`
+- `ImportNode`
+- `IncludeStmtNode`
+- `IndexAccessExprNode`
+- `IndexSegmentNode`
+- `InnerStmtNode`
+- `IRPatchPath`
+- `IRPathSegment`
+- `IterationVarExprNode`
+- `LexResult`
+- `LiteralExprNode`
+- `LiteralTypeNode`
+- `LoweredPatchOp`
+- `LoweredTypeExpr`
+- `LoweredTypeField`
+- `LoweringErrorCode`
+- `MelExprNode`
+- `MelIRPatchPath`
+- `MelIRPathSegment`
+- `MelObjField`
+- `MelPatchFragment`
+- `MelPatchOp`
+- `MelPathNode`
+- `MelPathSegment`
+- `MelPrimitive`
+- `MelRuntimePatch`
+- `MelRuntimePatchOp`
+- `MelSystemPath`
+- `MelTypeExpr`
+- `MelTypeField`
+- `ObjectLiteralExprNode`
+- `ObjectPropertyNode`
+- `ObjectTypeNode`
+- `OnceIntentStmtNode`
+- `OnceStmtNode`
+- `ParamNode`
+- `ParseResult`
+- `PatchEvaluationResult`
+- `PatchFragment`
+- `PatchLoweringContext`
+- `PatchOp`
+- `PatchStmtNode`
+- `PathNode`
+- `PathSegmentNode`
+- `Position`
+- `ProgramNode`
+- `PropertyAccessExprNode`
+- `PropertySegmentNode`
+- `RecordTypeNode`
+- `RelatedDiagnostic`
+- `RendererExprNode`
+- `RenderOptions`
+- `RuntimeConditionalPatchOp`
+- `RuntimePatchEvaluationResult`
+- `RuntimePatchSkipReason`
+- `SchemaConditionalPatchOp`
+- `SchemaGraph`
+- `SchemaGraphEdge`
+- `SchemaGraphEdgeRelation`
+- `SchemaGraphNode`
+- `SchemaGraphNodeId`
+- `SchemaGraphNodeKind`
+- `ScopeAnalysisResult`
+- `SetDefaultValueOp`
+- `SetFieldTypeOp`
+- `SimpleTypeNode`
+- `SkippedRuntimePatch`
+- `SourceLocation`
+- `StateFieldNode`
+- `StateNode`
+- `StateSpec`
+- `StopStmtNode`
+- `Symbol`
+- `SymbolKind`
+- `SystemIdentExprNode`
+- `TernaryExprNode`
+- `Token`
+- `TokenKind`
+- `TypeDeclNode`
+- `TypeDefinition`
+- `TypeExpr`
+- `TypeExprNode`
+- `TypeField`
+- `TypeFieldNode`
+- `TypeSpec`
+- `UnaryExprNode`
+- `UnionTypeNode`
+- `ValidationResult`
+- `WhenStmtNode`
+
+### @manifesto-ai/compiler/esbuild
+
+_Source: `packages/compiler/src/esbuild.ts`_
+
+#### Values
+
+- `melPlugin`
+
+#### Types
+
+- `MelCodegenArtifact`
+- `MelCodegenEmitter`
+- `MelCodegenOptions`
+- `MelPluginOptions`
+
+### @manifesto-ai/compiler/loader
+
+_Source: `packages/compiler/src/node-loader.ts`_
+
+#### Values
+
+- `load`
+- `resolve`
+
+#### Types
+
+_No named exports detected._
+
+### @manifesto-ai/compiler/node-loader
+
+_Source: `packages/compiler/src/node-loader.ts`_
+
+#### Values
+
+- `load`
+- `resolve`
+
+#### Types
+
+_No named exports detected._
+
+### @manifesto-ai/compiler/rollup
+
+_Source: `packages/compiler/src/rollup.ts`_
+
+#### Values
+
+- `melPlugin`
+
+#### Types
+
+- `MelCodegenArtifact`
+- `MelCodegenEmitter`
+- `MelCodegenOptions`
+- `MelPluginOptions`
+
+### @manifesto-ai/compiler/rspack
+
+_Source: `packages/compiler/src/rspack.ts`_
+
+#### Values
+
+- `melPlugin`
+
+#### Types
+
+- `MelCodegenArtifact`
+- `MelCodegenEmitter`
+- `MelCodegenOptions`
+- `MelPluginOptions`
+
+### @manifesto-ai/compiler/vite
+
+_Source: `packages/compiler/src/vite.ts`_
+
+#### Values
+
+- `melPlugin`
+
+#### Types
+
+- `MelCodegenArtifact`
+- `MelCodegenEmitter`
+- `MelCodegenOptions`
+- `MelPluginOptions`
+
+### @manifesto-ai/compiler/webpack
+
+_Source: `packages/compiler/src/webpack.ts`_
+
+#### Values
+
+- `melPlugin`
+
+#### Types
+
+- `MelCodegenArtifact`
+- `MelCodegenEmitter`
+- `MelCodegenOptions`
+- `MelPluginOptions`
+
+## @manifesto-ai/core
+
+### @manifesto-ai/core
+
+_Source: `packages/core/src/index.ts`_
+
+#### Values
+
+- `AbsExpr`
+- `ActionSpec`
+- `AddExpr`
+- `AndExpr`
+- `AppendExpr`
+- `apply`
+- `applySystemDelta`
+- `AtExpr`
+- `buildDependencyGraph`
+- `CallFlow`
+- `canonicalEqual`
+- `CeilExpr`
+- `CoalesceExpr`
+- `compareUnicodeCodePoints`
+- `compute`
+- `ComputedFieldSpec`
+- `ComputedSpec`
+- `ComputeResult`
+- `ComputeStatus`
+- `computeSync`
+- `ConcatExpr`
+- `CoreErrorCode`
+- `createContext`
+- `createCore`
+- `createError`
+- `createFlowState`
+- `createInitialSystemState`
+- `createIntent`
+- `createSnapshot`
+- `createTraceContext`
+- `createTraceNode`
+- `detectCycles`
+- `DivExpr`
+- `DomainSchema`
+- `EffectFlow`
+- `EndsWithExpr`
+- `EntriesExpr`
+- `EnumFieldType`
+- `EqExpr`
+- `err`
+- `ErrorValue`
+- `evaluateComputed`
+- `evaluateExpr`
+- `evaluateFlow`
+- `evaluateFlowSync`
+- `evaluateSingleComputed`
+- `EveryExpr`
+- `explain`
+- `ExplainResult`
+- `ExprKind`
+- `ExprNodeSchema`
+- `extractDefaults`
+- `FailFlow`
+- `FieldExpr`
+- `FieldSpec`
+- `FieldType`
+- `FilterExpr`
+- `FindExpr`
+- `FirstExpr`
+- `FlatExpr`
+- `FloorExpr`
+- `FlowKind`
+- `FlowNodeSchema`
+- `FlowPosition`
+- `fromCanonical`
+- `FromEntriesExpr`
+- `generateRequirementId`
+- `generateRequirementIdSync`
+- `generateTraceId`
+- `getAvailableActions`
+- `getByPatchPath`
+- `getByPath`
+- `GetExpr`
+- `getTransitiveDeps`
+- `GteExpr`
+- `GtExpr`
+- `HaltFlow`
+- `hashSchema`
+- `hashSchemaEffective`
+- `hashSchemaEffectiveSync`
+- `hashSchemaSync`
+- `HasKeyExpr`
+- `hasPath`
+- `HostContext`
+- `IfExpr`
+- `IfFlow`
+- `IncludesExpr`
+- `IndexOfExpr`
+- `indexSegment`
+- `Intent`
+- `invalidResult`
+- `isActionAvailable`
+- `isErr`
+- `isErrorValue`
+- `isIntentDispatchable`
+- `IsNullExpr`
+- `isOk`
+- `isSafePatchPath`
+- `joinPath`
+- `KeysExpr`
+- `LastExpr`
+- `lastSegment`
+- `LenExpr`
+- `LitExpr`
+- `LteExpr`
+- `LtExpr`
+- `MapExpr`
+- `MaxArrayExpr`
+- `MaxExpr`
+- `mergeAtPatchPath`
+- `mergeAtPath`
+- `MergeExpr`
+- `mergePatch`
+- `MinArrayExpr`
+- `MinExpr`
+- `ModExpr`
+- `MulExpr`
+- `NegExpr`
+- `NeqExpr`
+- `NotExpr`
+- `ObjectExpr`
+- `ok`
+- `OmitExpr`
+- `OrExpr`
+- `parentPath`
+- `parsePath`
+- `Patch`
+- `PatchFlow`
+- `PatchOp`
+- `PatchPath`
+- `patchPathToDisplayString`
+- `PatchSegment`
+- `PickExpr`
+- `PowExpr`
+- `PrimitiveFieldType`
+- `propSegment`
+- `ReplaceExpr`
+- `Requirement`
+- `Result`
+- `ReverseExpr`
+- `RoundExpr`
+- `SchemaMeta`
+- `SemanticPath`
+- `semanticPathToPatchPath`
+- `SeqFlow`
+- `setByPatchPath`
+- `setByPath`
+- `setPatch`
+- `sha256`
+- `sha256Sync`
+- `SliceExpr`
+- `Snapshot`
+- `SnapshotMeta`
+- `SomeExpr`
+- `sortKeys`
+- `SplitExpr`
+- `SqrtExpr`
+- `StartsWithExpr`
+- `StateSpec`
+- `StrIncludesExpr`
+- `StrLenExpr`
+- `SubExpr`
+- `SubstringExpr`
+- `SumArrayExpr`
+- `SystemDelta`
+- `SystemState`
+- `ToBooleanExpr`
+- `toCanonical`
+- `toJcs`
+- `ToLowerCaseExpr`
+- `ToNumberExpr`
+- `topologicalSort`
+- `ToStringExpr`
+- `ToUpperCaseExpr`
+- `TraceGraph`
+- `TraceNode`
+- `TraceNodeKind`
+- `TraceTermination`
+- `TrimExpr`
+- `TypeDefinition`
+- `TypeofExpr`
+- `TypeSpec`
+- `UniqueExpr`
+- `unsetByPatchPath`
+- `unsetByPath`
+- `unsetPatch`
+- `validate`
+- `validateIntentInput`
+- `ValidationError`
+- `ValidationResult`
+- `validResult`
+- `ValuesExpr`
+- `withCollectionContext`
+- `withNodePath`
+- `withSnapshot`
+
+#### Types
+
+- `AbsExpr`
+- `ActionSpec`
+- `AddExpr`
+- `AndExpr`
+- `AppendExpr`
+- `AtExpr`
+- `CallFlow`
+- `CeilExpr`
+- `CoalesceExpr`
+- `ComputedFieldSpec`
+- `ComputedSpec`
+- `ComputeResult`
+- `ComputeStatus`
+- `ConcatExpr`
+- `CoreErrorCode`
+- `DependencyGraph`
+- `DivExpr`
+- `DomainSchema`
+- `EffectFlow`
+- `EndsWithExpr`
+- `EntriesExpr`
+- `EnumFieldType`
+- `EqExpr`
+- `ErrorValue`
+- `EvalContext`
+- `EveryExpr`
+- `ExplainResult`
+- `ExprKind`
+- `ExprNode`
+- `ExprResult`
+- `FailFlow`
+- `FieldExpr`
+- `FieldSpec`
+- `FieldType`
+- `FilterExpr`
+- `FindExpr`
+- `FirstExpr`
+- `FlatExpr`
+- `FloorExpr`
+- `FlowKind`
+- `FlowNode`
+- `FlowPosition`
+- `FlowResult`
+- `FlowState`
+- `FlowStatus`
+- `FromEntriesExpr`
+- `GetExpr`
+- `GteExpr`
+- `GtExpr`
+- `HaltFlow`
+- `HasKeyExpr`
+- `HostContext`
+- `IfExpr`
+- `IfFlow`
+- `IncludesExpr`
+- `IndexOfExpr`
+- `Intent`
+- `IsNullExpr`
+- `KeysExpr`
+- `LastExpr`
+- `LenExpr`
+- `LitExpr`
+- `LteExpr`
+- `LtExpr`
+- `ManifestoCore`
+- `MapExpr`
+- `MaxArrayExpr`
+- `MaxExpr`
+- `MergeExpr`
+- `MergePatch`
+- `MinArrayExpr`
+- `MinExpr`
+- `ModExpr`
+- `MulExpr`
+- `NegExpr`
+- `NeqExpr`
+- `NotExpr`
+- `ObjectExpr`
+- `OmitExpr`
+- `OrExpr`
+- `Patch`
+- `PatchFlow`
+- `PatchOp`
+- `PatchPath`
+- `PatchSegment`
+- `PickExpr`
+- `PowExpr`
+- `PrimitiveFieldType`
+- `ReplaceExpr`
+- `Requirement`
+- `Result`
+- `ReverseExpr`
+- `RoundExpr`
+- `SchemaHashInput`
+- `SchemaHashMode`
+- `SchemaMeta`
+- `SemanticPath`
+- `SeqFlow`
+- `SetPatch`
+- `SliceExpr`
+- `Snapshot`
+- `SnapshotMeta`
+- `SomeExpr`
+- `SplitExpr`
+- `SqrtExpr`
+- `StartsWithExpr`
+- `StateSpec`
+- `StrIncludesExpr`
+- `StrLenExpr`
+- `SubExpr`
+- `SubstringExpr`
+- `SumArrayExpr`
+- `SystemDelta`
+- `SystemState`
+- `ToBooleanExpr`
+- `ToLowerCaseExpr`
+- `ToNumberExpr`
+- `ToStringExpr`
+- `ToUpperCaseExpr`
+- `TraceContext`
+- `TraceGraph`
+- `TraceNode`
+- `TraceNodeKind`
+- `TraceTermination`
+- `TrimExpr`
+- `TypeDefinition`
+- `TypeofExpr`
+- `TypeSpec`
+- `UniqueExpr`
+- `UnsetPatch`
+- `ValidationError`
+- `ValidationResult`
+- `ValuesExpr`
+
+## @manifesto-ai/governance
+
+### @manifesto-ai/governance
+
+_Source: `packages/governance/src/index.ts`_
+
+#### Values
+
+- `createInMemoryGovernanceStore`
+- `createNoopGovernanceEventSink`
+- `withGovernance`
+
+#### Types
+
+- `ActorAuthorityBinding`
+- `ActorId`
+- `ActorKind`
+- `ActorRef`
+- `AuthorityId`
+- `AuthorityKind`
+- `AuthorityPolicy`
+- `AuthorityRef`
+- `DecisionId`
+- `DecisionRecord`
+- `ErrorInfo`
+- `FinalDecision`
+- `GovernanceComposableManifesto`
+- `GovernanceConfig`
+- `GovernanceEvent`
+- `GovernanceEventSink`
+- `GovernanceEventType`
+- `GovernanceExecutionConfig`
+- `GovernanceInstance`
+- `IntentScope`
+- `PolicyCondition`
+- `PolicyRule`
+- `Proposal`
+- `ProposalId`
+- `ProposalStatus`
+- `QuorumRule`
+- `SourceKind`
+- `SourceRef`
+- `SupersedeReason`
+- `Vote`
+- `WaitingFor`
+
+### @manifesto-ai/governance/provider
+
+_Source: `packages/governance/src/provider.ts`_
+
+#### Values
+
+- `AuthorityEvaluator`
+- `AutoApproveHandler`
+- `computeIntentKey`
+- `createAuthorityEvaluator`
+- `createAutoApproveHandler`
+- `createDecisionId`
+- `createExecutionKey`
+- `createGovernanceEventDispatcher`
+- `createGovernanceService`
+- `createHITLHandler`
+- `createInMemoryGovernanceStore`
+- `createIntentInstance`
+- `createIntentInstanceSync`
+- `createNoopGovernanceEventSink`
+- `createPolicyRulesHandler`
+- `createProposalId`
+- `createTribunalHandler`
+- `DECISION_TRANSITION_TARGETS`
+- `defaultExecutionKeyPolicy`
+- `DefaultGovernanceService`
+- `EXECUTION_STAGE_STATUSES`
+- `getValidTransitions`
+- `HITLHandler`
+- `INGRESS_STATUSES`
+- `InMemoryGovernanceStore`
+- `isExecutionStageStatus`
+- `isIngressStatus`
+- `isTerminalStatus`
+- `isValidTransition`
+- `PolicyRulesHandler`
+- `TERMINAL_STATUSES`
+- `toHostIntent`
+- `transitionCreatesDecisionRecord`
+- `TribunalHandler`
+
+#### Types
+
+- `ActorAuthorityBinding`
+- `ActorId`
+- `ActorKind`
+- `ActorRef`
+- `AuthorityHandler`
+- `AuthorityId`
+- `AuthorityKind`
+- `AuthorityPolicy`
+- `AuthorityRef`
+- `CreateGovernanceEventDispatcherOptions`
+- `CreateIntentInstanceOptions`
+- `CustomConditionEvaluator`
+- `DecisionId`
+- `DecisionRecord`
+- `ErrorInfo`
+- `ExecutionKey`
+- `ExecutionKeyContext`
+- `ExecutionKeyPolicy`
+- `FinalDecision`
+- `GovernanceEvent`
+- `GovernanceEventDispatcher`
+- `GovernanceEventSink`
+- `GovernanceEventType`
+- `GovernanceService`
+- `GovernanceStore`
+- `HITLDecisionCallback`
+- `HITLNotificationCallback`
+- `HITLPendingState`
+- `Intent`
+- `IntentBody`
+- `IntentInstance`
+- `IntentOrigin`
+- `IntentScope`
+- `PolicyCondition`
+- `PolicyRule`
+- `PreparedGovernanceCommit`
+- `Proposal`
+- `ProposalId`
+- `ProposalStatus`
+- `QuorumRule`
+- `SourceKind`
+- `SourceRef`
+- `SupersedeReason`
+- `TribunalNotificationCallback`
+- `Vote`
+- `WaitingFor`
+
+## @manifesto-ai/host
+
+### @manifesto-ai/host
+
+_Source: `packages/host/src/index.ts`_
+
+#### Values
+
+- `createApplyPatchesJob`
+- `createContinueComputeJob`
+- `createEffectExecutor`
+- `createEffectRegistry`
+- `createExecutionContext`
+- `createFulfillEffectJob`
+- `createHost`
+- `createHostContextProvider`
+- `createHostError`
+- `createIntent`
+- `createMailbox`
+- `createMailboxManager`
+- `createRunnerState`
+- `createSnapshot`
+- `createStartIntentJob`
+- `createTestHostContextProvider`
+- `DefaultExecutionMailbox`
+- `DefaultHostContextProvider`
+- `defaultRuntime`
+- `EffectExecutor`
+- `EffectHandlerRegistry`
+- `enqueueAndKick`
+- `ExecutionContextImpl`
+- `generateJobId`
+- `getHostState`
+- `getIntentSlot`
+- `handleApplyPatches`
+- `handleContinueCompute`
+- `handleFulfillEffect`
+- `handleStartIntent`
+- `HostError`
+- `isHostError`
+- `isKickPending`
+- `isRunnerActive`
+- `kickRunner`
+- `MailboxManager`
+- `ManifestoHost`
+- `processMailbox`
+- `runJob`
+
+#### Types
+
+- `ApplyPatchesJob`
+- `ComputeResult`
+- `ContinueComputeJob`
+- `DomainSchema`
+- `EffectContext`
+- `EffectErrorInfo`
+- `EffectHandler`
+- `EffectHandlerOptions`
+- `EffectResult`
+- `ExecutionContext`
+- `ExecutionContextImplOptions`
+- `ExecutionContextOptions`
+- `ExecutionKey`
+- `ExecutionMailbox`
+- `FulfillEffectJob`
+- `HostContextProvider`
+- `HostContextProviderOptions`
+- `HostErrorCode`
+- `HostOptions`
+- `HostOwnedState`
+- `HostResult`
+- `Intent`
+- `IntentSlot`
+- `Job`
+- `JobType`
+- `Patch`
+- `RegisteredHandler`
+- `Requirement`
+- `RunnerState`
+- `Runtime`
+- `Snapshot`
+- `StartIntentJob`
+- `TraceEvent`
+- `TraceGraph`
+
+## @manifesto-ai/lineage
+
+### @manifesto-ai/lineage
+
+_Source: `packages/lineage/src/index.ts`_
+
+#### Values
+
+- `createInMemoryLineageStore`
+- `InMemoryLineageStore`
+- `withLineage`
+
+#### Types
+
+- `ArtifactRef`
+- `BranchId`
+- `BranchInfo`
+- `BranchSwitchResult`
+- `LineageConfig`
+- `LineageInstance`
+- `World`
+- `WorldHead`
+- `WorldId`
+- `WorldLineage`
+
+### @manifesto-ai/lineage/provider
+
+_Source: `packages/lineage/src/provider.ts`_
+
+#### Values
+
+- `attachLineageDecoration`
+- `createInMemoryLineageStore`
+- `createLineageRuntimeController`
+- `createLineageService`
+- `DefaultLineageService`
+- `getLineageDecoration`
+- `InMemoryLineageStore`
+
+#### Types
+
+- `AttemptId`
+- `BranchId`
+- `BranchInfo`
+- `BranchSwitchResult`
+- `LineageDecoration`
+- `LineageRuntimeController`
+- `LineageService`
+- `LineageStore`
+- `PersistedPatchDeltaV2`
+- `PreparedBranchBootstrap`
+- `PreparedBranchChange`
+- `PreparedBranchMutation`
+- `PreparedGenesisCommit`
+- `PreparedLineageCommit`
+- `PreparedLineageRecords`
+- `PreparedNextCommit`
+- `ProvenanceRef`
+- `ResolvedLineageConfig`
+- `SealAttempt`
+- `SealedIntentResult`
+- `SealGenesisInput`
+- `SealIntentOptions`
+- `SealNextInput`
+- `SnapshotHashInput`
+- `World`
+- `WorldEdge`
+- `WorldHead`
+- `WorldId`
+- `WorldLineage`
+
+## @manifesto-ai/sdk
+
+### @manifesto-ai/sdk
+
+_Source: `packages/sdk/src/index.ts`_
+
+#### Values
+
+- `AlreadyActivatedError`
+- `CompileError`
+- `createManifesto`
+- `createSnapshot`
+- `DisposedError`
+- `ManifestoError`
+- `ReservedEffectError`
+
+#### Types
+
+- `ActionArgs`
+- `ActionObjectBindingArgs`
+- `ActivatedInstance`
+- `BaseComposableLaws`
+- `BaseLaws`
+- `CanonicalPlatformNamespaces`
+- `CanonicalSnapshot`
+- `CompileDiagnostic`
+- `ComposableManifesto`
+- `ComputedRef`
+- `CoreSnapshot`
+- `CreateIntentArgs`
+- `DispatchBlocker`
+- `DomainSchema`
+- `EffectContext`
+- `EffectHandler`
+- `FieldRef`
+- `GovernanceLaws`
+- `GovernedComposableLaws`
+- `Intent`
+- `IntentExplanation`
+- `LineageComposableLaws`
+- `LineageLaws`
+- `ManifestoBaseInstance`
+- `ManifestoDecoratedRuntimeByLaws`
+- `ManifestoDomainShape`
+- `ManifestoEvent`
+- `ManifestoEventMap`
+- `ManifestoEventPayload`
+- `ManifestoRuntimeByLaws`
+- `Patch`
+- `SchemaGraph`
+- `SchemaGraphEdge`
+- `SchemaGraphEdgeRelation`
+- `SchemaGraphNode`
+- `SchemaGraphNodeId`
+- `SchemaGraphNodeKind`
+- `SchemaGraphNodeRef`
+- `SdkManifest`
+- `Selector`
+- `SimulateResult`
+- `Snapshot`
+- `TypedActionMetadata`
+- `TypedActionRef`
+- `TypedCommitAsync`
+- `TypedCreateIntent`
+- `TypedDispatchAsync`
+- `TypedGetActionMetadata`
+- `TypedGetIntentBlockers`
+- `TypedIntent`
+- `TypedIsIntentDispatchable`
+- `TypedMEL`
+- `TypedOn`
+- `TypedSimulate`
+- `TypedSubscribe`
+- `Unsubscribe`
+
+### @manifesto-ai/sdk/extensions
+
+_Source: `packages/sdk/src/extensions.ts`_
+
+#### Values
+
+- `createSimulationSession`
+- `getExtensionKernel`
+
+#### Types
+
+- `ExtensionKernel`
+- `ExtensionSimulateResult`
+- `SimulationActionRef`
+- `SimulationSession`
+- `SimulationSessionResult`
+- `SimulationSessionStatus`
+- `SimulationSessionStep`
+
+### @manifesto-ai/sdk/provider
+
+_Source: `packages/sdk/src/provider.ts`_
+
+#### Values
+
+- `activateComposable`
+- `assertComposableNotActivated`
+- `attachExtensionKernel`
+- `attachRuntimeKernelFactory`
+- `createRuntimeKernel`
+- `getActivationState`
+- `getRuntimeKernelFactory`
+
+#### Types
+
+- `ActivationState`
+- `HostDispatchOptions`
+- `RuntimeKernel`
+- `RuntimeKernelFactory`
+- `SimulateResult`

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -1,0 +1,57 @@
+# Runtime Instance
+
+> The activated runtime handle is the app-facing semantic boundary.
+
+## Base Runtime Shape
+
+The base runtime returned by `createManifesto(...).activate()` exposes:
+
+| API | Use For |
+|-----|---------|
+| `MEL` | Typed refs for actions, state, and computed values |
+| `schema` | The activated `DomainSchema` |
+| `createIntent(action, ...input)` | Build a typed intent |
+| `dispatchAsync(intent)` | Commit an intent through the base runtime |
+| `getSnapshot()` | Read projected app-facing state |
+| `getCanonicalSnapshot()` | Read the full canonical substrate for persistence/debug tooling |
+| `subscribe(selector, listener)` | React to selected Snapshot values |
+| `getAvailableActions()` | Read action names available in the current Snapshot |
+| `isActionAvailable(name)` | Check coarse action availability |
+| `getActionMetadata(name?)` | Inspect public action contract |
+| `isIntentDispatchable(action, ...input)` | Check a bound-intent gate |
+| `getIntentBlockers(action, ...input)` | Inspect the first failing legality layer |
+| `explainIntent(intent)` / `why(intent)` | Explain availability, dispatchability, or dry-run admission |
+| `whyNot(intent)` | Return blockers, or `null` when admitted |
+| `simulate(action, ...input)` | Dry-run against the current runtime state |
+| `on(event, handler)` | Subscribe to runtime dispatch events |
+| `dispose()` | Release the runtime and stop future dispatch |
+
+## Typical Loop
+
+```typescript
+const app = createManifesto(CounterSchema, {}).activate();
+
+const intent = app.createIntent(app.MEL.actions.increment);
+const next = await app.dispatchAsync(intent);
+
+console.log(next.data.count);
+console.log(app.getAvailableActions());
+```
+
+## Decorated Runtimes
+
+Decorators change the write verb:
+
+| Runtime | Write Verb |
+|---------|------------|
+| Base SDK | `dispatchAsync(intent)` |
+| Lineage runtime | `commitAsync(intent)` |
+| Governed runtime | `proposeAsync(intent)`, then `approve()` / `reject()` when policy requires review |
+
+Use the base runtime until approval, continuity, restore, branch/head history, or sealing is a product requirement.
+
+## Next
+
+- Build intents in [Intents](./intents)
+- Read state in [Snapshots and Subscriptions](./snapshots-and-subscriptions)
+- Inspect action gates in [Actions and Availability](./actions-and-availability)

--- a/docs/api/snapshots-and-subscriptions.md
+++ b/docs/api/snapshots-and-subscriptions.md
@@ -1,0 +1,62 @@
+# Snapshots and Subscriptions
+
+> Snapshot is the visible result of runtime work.
+
+## `getSnapshot()`
+
+Reads the projected app-facing Snapshot.
+
+```typescript
+const snapshot = app.getSnapshot();
+
+console.log(snapshot.data.todos);
+console.log(snapshot.computed.activeCount);
+```
+
+Use this in UI, routes, tools, tests, and agent context builders.
+
+## Dispatch Result
+
+`dispatchAsync(intent)` resolves with the next projected Snapshot.
+
+```typescript
+const next = await app.dispatchAsync(
+  app.createIntent(app.MEL.actions.toggleTodo, "todo-1"),
+);
+
+render(next.data.todos);
+```
+
+## `subscribe(selector, listener)`
+
+Subscribe to a selected Snapshot value.
+
+```typescript
+const unsubscribe = app.subscribe(
+  (snapshot) => snapshot.data.todos,
+  (todos) => {
+    render(todos);
+  },
+);
+
+render(app.getSnapshot().data.todos);
+```
+
+Seed initial UI with `getSnapshot()`. The subscription listener is for later publications.
+
+## `getCanonicalSnapshot()`
+
+Reads the full canonical runtime substrate.
+
+```typescript
+const canonical = app.getCanonicalSnapshot();
+await saveRuntimeSnapshot(canonical);
+```
+
+Use this for restore/persistence, seal-aware tooling, Studio overlays, and deep debugging. Prefer `getSnapshot()` for normal application rendering.
+
+## Next
+
+- Connect state to React in [React](/integration/react)
+- Read [Snapshot](/concepts/snapshot)
+- Debug canonical state in [Debugging](/guides/debugging)

--- a/docs/guide/essentials/actions-and-intents.md
+++ b/docs/guide/essentials/actions-and-intents.md
@@ -1,0 +1,50 @@
+# Actions and Intents
+
+> An action describes a transition; an intent requests that transition.
+
+Define actions in MEL. In TypeScript, create typed intents from `app.MEL.actions.*` and dispatch them.
+
+## Define an Action
+
+```mel
+domain Counter {
+  state {
+    count: number = 0
+  }
+
+  action add(amount: number) {
+    onceIntent {
+      patch count = add(count, amount)
+    }
+  }
+}
+```
+
+## Create and Dispatch an Intent
+
+```typescript
+const intent = app.createIntent(app.MEL.actions.add, 3);
+
+const snapshot = await app.dispatchAsync(intent);
+console.log(snapshot.data.count);
+```
+
+`dispatchAsync()` resolves with the next terminal Snapshot. The requested change does not return through a hidden side channel.
+
+## Object-Style Binding
+
+When it is clearer for your app code, use the keyed form:
+
+```typescript
+await app.dispatchAsync(
+  app.createIntent(app.MEL.actions.add, { amount: 3 }),
+);
+```
+
+## Common Mistake
+
+Do not dispatch raw string action names as your app-facing contract. Prefer `app.createIntent(app.MEL.actions.someAction, input)`.
+
+## Next
+
+Learn what the dispatch result contains in [Reading Snapshots](./reading-snapshots). For deeper intent semantics, read [Intent](/concepts/intent).

--- a/docs/guide/essentials/availability.md
+++ b/docs/guide/essentials/availability.md
@@ -1,0 +1,47 @@
+# Availability
+
+> Availability is the state-based precondition for an action.
+
+Use `available when` when an action should only be available in some current domain states.
+
+## Gate an Action
+
+```mel
+domain Counter {
+  state {
+    count: number = 0
+  }
+
+  computed canDecrement = gt(count, 0)
+
+  action decrement() available when canDecrement {
+    onceIntent {
+      patch count = sub(count, 1)
+    }
+  }
+}
+```
+
+`available when` reads current state and computed values. It is a good fit for rules like “only decrement above zero” or “only submit when the form is valid.”
+
+## Keep Input-Specific Gates Separate
+
+```mel
+action shoot(cellIndex: number)
+  available when gameIsRunning
+  dispatchable when eq(at(cells, cellIndex), "unknown") {
+  onceIntent {
+    patch cells = updateAt(cells, cellIndex, "pending")
+  }
+}
+```
+
+Use `dispatchable when` for bound-intent checks that need the action parameters. Treat it as the next step after `available when` is comfortable.
+
+## Common Mistake
+
+Do not reference action parameters in `available when`. If the gate depends on the specific submitted input, use `dispatchable when` and confirm the current MEL reference.
+
+## Next
+
+Put the essential pieces together in [Building a Todo App](./todo-app). For exact syntax, read the [MEL Syntax Cookbook](/mel/SYNTAX#available-when-precondition).

--- a/docs/guide/essentials/computed-values.md
+++ b/docs/guide/essentials/computed-values.md
@@ -1,0 +1,47 @@
+# Computed Values
+
+> Computed values are derived from current state and read from Snapshot.
+
+Use `computed` for values that can be recalculated from `state`: counts, booleans, labels, totals, and UI-ready summaries.
+
+## Declare Computed Values
+
+```mel
+domain Counter {
+  state {
+    count: number = 0
+  }
+
+  computed doubled = mul(count, 2)
+  computed canDecrement = gt(count, 0)
+}
+```
+
+Computed values are not separate storage. They describe how to derive a value from the current domain state.
+
+## Read Them in TypeScript
+
+```typescript
+const snapshot = app.getSnapshot();
+
+console.log(snapshot.computed.doubled);
+console.log(snapshot.computed.canDecrement);
+```
+
+## Use Them in the Domain
+
+```mel
+action decrement() available when canDecrement {
+  onceIntent {
+    patch count = sub(count, 1)
+  }
+}
+```
+
+## Common Mistake
+
+Do not patch a computed value. If the value must be stored, put it in `state`. If it can be derived, keep it in `computed`.
+
+## Next
+
+Learn how callers request transitions in [Actions and Intents](./actions-and-intents).

--- a/docs/guide/essentials/creating-an-app.md
+++ b/docs/guide/essentials/creating-an-app.md
@@ -1,0 +1,51 @@
+# Creating an App
+
+> Create an activated runtime from a MEL domain.
+
+A Manifesto app starts as a composable manifesto and becomes runnable after `activate()`.
+
+## The App Shape
+
+```typescript
+import { createManifesto } from "@manifesto-ai/sdk";
+import CounterSchema from "./counter.mel";
+
+const app = createManifesto(CounterSchema, {}).activate();
+```
+
+`app` is the base runtime handle. It can create intents, dispatch them, publish snapshots, notify subscribers, and clean itself up.
+
+## Schema and Effects
+
+The first argument is your domain schema. The second argument is the effect handler map.
+
+```typescript
+const app = createManifesto(UserProfileSchema, {
+  "api.fetchUser": async (params) => {
+    return [
+      { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
+    ];
+  },
+}).activate();
+```
+
+Pass `{}` when the domain does not declare external effects.
+
+## The Minimal Loop
+
+```typescript
+const snapshot = await app.dispatchAsync(
+  app.createIntent(app.MEL.actions.increment),
+);
+
+console.log(snapshot.data.count);
+app.dispose();
+```
+
+## Common Mistake
+
+`createManifesto()` does not expose runtime verbs by itself. Call `activate()` before using `createIntent()`, `dispatchAsync()`, `subscribe()`, or `getSnapshot()`.
+
+## Next
+
+Learn the domain file in [MEL Domain Basics](./mel-domain-basics), or walk through the longer [first app tutorial](/tutorial/01-your-first-app).

--- a/docs/guide/essentials/effects.md
+++ b/docs/guide/essentials/effects.md
@@ -1,0 +1,89 @@
+# Effects
+
+> Effects declare external work; effect handlers fulfill it and return patches.
+
+Core does not fetch, write databases, call APIs, or send messages. A MEL action declares an effect requirement, then the activated runtime calls the handler you registered.
+
+## Declare an Effect
+
+```mel
+domain UserProfile {
+  state {
+    userName: string? = null
+    loading: boolean = false
+  }
+
+  action fetchUser(id: string) {
+    onceIntent {
+      patch loading = true
+      effect api.fetchUser({ id: id })
+    }
+  }
+}
+```
+
+The effect type is the name after `effect`. In this example, the type is `api.fetchUser`.
+
+## Which Effect Should I Use?
+
+| Need | Use | Runtime Behavior |
+|------|-----|------------------|
+| Call an API, database, queue, storage layer, or model | your own named effect such as `api.fetchUser`, `db.saveTodo`, `agent.summarize` | Register a TypeScript handler with the same effect type |
+| Update each item in an array from existing Snapshot data | `effect array.map({ source, select, into })` | Pure runtime transform; no network handler |
+| Keep only matching array items from existing Snapshot data | `effect array.filter({ source, where, into })` | Pure runtime transform; no network handler |
+
+Start with a named effect when the work crosses a process boundary. Start with `array.map` or `array.filter` when you are transforming an array already in Snapshot.
+
+## Register a Handler
+
+```typescript
+const app = createManifesto(UserProfileSchema, {
+  "api.fetchUser": async (params) => {
+    const { id } = params as { id: string };
+    const user = await fetchUser(id);
+
+    return [
+      { op: "set", path: [{ kind: "prop", name: "userName" }], value: user.name },
+      { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
+    ];
+  },
+}).activate();
+```
+
+Handlers return patches. The next Snapshot carries the visible result.
+
+## Patch Ops Returned by Handlers
+
+Effect handlers return `Patch[]`. Use the smallest patch that describes the visible result:
+
+| Patch op | Use When | Example |
+|----------|----------|---------|
+| `set` | Replace a value, or create it when missing | `{ op: "set", path: [{ kind: "prop", name: "userName" }], value: "Ada" }` |
+| `unset` | Remove a property from domain state | `{ op: "unset", path: [{ kind: "prop", name: "error" }] }` |
+| `merge` | Shallow-merge fields into an object | `{ op: "merge", path: [{ kind: "prop", name: "profile" }], value: { name: "Ada" } }` |
+
+If a handler fetches data, patch the fetched data into domain state. If the UI needs `loading`, `error`, `saved`, or retry context, patch those fields too.
+
+## Array Transform Example
+
+```mel
+action completeTodo(id: string) {
+  onceIntent {
+    effect array.map({
+      source: todos,
+      select: if(eq($item.id, id), merge($item, { completed: true }), $item),
+      into: todos
+    })
+  }
+}
+```
+
+Use `$item` inside `select` or `where` to refer to the current array item.
+
+## Common Mistake
+
+Do not `return user` from the handler. Return precise patches for the domain state that should change.
+
+## Next
+
+Learn how to expose or hide actions with [Availability](./availability). For a deeper handler guide, read [Effect Handlers](/guides/effect-handlers). For the broader MEL effect reference, read [MEL Syntax: Effects](/mel/SYNTAX#effects).

--- a/docs/guide/essentials/mel-domain-basics.md
+++ b/docs/guide/essentials/mel-domain-basics.md
@@ -1,0 +1,56 @@
+# MEL Domain Basics
+
+> A MEL domain names your state, derived values, and allowed actions.
+
+MEL is the authoring format for Manifesto domains. It compiles to schema data that the runtime can compute deterministically.
+
+## A Small Domain
+
+```mel
+domain Counter {
+  type Label = {
+    text: string
+  }
+
+  state {
+    count: number = 0
+    label: Label = { text: "Counter" }
+  }
+
+  computed doubled = mul(count, 2)
+
+  action increment() {
+    onceIntent {
+      patch count = add(count, 1)
+    }
+  }
+}
+```
+
+## What Each Part Means
+
+| Part | Purpose |
+|------|---------|
+| `domain Counter` | Names the domain model |
+| `type Label` | Defines a reusable MEL type |
+| `state` | Declares source-of-truth data and defaults |
+| `computed` | Declares values derived from current state |
+| `action` | Declares a typed transition that callers can request |
+| `onceIntent` | Makes the action body run once for one dispatched intent |
+| `patch` | Writes the next state through the runtime |
+
+## In Your App
+
+```typescript
+import CounterSchema from "./counter.mel";
+
+const app = createManifesto(CounterSchema, {}).activate();
+```
+
+## Common Mistake
+
+MEL is not executed like JavaScript. It defines the semantic model. TypeScript code activates that model, creates intents, and reads Snapshots.
+
+## Next
+
+Learn what belongs in [State](./state), then what belongs in [Computed Values](./computed-values). For full syntax, use the [MEL Reference](/mel/REFERENCE).

--- a/docs/guide/essentials/reading-snapshots.md
+++ b/docs/guide/essentials/reading-snapshots.md
@@ -1,0 +1,46 @@
+# Reading Snapshots
+
+> Snapshot is the visible result after runtime work completes.
+
+In ordinary SDK apps, use `getSnapshot()` for the current published read model and use the value returned by `dispatchAsync()` for the newly published result.
+
+## Read the Current Snapshot
+
+```typescript
+const snapshot = app.getSnapshot();
+
+console.log(snapshot.data);
+console.log(snapshot.computed);
+console.log(snapshot.system.lastError);
+```
+
+## Read the Dispatch Result
+
+```typescript
+const nextSnapshot = await app.dispatchAsync(
+  app.createIntent(app.MEL.actions.increment),
+);
+
+console.log(nextSnapshot.data.count);
+```
+
+The intent is the request. The snapshot is the result.
+
+## Data and Computed
+
+```typescript
+const snapshot = app.getSnapshot();
+
+const count = snapshot.data.count;
+const doubled = snapshot.computed.doubled;
+```
+
+`data` contains domain state. `computed` contains public derived values.
+
+## Common Mistake
+
+Do not expect an effect handler or action to return a separate payload from `dispatchAsync()`. Make the visible result part of the next Snapshot.
+
+## Next
+
+Learn how to react to later publications with [Subscriptions](./subscriptions). For the canonical/projected split, read [Snapshot](/concepts/snapshot).

--- a/docs/guide/essentials/state.md
+++ b/docs/guide/essentials/state.md
@@ -1,0 +1,55 @@
+# State
+
+> State is the source-of-truth domain data stored in Snapshot.
+
+Use `state` for values that must survive from one transition to the next: records, selected ids, form fields, status flags, and domain collections.
+
+## Declare State in MEL
+
+```mel
+domain TodoApp {
+  type Todo = {
+    id: string,
+    title: string,
+    completed: boolean
+  }
+
+  state {
+    todos: Array<Todo> = []
+    filter: "all" | "active" | "completed" = "all"
+    selectedTodoId: string? = null
+  }
+}
+```
+
+## Read State in TypeScript
+
+```typescript
+const snapshot = app.getSnapshot();
+
+console.log(snapshot.data.todos);
+console.log(snapshot.data.filter);
+console.log(snapshot.data.selectedTodoId);
+```
+
+Application code reads state through `snapshot.data`.
+
+## Change State with Actions
+
+```mel
+action setFilter(nextFilter: string) {
+  onceIntent {
+    patch filter = nextFilter
+  }
+}
+```
+
+State changes happen through patches declared by the domain, or through patches returned by effect handlers.
+
+## Common Mistake
+
+Do not mutate `snapshot.data` in UI, server, or agent code. A snapshot is the read result. To request change, create an intent and dispatch it.
+
+## Next
+
+Move derived labels, totals, and flags into [Computed Values](./computed-values).

--- a/docs/guide/essentials/subscriptions.md
+++ b/docs/guide/essentials/subscriptions.md
@@ -1,0 +1,48 @@
+# Subscriptions
+
+> Subscriptions run a listener when a selected Snapshot value changes.
+
+Use `subscribe(selector, listener)` when UI, logs, scripts, or integrations need to react to published runtime state.
+
+## Subscribe to a Slice
+
+```typescript
+const unsubscribe = app.subscribe(
+  (snapshot) => snapshot.data.count,
+  (count) => {
+    console.log("Count changed:", count);
+  },
+);
+```
+
+The selector receives each published Snapshot. The listener receives the selected value.
+
+## Seed the Initial Render
+
+```typescript
+render(app.getSnapshot());
+
+const unsubscribe = app.subscribe(
+  (snapshot) => snapshot,
+  (snapshot) => render(snapshot),
+);
+```
+
+`subscribe()` observes later publications. Read `getSnapshot()` once when you also need the current value immediately.
+
+## Clean Up
+
+```typescript
+unsubscribe();
+app.dispose();
+```
+
+Unsubscribe when the consumer is gone. Dispose the runtime when the app-owned runtime lifetime ends.
+
+## Common Mistake
+
+Do not subscribe to the whole snapshot when one field is enough. A focused selector makes update behavior easier to explain.
+
+## Next
+
+Learn how Manifesto connects to external systems in [Effects](./effects).

--- a/docs/guide/essentials/todo-app.md
+++ b/docs/guide/essentials/todo-app.md
@@ -1,0 +1,62 @@
+# Building a Todo App
+
+> A small app is one MEL domain plus one activated runtime plus one presentation layer.
+
+This page is a map of the pieces. For the full hands-on walkthrough, use [Building a Todo App](/tutorial/04-todo-app).
+
+## Domain
+
+```mel
+domain TodoApp {
+  type Todo = {
+    id: string,
+    title: string,
+    completed: boolean
+  }
+
+  state {
+    todos: Array<Todo> = []
+  }
+
+  computed totalCount = len(todos)
+
+  action addTodo(title: string, id: string) {
+    onceIntent {
+      patch todos = append(todos, {
+        id: id,
+        title: title,
+        completed: false
+      })
+    }
+  }
+}
+```
+
+## Runtime
+
+```typescript
+export const app = createManifesto(TodoAppSchema, {}).activate();
+
+await app.dispatchAsync(
+  app.createIntent(app.MEL.actions.addTodo, "Write a domain", crypto.randomUUID()),
+);
+```
+
+## Presentation
+
+```typescript
+function renderTodos() {
+  const snapshot = app.getSnapshot();
+  console.log(snapshot.data.todos);
+  console.log(snapshot.computed.totalCount);
+}
+
+renderTodos();
+app.subscribe((snapshot) => snapshot.data.todos, renderTodos);
+```
+
+Keep framework code outside MEL. The same domain can sit behind React, a backend route, a CLI, or an agent turn.
+
+## Next
+
+Try the [hands-on todo tutorial](/tutorial/04-todo-app), then choose an [Integration](/integration/react) or continue to the [In-Depth shared semantic model](/concepts/shared-semantic-model).

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,0 +1,49 @@
+# Introduction
+
+> Manifesto is a semantic layer for deterministic domain state.
+
+Manifesto lets you define a domain once in MEL, run that domain through the SDK, and expose the same semantics to frontend code, backend services, and agents.
+
+It is not a state management library, an AI framework, a database, or a workflow engine. It is the semantic model underneath those surfaces.
+
+## Why Manifesto?
+
+### Deterministic by design
+
+Core computation is pure. Effects are explicit declarations. Given the same schema, snapshot, and intent, Manifesto computes the same transition.
+
+### Frontend, backend, and agents
+
+UI components, server routes, scripts, jobs, and agents can all submit typed intents against the same domain model.
+
+You do not need one state contract for UI, another for automation, and another for audit.
+
+### Snapshot-first state
+
+Dispatch an intent, then observe the next Snapshot. Effect results also return as patches into Snapshot.
+
+That keeps the visible result in one place.
+
+## The Base Runtime Path
+
+Start here:
+
+```text
+MEL domain -> createManifesto() -> activate() -> createIntent() -> dispatchAsync() -> Snapshot
+```
+
+The base SDK runtime is the normal app path. It is the right default for learning, UI integration, backend routes, scripts, and trusted agent turns.
+
+## Add Governance Later
+
+When writes need review, branch continuity, explicit actor identity, or sealed history, compose the same manifesto before activation:
+
+```text
+createManifesto() -> withLineage() -> withGovernance() -> activate()
+```
+
+Governance and lineage add legitimacy and continuity around the same semantic core. They are not prerequisites for your first app.
+
+## Next
+
+Start with [Quick Start](./quick-start), then continue through [First App](/tutorial/01-your-first-app) and [Actions and State](/tutorial/02-actions-and-state).

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,4 +1,4 @@
-# Quickstart
+# Quick Start
 
 > Get one base-runtime app running in a few minutes.
 
@@ -42,19 +42,19 @@ export default defineConfig({
 });
 ```
 
-::: tip Other bundlers?
-Next.js, Webpack, Rollup, esbuild, and Rspack are all supported. See [Bundler Setup](/guides/bundler-setup), or run `manifesto integrate`.
-:::
+Other bundlers are covered in [Bundler Setup](/guides/bundler-setup), or can be wired with `manifesto integrate`.
 
-## Create Your First App
+## Define Your Domain
 
-### 1. Define the domain
+Create `counter.mel`:
 
 ```mel
 domain Counter {
   state {
     count: number = 0
   }
+
+  computed doubled = mul(count, 2)
 
   action increment() {
     onceIntent {
@@ -64,36 +64,31 @@ domain Counter {
 }
 ```
 
-### 2. Activate and run
+## Run It In Your App
 
 ```typescript
 import { createManifesto } from "@manifesto-ai/sdk";
-import CounterMel from "./counter.mel";
+import CounterSchema from "./counter.mel";
 
-const instance = createManifesto(CounterMel, {}).activate();
+const app = createManifesto(CounterSchema, {}).activate();
 
-await instance.dispatchAsync(
-  instance.createIntent(instance.MEL.actions.increment),
+await app.dispatchAsync(
+  app.createIntent(app.MEL.actions.increment),
 );
-console.log(instance.getSnapshot().data.count); // 1
 
-await instance.dispatchAsync(
-  instance.createIntent(instance.MEL.actions.increment),
-);
-console.log(instance.getSnapshot().data.count); // 2
+const snapshot = app.getSnapshot();
+console.log(snapshot.data.count);       // 1
+console.log(snapshot.computed.doubled); // 2
 ```
 
 ## What Just Happened?
 
-- MEL defined the state and action semantics.
-- `createManifesto()` created a composable manifesto.
-- `activate()` opened the runtime surface.
-- `createIntent()` built a typed intent from the MEL action.
-- `dispatchAsync()` executed that intent and resolved after the next terminal snapshot was published.
+- MEL declared domain state, derived values, and an action.
+- `createManifesto()` created a composable manifesto from the schema.
+- `activate()` opened the base runtime surface.
+- `createIntent()` built a typed request from `MEL.actions.increment`.
+- `dispatchAsync()` published the next terminal Snapshot.
 
-## Next Step
+## Next
 
-1. Continue with the [Tutorial](/tutorial/) for the normal learning path.
-2. Use [Bundler Setup](/guides/bundler-setup) only if you are not on Vite.
-3. Use [Developer Tooling](/guides/developer-tooling) when you want CLI, editor, Studio, or AI-tool setup.
-4. Use [When You Need Approval or History](/guides/approval-and-history) only if the project later needs review, audit history, or sealing.
+Continue to [Creating an App](./essentials/creating-an-app), or jump to [React](/integration/react), [AI Agents](/integration/ai-agents), or [API Reference](/api/) if you already know what you need.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,74 +4,56 @@ layout: home
 hero:
   name: Manifesto
   text: Semantic Layer for Deterministic Domain State
-  tagline: Define meaning once, then ship runtime, editor, agent, and inspection surfaces from the same MEL schema.
+  tagline: Define your domain once in MEL, then run it, inspect it, and extend it from the same schema.
   actions:
     - theme: brand
-      text: Start Building
-      link: /quickstart
+      text: Get Started
+      link: /guide/quick-start
     - theme: alt
-      text: Tooling Setup
-      link: /guides/developer-tooling
+      text: Learn the Model
+      link: /guide/introduction
 
 features:
   - icon: 🎯
-    title: Deterministic
-    details: Same input -> same output. Always.
-  - icon: 🧭
-    title: Expandable
-    details: Start with the base runtime, then add approval and sealed history only when you need them.
-  - icon: 📐
-    title: Schema-First
-    details: MEL and DomainSchema stay at the center of every surface.
-  - icon: 🛠️
-    title: Toolable
-    details: CLI, LSP, Studio, and agent tooling all derive from the same model.
-  - icon: ⚡
-    title: Effect Isolation
-    details: Pure computation stays separate from IO.
+    title: Deterministic by Design
+    details: Pure compute, explicit effects, and the same state transition for the same input.
+  - icon: 🧩
+    title: Frontend, Backend, and Agents
+    details: Use the same domain model to power UI, backend services, and agent workflows without redefining semantics for each surface.
+  - icon: 📸
+    title: Snapshot-First State
+    details: The next snapshot is the visible result. No hidden channels, no side-effect return path.
 ---
-
-## Build Your First App
-
-Most teams should start with the base runtime and stay there until review or history becomes a real requirement.
-
-1. Read [Quickstart](/quickstart) to get one app running.
-2. Continue to the [Tutorial](/tutorial/) to learn the base runtime properly.
-3. Use [Guides](/guides/) only when you hit a concrete problem.
-
-Start with `@manifesto-ai/sdk` and `@manifesto-ai/compiler`. Add Lineage or Governance only later.
-
-## Add Only What You Need Later
-
-| Need | Go Here | Why |
-|------|---------|-----|
-| Set up CLI, editor, AI, or Studio workflows | [Developer Tooling](/guides/developer-tooling) | Add surrounding DX without changing the runtime path |
-| Add approval, review, or sealed history | [When You Need Approval or History](/guides/approval-and-history) | Escalate from direct dispatch only when the project needs it |
-| Look up a package you already know | [API Reference](/api/) | Use package docs as lookup, not onboarding |
-| Understand the model more deeply | [Concepts](/concepts/), [Architecture](/architecture/), [Internals](/internals/) | Deep-dive material after the app path feels normal |
 
 ## Quick Example
 
+### First, define your domain in MEL:
 ```mel
 domain Counter {
-  state { count: number = 0 }
+  state {
+    count: number = 0
+  }
+
+  computed doubled = mul(count, 2)
+
   action increment() {
-    onceIntent { patch count = add(count, 1) }
+    onceIntent {
+      patch count = add(count, 1)
+    }
   }
 }
 ```
 
+### Then, run it in your app:
 ```typescript
 import { createManifesto } from "@manifesto-ai/sdk";
 import CounterSchema from "./counter.mel";
 
 const app = createManifesto(CounterSchema, {}).activate();
 await app.dispatchAsync(app.createIntent(app.MEL.actions.increment));
-console.log(app.getSnapshot().data.count); // 1
+
+console.log(app.getSnapshot().data.count);        // 1
+console.log(app.getSnapshot().computed.doubled);  // 2
 ```
 
-## Keep These Defaults
-
-- Build the first app before reading package reference pages front-to-back.
-- Treat direct dispatch and projected `getSnapshot()` reads as the default mental model.
-- Add tooling, approval/history, and deep-dive docs only when the app path already feels concrete.
+Start with [Quick Start](/guide/quick-start). Use the [Guide](/guide/introduction) to learn the runtime step by step, or jump to the [API Reference](/api/) if you already know the package you need.

--- a/docs/integration/ai-agents.md
+++ b/docs/integration/ai-agents.md
@@ -1,171 +1,283 @@
 # AI Agent Integration
 
-> Let an agent choose the next change, then route that change through the base runtime first and escalate only when writes need review or audit history.
+> Let agents see the current Snapshot, see the actions that are available now, and submit domain changes through the runtime.
 >
-> **Current Contract Note:** This page describes the current activation-first SDK surface and the current Lineage/Governance decorator runtime surface. SDK snapshots follow the current Core v4.2.0 contract and no longer expose accumulated `system.errors`.
+> **Current Contract Note:** This page uses the activation-first SDK surface: activate a `createManifesto(...)` app, then call `getSnapshot`, `getAvailableActions`, `getActionMetadata`, `createIntent`, and `dispatchAsync`. Governed examples use the current `withLineage(...) -> withGovernance(...) -> activate()` surface.
 
----
+An agent should not guess your domain API from prompt text. It should read the current state, read the currently legal actions, call an app-owned tool, and receive a Snapshot view back.
 
-## Two Agent Paths
-
-Manifesto supports two stable agent patterns:
-
-1. direct-dispatch agent turns
-2. governed proposal turns
-
-Use direct dispatch when the agent is operating inside a trusted app session and does not need approval. Escalate to reviewable proposals only when the action needs legitimacy, actor tracking, or branch history.
-
-## Agent Tooling Stack
-
-Current agent-facing DX is split across three packages:
-
-- [`@manifesto-ai/skills`](/api/skills) installs current Manifesto guidance into Codex, Claude Code, Cursor, Copilot, and Windsurf
-- [`@manifesto-ai/mel-lsp`](/api/mel-lsp) adds MEL diagnostics plus `mel/schemaIntrospection` and `mel/actionSignatures`
-- [`@manifesto-ai/studio-mcp`](/api/studio-mcp) exposes graph, findings, availability, trace, lineage, and governance over MCP
-
-Use `skills` for prompt context, `mel-lsp` for authoring-time schema awareness, and `studio-mcp` when an agent needs read-only inspection tools against a concrete domain.
-
-If you use Codex and want Manifesto-specific guidance loaded into the agent session, install `@manifesto-ai/skills` separately and run its explicit Codex setup command.
-
-If you are still deciding whether the agent really needs approval or history, read [When You Need Approval or History](/guides/approval-and-history) before adopting the advanced runtime.
-
----
-
-## 1. Direct-Dispatch Agent Path
-
-```typescript
-import { createManifesto } from "@manifesto-ai/sdk";
-
-const instance = createManifesto(todoSchema, effects).activate();
-
-const snapshot = await instance.dispatchAsync(
-  instance.createIntent(
-    instance.MEL.actions.addTodo,
-    "Agent-authored task",
-  ),
-);
+```text
+Snapshot + getAvailableActions()
+  -> agent context for this step
+  -> model chooses a stable app-owned tool
+  -> tool re-reads runtime availability
+  -> tool creates a typed Manifesto Intent
+  -> runtime dispatches or proposes
+  -> fresh context returns for the next step
 ```
 
-This path is appropriate when the agent is already trusted to act on the current Snapshot and the app does not need proposal review.
+This guide uses a Todo app. Build that domain first in [Building a Todo App](/guide/essentials/todo-app).
+
+The examples assume action-level gates are modeled with MEL `available when`. `getAvailableActions()` reflects those current-snapshot action gates. Bound-input checks still belong to `dispatchable when`, `whyNot()`, or the final runtime dispatch.
 
 ---
 
-## 2. Optional Proposal Path
+## 1. Give The Agent Runtime Context
 
-When the agent genuinely needs explicit approval or audit history, compose Governance and Lineage first, then submit a proposal from the activated runtime.
+`getSnapshot()` tells the agent what is true. `getAvailableActions()` tells the agent what the domain allows now.
+
+```typescript
+import { app } from "./manifesto-app";
+
+export function readAgentContext() {
+  const snapshot = app.getSnapshot();
+  const availableActionNames = app.getAvailableActions();
+
+  return {
+    data: snapshot.data,
+    computed: snapshot.computed,
+    availableActions: availableActionNames.map((name) =>
+      app.getActionMetadata(name),
+    ),
+  };
+}
+```
+
+This is the agent's starting point: state plus the runtime's current public action contract. Do not maintain a parallel "actions the agent may call" list in prompt text.
+
+---
+
+## 2. Map Runtime Actions To Tools
+
+Start with app-owned tools. Each writer creates a typed Manifesto Intent.
+
+```typescript
+import { tool } from "ai";
+import { z } from "zod";
+
+import { app } from "./manifesto-app";
+import { readAgentContext } from "./agent-context";
+
+function isAvailable(actionName: "addTodo" | "clearCompleted") {
+  return app.getAvailableActions().includes(actionName);
+}
+
+function unavailable(actionName: "addTodo" | "clearCompleted") {
+  return {
+    status: "blocked" as const,
+    reason: `${actionName} is not available in the current Snapshot.`,
+    context: readAgentContext(),
+  };
+}
+
+export const todoTools = {
+  readTodoContext: tool({
+    description: "Read Todo Snapshot data, computed values, and available actions.",
+    inputSchema: z.object({}),
+    execute: async () => readAgentContext(),
+  }),
+
+  addTodo: tool({
+    description: "Add one todo through the Manifesto runtime.",
+    inputSchema: z.object({ title: z.string().min(1) }),
+    execute: async ({ title }) => {
+      if (!isAvailable("addTodo")) {
+        return unavailable("addTodo");
+      }
+
+      await app.dispatchAsync(
+        app.createIntent(app.MEL.actions.addTodo, title),
+      );
+
+      return {
+        status: "dispatched" as const,
+        context: readAgentContext(),
+      };
+    },
+  }),
+
+  clearCompleted: tool({
+    description: "Clear completed todos when the action is available.",
+    inputSchema: z.object({}),
+    execute: async () => {
+      if (!isAvailable("clearCompleted")) {
+        return unavailable("clearCompleted");
+      }
+
+      await app.dispatchAsync(
+        app.createIntent(app.MEL.actions.clearCompleted),
+      );
+
+      return {
+        status: "dispatched" as const,
+        context: readAgentContext(),
+      };
+    },
+  }),
+};
+```
+
+Keep tool results fresh. A multi-step agent should receive updated `availableActions` after every tool call: read context, write, read the context returned by that write, decide the next tool.
+
+Do not cache `getAvailableActions()` for a whole agent turn. It is a read against the current Snapshot; every dispatch or approved proposal can change it.
+The runtime still checks again during dispatch, so a stale agent step cannot force an unavailable action through.
+
+---
+
+## 3. Run A Multi-Step AI SDK Turn
+
+Pass the current context to the model. Pass stable tools that re-check runtime availability during `execute`.
+
+```typescript
+import { openai } from "@ai-sdk/openai";
+import { generateText, stepCountIs } from "ai";
+
+import { readAgentContext } from "./agent-context";
+import { todoTools } from "./todo-agent-tools";
+
+export async function runTodoAgent(prompt: string) {
+  const context = readAgentContext();
+
+  return generateText({
+    model: openai("gpt-5.2"),
+    system:
+      "You are a Todo agent. Use the provided context and tools. " +
+      "Tool results include fresh Manifesto context. " +
+      "Check availableActions after each write. " +
+      "Do not claim a write happened unless a tool returns status='dispatched'.",
+    prompt: JSON.stringify({
+      userRequest: prompt,
+      manifestoContext: context,
+    }, null, 2),
+    tools: todoTools,
+    stopWhen: stepCountIs(4),
+  });
+}
+```
+
+The same pattern fits a backend route, worker, CLI, MCP server, or another agent framework. Keep the binding small: model loop outside, domain transition inside Manifesto.
+
+---
+
+## 4. Add HITL With Governance
+
+When the agent's writes need review, swap the activated runtime. The MEL domain and typed action refs stay the same.
 
 ```typescript
 import { createManifesto } from "@manifesto-ai/sdk";
 import { createInMemoryLineageStore, withLineage } from "@manifesto-ai/lineage";
-import { createInMemoryGovernanceStore, withGovernance } from "@manifesto-ai/governance";
+import {
+  createInMemoryGovernanceStore,
+  withGovernance,
+} from "@manifesto-ai/governance";
 
-const agentRuntime = withGovernance(
-  withLineage(createManifesto(todoSchema, effects), {
+export const app = withGovernance(
+  withLineage(createManifesto(todoSchema, {}), {
     store: createInMemoryLineageStore(),
   }),
   {
     governanceStore: createInMemoryGovernanceStore(),
     bindings: [
       {
-        actorId: "actor:agent",
-        authorityId: "authority:auto",
-        policy: { mode: "auto_approve" },
+        actorId: "actor:todo-agent",
+        authorityId: "authority:human-reviewer",
+        policy: {
+          mode: "hitl",
+          delegate: {
+            actorId: "actor:reviewer",
+            kind: "human",
+            name: "Reviewer",
+          },
+        },
       },
     ],
     execution: {
       projectionId: "todo-agent",
-      deriveActor: () => ({ actorId: "actor:agent", kind: "agent" }),
-      deriveSource: () => ({ kind: "agent", eventId: crypto.randomUUID() }),
+      deriveActor: () => ({ actorId: "actor:todo-agent", kind: "agent" }),
+      deriveSource: (intent) => ({ kind: "agent", eventId: intent.intentId }),
     },
   },
 ).activate();
-
-const proposal = await agentRuntime.proposeAsync(
-  agentRuntime.createIntent(
-    agentRuntime.MEL.actions.addTodo,
-    "Agent-authored task",
-  ),
-);
 ```
 
-From there, the agent can submit the proposal for approval, wait for authority resolution, and let the advanced runtime seal the result.
-
----
-
-## When To Propose Versus Route Directly
-
-| Use Direct Dispatch When | Use Governance When |
-|--------------------------|---------------------|
-| The action is routine and local | The action needs approval or review |
-| The agent is acting inside a trusted session | The agent may affect other users or branches |
-| The result can be observed from Snapshot only | You need proposal history or legitimacy records |
-| Latency matters more than audit structure | Auditability matters more than the shortest path |
-
-If the agent is deciding between candidate writes but does not need a formal review, direct dispatch is usually enough.
-
----
-
-## 3. Keep The Translator Boundary Clean
-
-If you use a translator or planner, treat its output as an intent candidate, not as a state mutation.
+Now writer tools propose instead of dispatching.
 
 ```typescript
-type AgentCommand =
-  | { kind: "addTodo"; title: string }
-  | { kind: "toggleTodo"; id: string };
+const addTodoForReview = tool({
+  description: "Propose a todo. A human reviewer must approve before it changes state.",
+  inputSchema: z.object({ title: z.string().min(1) }),
+  execute: async ({ title }) => {
+    const proposal = await app.proposeAsync(
+      app.createIntent(app.MEL.actions.addTodo, title),
+    );
 
-async function runAgentTurn(command: AgentCommand) {
-  switch (command.kind) {
-    case "addTodo":
-      return instance.dispatchAsync(
-        instance.createIntent(instance.MEL.actions.addTodo, command.title),
-      );
-    case "toggleTodo":
-      return instance.dispatchAsync(
-        instance.createIntent(instance.MEL.actions.toggleTodo, command.id),
-      );
-  }
+    if (proposal.status === "evaluating") {
+      return {
+        status: "needs_review" as const,
+        proposalId: proposal.proposalId,
+        context: readAgentContext(),
+      };
+    }
+
+    return {
+      status: proposal.status,
+      proposalId: proposal.proposalId,
+      context: readAgentContext(),
+    };
+  },
+});
+```
+
+With `mode: "hitl"`, the proposal remains `evaluating` and the visible Snapshot does not change until a reviewer approves it.
+
+```typescript
+export async function approveAgentProposal(proposalId: string) {
+  const proposal = await app.approve(proposalId);
+
+  return {
+    proposal,
+    context: readAgentContext(),
+  };
 }
 ```
 
-The agent or planner can still choose the next command. The app-owned translator layer is responsible for mapping that command into the runtime's typed action refs instead of letting the agent mutate state directly or rely on raw string names as the app-facing contract.
+That is the upgrade path: direct tools use `dispatchAsync()`. Reviewable tools use `proposeAsync()` and a reviewer calls `approve()`.
 
 ---
 
-## 4. Keep Approval Logic Out Of The Prompt Alone
+## What Manifesto Adds To Agents
 
-If the action requires explicit approval, do not bury the policy inside prompt text only. Route it through governance so the review, decision, and seal are visible in the runtime model.
-
-That is the right place for:
-
-- actor identity
-- proposal review
-- branch-aware decisions
-- audit history
+- **Live capability discovery:** `getAvailableActions()` tells the agent which domain actions are legal against the current Snapshot.
+- **Runtime-owned writes:** tools translate model requests into `createIntent(app.MEL.actions.*)`; the model never mutates state directly.
+- **Snapshot feedback:** tool results return selected `snapshot.data`, `snapshot.computed`, and updated availability.
+- **Simple HITL escalation:** `withGovernance()` turns a write tool into a proposal tool without rewriting the MEL domain.
 
 ---
 
 ## Common Mistakes
 
-### Letting the agent bypass the runtime
+### Describing actions only in the system prompt
 
-If the agent edits storage or UI state directly, humans and automation stop sharing one truth.
+Use `getAvailableActions()` and `getActionMetadata()` as the source for agent-facing capabilities. Prompt text can explain behavior, but the runtime owns action availability.
 
-### Hiding approval logic in the agent layer
+### Letting the agent edit state directly
 
-If you need explicit approval, model it in governance or application policy, not in ad-hoc prompt logic alone.
+Do not let the agent write storage rows, React state, Redux slices, or serialized snapshots as its domain command. Call a tool that dispatches or proposes an Intent.
 
-### Forgetting to persist the resulting snapshot
+### Hiding approval logic in prompt text
 
-The agent should reason from Snapshot, not from a private memory of what it thinks happened.
+If a write requires review, use Governance or application policy. A prompt instruction like "ask me first" is not an auditable decision record.
+
+### Returning effect results as the action outcome
+
+Effects report back through patches. Actions and tools should read the resulting Snapshot view.
 
 ---
 
 ## Next
 
-- Install [`@manifesto-ai/skills`](/api/skills) if you want Codex or another AI tool to load Manifesto-specific guidance
-- Use [`@manifesto-ai/studio-mcp`](/api/studio-mcp) when the agent should inspect graph, findings, or runtime overlays through MCP
-- Read [React](./react) to connect the same instance to a UI
-- Read [When You Need Approval or History](/guides/approval-and-history) when the agent may need review, approval, or sealed history
-- Read [Governance API](/api/governance) when the agent should work through proposals and sealing
-- Read [Architecture](/architecture/) when you want the bigger system model
+- Build the domain first in [Building a Todo App](/guide/essentials/todo-app)
+- Connect the same runtime to a UI with [React](./react)
+- Learn action inspection in [SDK API](/api/sdk)
+- Read [When You Need Approval or History](/guides/approval-and-history) before adding sealed history to the product
+- Use [`@manifesto-ai/studio-mcp`](/api/studio-mcp) when an agent should inspect graph, findings, trace, lineage, or governance over MCP

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "docs:canonical:list": "node scripts/export-canonical-docs.mjs --list",
     "docs:mel-grammar": "node scripts/update-mel-grammar.mjs",
     "docs:check:maintained": "node scripts/check-maintained-docs.mjs",
-    "docs:check": "pnpm docs:governance-check && pnpm docs:check:maintained",
+    "docs:api:inventory": "node scripts/update-api-public-surface.mjs",
+    "docs:api:check": "node scripts/update-api-public-surface.mjs --check",
+    "docs:check": "pnpm docs:governance-check && pnpm docs:api:check && pnpm docs:check:maintained",
     "docs:release:check": "pnpm docs:check && pnpm docs:build",
     "docs:governance-check": "node scripts/check-doc-governance.mjs",
     "docs:api:clean": "rm -rf docs/api"

--- a/scripts/update-api-public-surface.mjs
+++ b/scripts/update-api-public-surface.mjs
@@ -1,0 +1,264 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const outPath = path.join(repoRoot, "docs/api/public-surface.md");
+
+const packageRoots = [
+  "packages/sdk",
+  "packages/lineage",
+  "packages/governance",
+  "packages/compiler",
+  "packages/core",
+  "packages/host",
+  "packages/codegen",
+];
+
+const checkOnly = process.argv.includes("--check");
+
+function sourceFileFromTypesPath(packageRoot, typesPath) {
+  const distRelative = typesPath
+    .replace(/^\.\//, "")
+    .replace(/^dist\//, "")
+    .replace(/\.d\.ts$/, ".ts");
+
+  return path.join(repoRoot, packageRoot, "src", distRelative);
+}
+
+async function readJson(relativePath) {
+  return JSON.parse(
+    await fs.readFile(path.join(repoRoot, relativePath), "utf8"),
+  );
+}
+
+function add(target, name) {
+  if (name && name !== "default") {
+    target.add(name);
+  }
+}
+
+function hasExportModifier(node) {
+  return Boolean(
+    node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword),
+  );
+}
+
+function hasDefaultModifier(node) {
+  return Boolean(
+    node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword),
+  );
+}
+
+function exportedDeclarationName(node) {
+  return node.name && ts.isIdentifier(node.name) ? node.name.text : null;
+}
+
+function resolveModulePath(fromFile, specifier) {
+  if (!specifier.startsWith(".")) {
+    return null;
+  }
+
+  const withoutJs = specifier.replace(/\.js$/, ".ts");
+  const resolved = path.resolve(path.dirname(fromFile), withoutJs);
+
+  if (resolved.endsWith(".ts")) {
+    return resolved;
+  }
+
+  return path.join(resolved, "index.ts");
+}
+
+async function pathExists(target) {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function collectExports(filePath, seen = new Set()) {
+  const normalized = path.normalize(filePath);
+  if (seen.has(normalized)) {
+    return { values: new Set(), types: new Set() };
+  }
+  seen.add(normalized);
+
+  if (!(await pathExists(normalized))) {
+    throw new Error(`Public API source barrel not found: ${path.relative(repoRoot, normalized)}`);
+  }
+
+  const sourceText = await fs.readFile(normalized, "utf8");
+  const source = ts.createSourceFile(
+    normalized,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  const values = new Set();
+  const types = new Set();
+
+  for (const statement of source.statements) {
+    if (ts.isExportDeclaration(statement)) {
+      if (statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+        for (const specifier of statement.exportClause.elements) {
+          const exportedName = specifier.name.text;
+          const typeOnly = statement.isTypeOnly || specifier.isTypeOnly;
+          add(typeOnly ? types : values, exportedName);
+        }
+        continue;
+      }
+
+      const moduleSpecifier = statement.moduleSpecifier;
+      if (moduleSpecifier && ts.isStringLiteral(moduleSpecifier)) {
+        const recursivePath = resolveModulePath(normalized, moduleSpecifier.text);
+        if (recursivePath) {
+          const nested = await collectExports(recursivePath, seen);
+          nested.values.forEach((name) => add(values, name));
+          nested.types.forEach((name) => add(types, name));
+        }
+      }
+      continue;
+    }
+
+    if (!hasExportModifier(statement)) {
+      continue;
+    }
+
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) {
+          add(values, declaration.name.text);
+        }
+      }
+      continue;
+    }
+
+    if (
+      ts.isFunctionDeclaration(statement) ||
+      ts.isClassDeclaration(statement) ||
+      ts.isEnumDeclaration(statement)
+    ) {
+      if (hasDefaultModifier(statement)) {
+        add(values, "default");
+      } else {
+        add(values, exportedDeclarationName(statement));
+      }
+      continue;
+    }
+
+    if (
+      ts.isInterfaceDeclaration(statement) ||
+      ts.isTypeAliasDeclaration(statement)
+    ) {
+      add(types, exportedDeclarationName(statement));
+    }
+  }
+
+  return { values, types };
+}
+
+function sortNames(names) {
+  return [...names].sort((left, right) => left.localeCompare(right));
+}
+
+function packageSpecifier(packageName, subpath) {
+  return subpath === "." ? packageName : `${packageName}${subpath.slice(1)}`;
+}
+
+async function collectPublicEntries() {
+  const entries = [];
+
+  for (const packageRoot of packageRoots) {
+    const packageJson = await readJson(`${packageRoot}/package.json`);
+    const packageName = packageJson.name;
+    const exportEntries = Object.entries(packageJson.exports ?? {});
+
+    for (const [subpath, config] of exportEntries) {
+      const typesPath = typeof config === "string" ? config : config.types;
+      if (!typesPath) {
+        continue;
+      }
+
+      const sourceFile = sourceFileFromTypesPath(packageRoot, typesPath);
+      const collected = await collectExports(sourceFile);
+
+      entries.push({
+        packageName,
+        subpath,
+        specifier: packageSpecifier(packageName, subpath),
+        sourceFile: path.relative(repoRoot, sourceFile),
+        values: sortNames(collected.values),
+        types: sortNames(collected.types),
+      });
+    }
+  }
+
+  return entries.sort((left, right) =>
+    left.specifier.localeCompare(right.specifier),
+  );
+}
+
+function renderNameList(names) {
+  if (names.length === 0) {
+    return ["_No named exports detected._"];
+  }
+
+  return names.map((name) => `- \`${name}\``);
+}
+
+function renderInventory(entries) {
+  const lines = [
+    "# Public Surface Inventory",
+    "",
+    "> Generated from package `exports` and source barrels. Do not edit by hand.",
+    ">",
+    "> Run `pnpm docs:api:inventory` to update this page.",
+    "",
+    "This page is a drift guard. Use the curated API reference pages for usage guidance.",
+    "",
+  ];
+
+  let currentPackage = "";
+
+  for (const entry of entries) {
+    if (entry.packageName !== currentPackage) {
+      currentPackage = entry.packageName;
+      lines.push(`## ${currentPackage}`, "");
+    }
+
+    lines.push(`### ${entry.specifier}`, "");
+    lines.push(`_Source: \`${entry.sourceFile}\`_`, "");
+    lines.push("#### Values", "");
+    lines.push(...renderNameList(entry.values), "");
+    lines.push("#### Types", "");
+    lines.push(...renderNameList(entry.types), "");
+  }
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+async function main() {
+  const inventory = renderInventory(await collectPublicEntries());
+
+  if (checkOnly) {
+    const current = await fs.readFile(outPath, "utf8").catch(() => "");
+    if (current !== inventory) {
+      console.error("docs/api/public-surface.md is out of date.");
+      console.error("Run `pnpm docs:api:inventory` and commit the result.");
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  await fs.writeFile(outPath, inventory);
+  console.log(`Updated ${path.relative(repoRoot, outPath)}`);
+}
+
+await main();


### PR DESCRIPTION
## Summary

- Reframe docs home and VitePress IA around a Vue-style Guide shell
- Add `/guide/` introduction, quick start, and Essentials pages for app-building concepts
- Rewrite AI Agent integration around fresh Snapshot context, `getAvailableActions()`, tool dispatch, and optional Governance HITL
- Rebuild `/api/` as an app-runtime-first API reference while preserving package overview URLs
- Add generated `docs/api/public-surface.md` plus `docs:api:inventory` / `docs:api:check` drift tooling

## Validation

- `pnpm docs:api:inventory`
- `pnpm docs:api:check`
- `pnpm docs:check`
- `pnpm docs:build`

Notes: VitePress build still prints the existing `ebnf` highlighting fallback and large-chunk warning; build completes successfully.