### PR TITLE
fix(release): key turbo cache by release mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,10 +66,12 @@ Changes that violate this constitution produce systems that are NOT Manifesto-co
 
 When documents conflict, prefer higher-ranked sources.
 
-**Commit discipline:**
+**Commit and PR discipline:**
 - If an agent creates or rewrites commits, each commit subject must use Conventional Commit format: `type(scope): summary` or `type: summary`.
+- If an agent opens or updates a pull request, the pull request title must also use Conventional Commit format: `type(scope): summary` or `type: summary`.
 - Allowed types are the repository-enforced set: `build`, `chore`, `ci`, `deps`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
 - Treat non-conforming commit subjects as invalid output, not as a style preference, because CI rejects them and release automation relies on them.
+- Treat non-conforming pull request titles as invalid output, not as a style preference, because CI rejects them at the pull request gate.
 
 ---
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["MANIFESTO_RELEASE"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## What changed
- added `MANIFESTO_RELEASE` to Turbo `globalEnv`
- separated build cache keys for normal builds and release builds

## Why
Release builds disable tsup sourcemaps via `MANIFESTO_RELEASE=1`, but Turbo was not treating that env var as a build input. A cached non-release `dist` could therefore be replayed during publish and ship `*.map` files.

## Impact
Release packaging now rebuilds against the release-mode cache key, so published `dist` output no longer reuses sourcemap-enabled artifacts from normal builds.

## Root cause
The release workflow set `MANIFESTO_RELEASE`, but `turbo.json` did not include that variable in cache invalidation.

## Validation
- `pnpm turbo run build --filter=@manifesto-ai/core`
- `MANIFESTO_RELEASE=1 pnpm turbo run build --filter=@manifesto-ai/core`
- `find packages/core/dist -maxdepth 1 -type f | sort`
