### PR TITLE
docs: add Google Analytics tag to docs site

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -91,6 +91,12 @@ export default defineConfig({
   title: 'Manifesto',
   description: 'Semantic layer for deterministic domain state — define meaning once, derive everything as projections',
   head: [
+    ['script', { async: '', src: 'https://www.googletagmanager.com/gtag/js?id=G-FW564PKJWF' }],
+    ['script', {}, `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'G-FW564PKJWF');`],
     ['meta', { property: 'og:title', content: 'Manifesto' }],
     ['meta', { property: 'og:description', content: 'Semantic layer for deterministic domain state — define meaning once, derive everything as projections' }],
     ['meta', { property: 'og:type', content: 'website' }],


### PR DESCRIPTION
## Summary
- add the Google Analytics gtag loader to the VitePress docs head
- initialize tracking with measurement ID `G-FW564PKJWF` for all docs pages
- keep the change scoped to the docs site configuration

## Why
The docs site needs GA tracking injected globally so page views are recorded across the generated VitePress pages.

## Impact
Docs deployments will include the GA tag on every page without changing package runtime behavior.

## Validation
- `pnpm docs:build`
- verified the generated HTML in `docs/.vitepress/dist` contains the Google tag snippet