### PR TITLE
feat(examples): redesign todo-governed-react with Tailwind and Motion

### DIFF
--- a/examples/todo-governed-react/README.md
+++ b/examples/todo-governed-react/README.md
@@ -1,0 +1,21 @@
+# Governed Todo React Example
+
+This example shows a real governed UI flow around `waitForProposal()`.
+
+- `addTodo`, `toggleTodo`, and `setFilter` use `proposeAsync()` but auto-approve immediately.
+- `removeTodo` and `clearCompleted` also use `proposeAsync()`, but policy leaves them in `evaluating` until a reviewer decides.
+- The requester calls `waitForProposal()` after every submission, so destructive actions surface as `timed_out` until the reviewer queue settles them.
+- The reviewer panel then calls `approve()` or `reject()` and re-observes the same proposal with `waitForProposal()` to normalize the terminal outcome.
+
+## Run
+
+```bash
+pnpm install
+pnpm --filter @manifesto-ai/example-todo-governed-react dev
+```
+
+## What to try
+
+1. Add a todo and watch the settlement log report `completed`.
+2. Delete that todo and watch the requester side report `timed_out`.
+3. Approve or reject the proposal from the reviewer panel and watch the same proposal update to `completed` or `rejected`.

--- a/examples/todo-governed-react/index.html
+++ b/examples/todo-governed-react/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Manifesto Governed Todo Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/todo-governed-react/package.json
+++ b/examples/todo-governed-react/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@manifesto-ai/example-todo-governed-react",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@manifesto-ai/governance": "workspace:*",
+    "@manifesto-ai/lineage": "workspace:*",
+    "@manifesto-ai/sdk": "workspace:*",
+    "@tailwindcss/vite": "^4.2.2",
+    "motion": "^12.38.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tailwindcss": "^4.2.2"
+  },
+  "devDependencies": {
+    "@manifesto-ai/compiler": "workspace:*",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.3"
+  }
+}

--- a/examples/todo-governed-react/src/app.tsx
+++ b/examples/todo-governed-react/src/app.tsx
@@ -1,0 +1,161 @@
+import { AnimatePresence, motion } from "motion/react";
+import { ProposalQueue } from "./components/governance/proposal-queue";
+import { ActivityFeed } from "./components/governance/activity-feed";
+import { TodoFooter } from "./components/todo/todo-footer";
+import { TodoInput } from "./components/todo/todo-input";
+import { TodoList } from "./components/todo/todo-list";
+import { useGovernedManifesto } from "./hooks/use-governed-manifesto";
+import type { TodoComputed } from "./types";
+
+export function App() {
+  const {
+    state,
+    ready,
+    error,
+    reviewQueue,
+    activity,
+    addTodo,
+    toggleTodo,
+    removeTodo,
+    setFilter,
+    clearCompleted,
+    approveProposal,
+    rejectProposal,
+  } = useGovernedManifesto();
+
+  if (!ready || !state) {
+    return (
+      <div className="min-h-screen grid place-items-center">
+        <div className="text-center">
+          <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-sage-500/10 text-sage-500 text-sm font-medium tracking-wide">
+            <span className="w-2 h-2 rounded-full bg-sage-500 animate-pulse-dot" />
+            Initializing governed runtime
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const data = state.data;
+  const computed = state.computed as TodoComputed;
+  const filteredTodos = data.todos.filter((todo) => {
+    if (data.filterMode === "active") return !todo.completed;
+    if (data.filterMode === "completed") return todo.completed;
+    return true;
+  });
+
+  const pendingDeletes = new Set(
+    reviewQueue
+      .filter((item) => item.proposal.intent.type === "removeTodo")
+      .map((item) => item.proposal.intent.input as string),
+  );
+
+  return (
+    <div className="w-[min(1280px,calc(100vw-2rem))] mx-auto py-8 md:py-10">
+      {/* Header */}
+      <header className="mb-6 animate-fade-in">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <div className="flex items-center gap-2.5 mb-2">
+              <div className="w-7 h-7 rounded-lg bg-sage-500 flex items-center justify-center">
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <path d="M2 7.5L5.5 11L12 3" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              </div>
+              <h1 className="text-lg font-semibold text-sage-900 tracking-tight">Governed Todo</h1>
+            </div>
+            <p className="text-sage-400 text-sm max-w-md leading-relaxed">
+              Actions flow through governance. Some settle instantly, others await human review.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 mt-1">
+            <div className="flex items-center gap-1.5 text-xs text-sage-400">
+              <span className="w-1.5 h-1.5 rounded-full bg-sage-500" />
+              <span>Auto-approve</span>
+            </div>
+            <div className="flex items-center gap-1.5 text-xs text-sage-400">
+              <span className="w-1.5 h-1.5 rounded-full bg-ember-400" />
+              <span>Needs review</span>
+            </div>
+            <div className="px-2.5 py-1 rounded-md bg-sage-900/5 text-xs font-mono text-sage-600">
+              v.{state.meta.version}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Main workspace */}
+      <main className="grid grid-cols-1 lg:grid-cols-[1.15fr_0.85fr] gap-5 items-start">
+        {/* Writer panel */}
+        <section className="bg-sand-200/88 border border-sage-900/[0.06] rounded-2xl shadow-[0_16px_48px_rgba(36,55,51,0.07)] backdrop-blur-lg overflow-hidden animate-fade-in-delay-1">
+          <div className="px-6 pt-5 pb-4">
+            <div className="flex items-center justify-between mb-1">
+              <div className="flex items-center gap-2">
+                <span className="text-[0.65rem] uppercase tracking-[0.16em] text-sage-400 font-medium">Writer</span>
+              </div>
+            </div>
+            <h2 className="font-serif text-xl font-semibold text-sage-900 -tracking-[0.01em]">Tasks</h2>
+          </div>
+
+          <AnimatePresence>
+            {error && (
+              <motion.div
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+                className="mx-5 mb-3 px-4 py-3 rounded-xl bg-red-50 text-red-700 text-sm border border-red-100"
+              >
+                {error}
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          <div className="bg-sand-50 rounded-xl mx-3 mb-3 border border-sage-900/[0.05] overflow-hidden">
+            <div className="px-4 pt-4">
+              <TodoInput onAdd={(title) => void addTodo(title)} />
+            </div>
+
+            {data.todos.length > 0 ? (
+              <>
+                <div className="border-t border-sage-900/[0.06] mt-3">
+                  <TodoList
+                    todos={filteredTodos}
+                    pendingDeletes={pendingDeletes}
+                    onToggle={(id) => void toggleTodo(id)}
+                    onRemove={(id) => void removeTodo(id)}
+                  />
+                </div>
+                <TodoFooter
+                  activeCount={computed.activeCount}
+                  hasCompleted={computed.hasCompleted}
+                  filterMode={data.filterMode}
+                  onSetFilter={(filter) => void setFilter(filter)}
+                  onClearCompleted={() => void clearCompleted()}
+                />
+              </>
+            ) : (
+              <div className="px-5 py-8 text-center text-sage-300 text-sm">
+                <div className="w-10 h-10 mx-auto mb-3 rounded-xl bg-sage-900/[0.04] flex items-center justify-center">
+                  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" className="text-sage-300">
+                    <path d="M10 4V16M4 10H16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                  </svg>
+                </div>
+                Add your first task. Try deleting one to trigger a governance review.
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* Reviewer panel */}
+        <aside className="grid gap-4 animate-fade-in-delay-2">
+          <ProposalQueue
+            reviewQueue={reviewQueue}
+            onApprove={(proposalId) => void approveProposal(proposalId)}
+            onReject={(proposalId) => void rejectProposal(proposalId)}
+          />
+          <ActivityFeed activity={activity} />
+        </aside>
+      </main>
+    </div>
+  );
+}

--- a/examples/todo-governed-react/src/components/governance/activity-feed.tsx
+++ b/examples/todo-governed-react/src/components/governance/activity-feed.tsx
@@ -1,0 +1,82 @@
+import { AnimatePresence, motion } from "motion/react";
+import type { ActivityEntry } from "../../types";
+import { SettlementBadge } from "./settlement-badge";
+
+type Props = {
+  readonly activity: readonly ActivityEntry[];
+};
+
+function formatTimestamp(timestamp: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(timestamp);
+}
+
+function toShortId(value: string): string {
+  return value.slice(-6);
+}
+
+export function ActivityFeed({ activity }: Props) {
+  return (
+    <div className="bg-sand-200/88 border border-sage-900/[0.06] rounded-2xl shadow-[0_16px_48px_rgba(36,55,51,0.07)] backdrop-blur-lg p-5">
+      <div className="mb-1">
+        <span className="text-[0.65rem] uppercase tracking-[0.16em] text-sage-400 font-medium">Activity</span>
+      </div>
+      <h2 className="font-serif text-xl font-semibold text-sage-900 -tracking-[0.01em] mb-4">Settlement Log</h2>
+
+      <div className="grid gap-2">
+        <AnimatePresence mode="popLayout">
+          {activity.length === 0 ? (
+            <motion.div
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="py-6 text-center text-sage-300 text-sm"
+            >
+              Settlements will appear here as actions are processed
+            </motion.div>
+          ) : (
+            activity.map((entry, index) => (
+              <motion.article
+                key={entry.proposalId}
+                layout
+                initial={{ opacity: 0, y: -6 }}
+                animate={{ opacity: index === 0 ? 1 : 0.7, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.25 }}
+                className="p-3.5 rounded-xl bg-sand-50 border border-sage-900/[0.05]"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <SettlementBadge kind={entry.settlement} />
+                    <span className="text-[0.7rem] font-mono text-sage-300">
+                      #{toShortId(entry.proposalId)}
+                    </span>
+                  </div>
+                  <span className="text-[0.65rem] text-sage-300">
+                    {formatTimestamp(entry.observedAt)}
+                  </span>
+                </div>
+
+                <h3 className="text-[0.82rem] font-medium text-sage-700 mt-1.5">{entry.label}</h3>
+                <p className="text-sage-400 text-[0.72rem] leading-relaxed mt-0.5">{entry.detail}</p>
+
+                <div className="flex items-center gap-2 mt-1.5 text-[0.65rem] text-sage-300">
+                  <span className="capitalize">{entry.observedBy}</span>
+                  {entry.resultWorld && (
+                    <>
+                      <span className="text-sage-200">&middot;</span>
+                      <span className="font-mono">world ...{entry.resultWorld.slice(-8)}</span>
+                    </>
+                  )}
+                </div>
+              </motion.article>
+            ))
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/examples/todo-governed-react/src/components/governance/proposal-queue.tsx
+++ b/examples/todo-governed-react/src/components/governance/proposal-queue.tsx
@@ -1,0 +1,99 @@
+import { AnimatePresence, motion } from "motion/react";
+import type { ReviewItem } from "../../types";
+import { SettlementBadge } from "./settlement-badge";
+
+type Props = {
+  readonly reviewQueue: readonly ReviewItem[];
+  readonly onApprove: (proposalId: string) => void;
+  readonly onReject: (proposalId: string) => void;
+};
+
+function formatTimestamp(timestamp: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(timestamp);
+}
+
+function toShortId(value: string): string {
+  return value.slice(-6);
+}
+
+export function ProposalQueue({ reviewQueue, onApprove, onReject }: Props) {
+  return (
+    <div className="bg-sand-200/88 border border-sage-900/[0.06] rounded-2xl shadow-[0_16px_48px_rgba(36,55,51,0.07)] backdrop-blur-lg p-5">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[0.65rem] uppercase tracking-[0.16em] text-sage-400 font-medium">Reviewer</span>
+        {reviewQueue.length > 0 && (
+          <span className="text-[0.65rem] font-semibold text-ember-400 bg-ember-400/10 px-2 py-0.5 rounded-full">
+            {reviewQueue.length}
+          </span>
+        )}
+      </div>
+      <h2 className="font-serif text-xl font-semibold text-sage-900 -tracking-[0.01em] mb-3">Review Inbox</h2>
+
+      <p className="text-sage-400 text-[0.8rem] leading-relaxed mb-4">
+        Destructive actions are held for approval. The writer sees a timeout until you decide.
+      </p>
+
+      <div className="grid gap-2.5">
+        <AnimatePresence mode="popLayout">
+          {reviewQueue.length === 0 ? (
+            <motion.div
+              key="empty"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="py-6 text-center text-sage-300 text-sm"
+            >
+              No proposals awaiting review
+            </motion.div>
+          ) : (
+            reviewQueue.map(({ proposal, label, detail }) => (
+              <motion.article
+                key={proposal.proposalId}
+                layout
+                initial={{ opacity: 0, scale: 0.97 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.95, y: -10, transition: { duration: 0.2 } }}
+                className="p-4 rounded-xl bg-sand-50 border border-sage-900/[0.05]"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <SettlementBadge kind="evaluating" />
+                    <span className="text-[0.7rem] font-mono text-sage-300">
+                      #{toShortId(proposal.proposalId)}
+                    </span>
+                  </div>
+                </div>
+                <h3 className="text-sm font-semibold text-sage-800 mt-2">{label}</h3>
+                <p className="text-sage-400 text-[0.78rem] leading-relaxed mt-1">{detail}</p>
+
+                <div className="flex items-center gap-2 mt-2 text-[0.7rem] text-sage-300">
+                  <span>{formatTimestamp(proposal.submittedAt)}</span>
+                  <span className="text-sage-200">&middot;</span>
+                  <span>{proposal.actorId}</span>
+                </div>
+
+                <div className="flex gap-2 mt-3">
+                  <button
+                    className="flex-1 px-3 py-2 rounded-lg text-xs font-semibold bg-sage-600 text-sand-100 hover:bg-sage-500 cursor-pointer transition-colors shadow-sm"
+                    onClick={() => onApprove(proposal.proposalId)}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    className="flex-1 px-3 py-2 rounded-lg text-xs font-semibold bg-sage-900/[0.06] text-sage-600 hover:bg-sage-900/10 cursor-pointer transition-colors"
+                    onClick={() => onReject(proposal.proposalId)}
+                  >
+                    Reject
+                  </button>
+                </div>
+              </motion.article>
+            ))
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/examples/todo-governed-react/src/components/governance/settlement-badge.tsx
+++ b/examples/todo-governed-react/src/components/governance/settlement-badge.tsx
@@ -1,0 +1,46 @@
+import { motion } from "motion/react";
+
+type SettlementKind = "evaluating" | "completed" | "failed" | "rejected" | "superseded" | "pending" | "timed_out";
+
+type Props = {
+  readonly kind: SettlementKind;
+};
+
+const BADGE_STYLES: Record<SettlementKind, string> = {
+  evaluating: "bg-amber-400/15 text-amber-600",
+  pending: "bg-amber-400/15 text-amber-600",
+  completed: "bg-sage-500/12 text-sage-500",
+  rejected: "bg-red-100 text-red-600",
+  failed: "bg-red-100 text-red-600",
+  timed_out: "bg-sage-900/[0.06] text-sage-400",
+  superseded: "bg-sage-900/[0.06] text-sage-400",
+};
+
+const LABELS: Record<SettlementKind, string> = {
+  evaluating: "Evaluating",
+  pending: "Pending",
+  completed: "Approved",
+  rejected: "Rejected",
+  failed: "Failed",
+  timed_out: "Timed out",
+  superseded: "Superseded",
+};
+
+export function SettlementBadge({ kind }: Props) {
+  return (
+    <motion.span
+      initial={{ scale: 0.9, opacity: 0 }}
+      animate={{ scale: 1, opacity: 1 }}
+      className={`
+        inline-flex items-center gap-1 px-2 py-0.5 rounded-full
+        text-[0.6rem] uppercase tracking-[0.08em] font-semibold
+        ${BADGE_STYLES[kind]}
+      `}
+    >
+      {(kind === "evaluating" || kind === "pending") && (
+        <span className="w-1 h-1 rounded-full bg-current animate-pulse-dot" />
+      )}
+      {LABELS[kind]}
+    </motion.span>
+  );
+}

--- a/examples/todo-governed-react/src/components/todo/todo-footer.tsx
+++ b/examples/todo-governed-react/src/components/todo/todo-footer.tsx
@@ -1,0 +1,56 @@
+import type { FilterMode } from "../../types";
+
+type Props = {
+  readonly activeCount: number;
+  readonly hasCompleted: boolean;
+  readonly filterMode: FilterMode;
+  readonly onSetFilter: (filter: FilterMode) => void;
+  readonly onClearCompleted: () => void;
+};
+
+const FILTERS: FilterMode[] = ["all", "active", "completed"];
+
+export function TodoFooter({
+  activeCount,
+  hasCompleted,
+  filterMode,
+  onSetFilter,
+  onClearCompleted,
+}: Props) {
+  return (
+    <footer className="flex items-center justify-between gap-3 px-4 py-3 text-sm flex-wrap">
+      <span className="text-sage-400">
+        <strong className="text-sage-600 font-medium">{activeCount}</strong>{" "}
+        {activeCount === 1 ? "item" : "items"} left
+      </span>
+
+      <div className="flex gap-1">
+        {FILTERS.map((filter) => (
+          <button
+            key={filter}
+            className={`
+              px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer transition-all duration-150
+              ${filterMode === filter
+                ? "bg-sage-500/10 text-sage-500"
+                : "text-sage-400 hover:text-sage-600 hover:bg-sage-900/[0.04]"
+              }
+            `}
+            onClick={() => onSetFilter(filter)}
+          >
+            {filter.charAt(0).toUpperCase() + filter.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {hasCompleted && (
+        <button
+          className="px-2.5 py-1 rounded-md text-xs font-medium text-ember-500 hover:bg-ember-400/10 cursor-pointer transition-colors duration-150 relative"
+          onClick={onClearCompleted}
+        >
+          <span className="absolute -top-0.5 left-0 w-1.5 h-1.5 rounded-full bg-ember-400" />
+          Clear completed
+        </button>
+      )}
+    </footer>
+  );
+}

--- a/examples/todo-governed-react/src/components/todo/todo-input.tsx
+++ b/examples/todo-governed-react/src/components/todo/todo-input.tsx
@@ -1,0 +1,29 @@
+import { useState, type FormEvent } from "react";
+
+type Props = {
+  onAdd: (title: string) => void;
+};
+
+export function TodoInput({ onAdd }: Props) {
+  const [value, setValue] = useState("");
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const title = value.trim();
+    if (!title) return;
+    onAdd(title);
+    setValue("");
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        className="w-full border-none outline-none px-4 py-3 rounded-xl bg-sage-900/[0.03] text-sage-800 text-[0.95rem] placeholder:text-sage-300 focus:bg-sage-900/[0.05] transition-colors"
+        placeholder="What needs to be done?"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        autoFocus
+      />
+    </form>
+  );
+}

--- a/examples/todo-governed-react/src/components/todo/todo-item.tsx
+++ b/examples/todo-governed-react/src/components/todo/todo-item.tsx
@@ -1,0 +1,69 @@
+import { motion } from "motion/react";
+import type { Todo } from "../../types";
+
+type Props = {
+  readonly todo: Todo;
+  readonly isPendingDelete: boolean;
+  readonly onToggle: (id: string) => void;
+  readonly onRemove: (id: string) => void;
+};
+
+export function TodoItem({ todo, isPendingDelete, onToggle, onRemove }: Props) {
+  return (
+    <motion.li
+      layout
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: isPendingDelete ? 0.45 : 1, y: 0 }}
+      exit={{ opacity: 0, x: -20, transition: { duration: 0.2 } }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+      className="border-b border-sage-900/[0.06] last:border-b-0"
+    >
+      <div className="flex items-center gap-3 px-4 py-3 group">
+        {/* Checkbox */}
+        <button
+          onClick={() => onToggle(todo.id)}
+          className={`
+            w-5.5 h-5.5 rounded-full border flex-shrink-0 flex items-center justify-center transition-all duration-200 cursor-pointer
+            ${todo.completed
+              ? "bg-sage-500 border-sage-500"
+              : "border-sage-900/20 hover:border-sage-500/50"
+            }
+          `}
+        >
+          {todo.completed && (
+            <motion.svg
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              width="11" height="11" viewBox="0 0 14 14" fill="none"
+            >
+              <path d="M2.5 7.5L5.5 10.5L11.5 3.5" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            </motion.svg>
+          )}
+        </button>
+
+        {/* Label */}
+        <span className={`flex-1 text-[0.92rem] leading-snug transition-all duration-200 ${
+          todo.completed ? "text-sage-300 line-through" : "text-sage-800"
+        }`}>
+          {todo.title}
+        </span>
+
+        {/* Pending badge or delete button */}
+        {isPendingDelete ? (
+          <span className="text-[0.65rem] uppercase tracking-wider text-amber-600 bg-amber-400/15 px-2 py-0.5 rounded-full font-medium">
+            Pending
+          </span>
+        ) : (
+          <button
+            onClick={() => onRemove(todo.id)}
+            className="opacity-0 group-hover:opacity-60 hover:!opacity-100 text-ember-500 text-lg leading-none cursor-pointer transition-opacity duration-150 relative"
+            title="Requires review"
+          >
+            <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-ember-400" />
+            &times;
+          </button>
+        )}
+      </div>
+    </motion.li>
+  );
+}

--- a/examples/todo-governed-react/src/components/todo/todo-list.tsx
+++ b/examples/todo-governed-react/src/components/todo/todo-list.tsx
@@ -1,0 +1,28 @@
+import { AnimatePresence } from "motion/react";
+import type { Todo } from "../../types";
+import { TodoItem } from "./todo-item";
+
+type Props = {
+  readonly todos: readonly Todo[];
+  readonly pendingDeletes: ReadonlySet<string>;
+  readonly onToggle: (id: string) => void;
+  readonly onRemove: (id: string) => void;
+};
+
+export function TodoList({ todos, pendingDeletes, onToggle, onRemove }: Props) {
+  return (
+    <ul className="list-none m-0 p-0">
+      <AnimatePresence mode="popLayout">
+        {todos.map((todo) => (
+          <TodoItem
+            key={todo.id}
+            todo={todo}
+            isPendingDelete={pendingDeletes.has(todo.id)}
+            onToggle={onToggle}
+            onRemove={onRemove}
+          />
+        ))}
+      </AnimatePresence>
+    </ul>
+  );
+}

--- a/examples/todo-governed-react/src/domain/todo.mel
+++ b/examples/todo-governed-react/src/domain/todo.mel
@@ -1,0 +1,56 @@
+domain TodoApp {
+  type Todo = {
+    id: string,
+    title: string,
+    completed: boolean
+  }
+
+  state {
+    todos: Array<Todo> = []
+    filterMode: "all" | "active" | "completed" = "all"
+  }
+
+  computed todoCount = len(todos)
+  computed completedCount = len(filter(todos, $item.completed))
+  computed activeCount = sub(todoCount, completedCount)
+  computed hasCompleted = gt(completedCount, 0)
+
+  action addTodo(title: string) {
+    onceIntent when neq(trim(title), "") {
+      patch todos = append(todos, {
+        id: $system.uuid,
+        title: trim(title),
+        completed: false
+      })
+    }
+  }
+
+  action toggleTodo(id: string) {
+    onceIntent {
+      patch todos = map(todos,
+        cond(eq($item.id, id),
+          { id: $item.id, title: $item.title, completed: not($item.completed) },
+          $item
+        )
+      )
+    }
+  }
+
+  action removeTodo(id: string) {
+    onceIntent {
+      patch todos = filter(todos, neq($item.id, id))
+    }
+  }
+
+  action setFilter(newFilter: "all" | "active" | "completed") {
+    onceIntent {
+      patch filterMode = newFilter
+    }
+  }
+
+  action clearCompleted() {
+    onceIntent when hasCompleted {
+      patch todos = filter(todos, not($item.completed))
+    }
+  }
+}

--- a/examples/todo-governed-react/src/domain/todo.mel.d.ts
+++ b/examples/todo-governed-react/src/domain/todo.mel.d.ts
@@ -1,0 +1,2 @@
+declare const source: unknown;
+export default source;

--- a/examples/todo-governed-react/src/hooks/use-governed-manifesto.ts
+++ b/examples/todo-governed-react/src/hooks/use-governed-manifesto.ts
@@ -1,0 +1,359 @@
+import {
+  startTransition,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from "react";
+import {
+  createInMemoryGovernanceStore,
+  waitForProposal,
+  withGovernance,
+  type GovernanceInstance,
+  type Proposal,
+} from "@manifesto-ai/governance";
+import {
+  createInMemoryLineageStore,
+  withLineage,
+} from "@manifesto-ai/lineage";
+import {
+  type TypedIntent,
+  createManifesto,
+  type Snapshot,
+} from "@manifesto-ai/sdk";
+
+import todoSchema from "../domain/todo.mel";
+import type {
+  ActivityEntry,
+  FilterMode,
+  ReviewItem,
+  TodoData,
+  TodoDomain,
+  TodoSettlement,
+} from "../types";
+
+type TodoSnapshot = Snapshot<TodoData>;
+
+type UseGovernedManifestoResult = {
+  readonly state: TodoSnapshot | null;
+  readonly ready: boolean;
+  readonly error: string | null;
+  readonly availableActions: readonly string[];
+  readonly reviewQueue: readonly ReviewItem[];
+  readonly activity: readonly ActivityEntry[];
+  readonly addTodo: (title: string) => Promise<void>;
+  readonly toggleTodo: (id: string) => Promise<void>;
+  readonly removeTodo: (id: string) => Promise<void>;
+  readonly setFilter: (newFilter: FilterMode) => Promise<void>;
+  readonly clearCompleted: () => Promise<void>;
+  readonly approveProposal: (proposalId: string) => Promise<void>;
+  readonly rejectProposal: (proposalId: string) => Promise<void>;
+};
+
+const AUTO_ACTOR_ID = "actor:writer:auto";
+const REVIEWABLE_ACTOR_ID = "actor:writer:reviewable";
+const REVIEWER_ID = "actor:reviewer";
+const REVIEWABLE_ACTIONS = new Set<string>(["removeTodo", "clearCompleted"]);
+
+function createGovernedRuntime(): GovernanceInstance<TodoDomain> {
+  return withGovernance(
+    withLineage(
+      createManifesto<TodoDomain>(todoSchema as string, {}),
+      { store: createInMemoryLineageStore() },
+    ),
+    {
+      governanceStore: createInMemoryGovernanceStore(),
+      bindings: [
+        {
+          actorId: AUTO_ACTOR_ID,
+          authorityId: "authority:auto",
+          policy: { mode: "auto_approve" },
+        },
+        {
+          actorId: REVIEWABLE_ACTOR_ID,
+          authorityId: "authority:human-review",
+          policy: {
+            mode: "hitl",
+            delegate: {
+              actorId: REVIEWER_ID,
+              kind: "human",
+              name: "Manual Reviewer",
+            },
+          },
+        },
+      ],
+      execution: {
+        projectionId: "todo-governed-react",
+        deriveActor: (intent) => ({
+          actorId: REVIEWABLE_ACTIONS.has(intent.type)
+            ? REVIEWABLE_ACTOR_ID
+            : AUTO_ACTOR_ID,
+          kind: "human",
+          name: REVIEWABLE_ACTIONS.has(intent.type)
+            ? "Reviewable Writer"
+            : "Auto Writer",
+        }),
+        deriveSource: (intent) => ({
+          kind: "ui",
+          eventId: intent.intentId ?? crypto.randomUUID(),
+        }),
+      },
+    },
+  ).activate();
+}
+
+function sortBySubmittedAt(proposals: readonly Proposal[]): readonly Proposal[] {
+  return [...proposals].sort((left, right) => right.submittedAt - left.submittedAt);
+}
+
+function formatTodoLabel(
+  type: string,
+  input: unknown,
+  snapshot: TodoSnapshot | null,
+): string {
+  if (type === "addTodo" && typeof input === "string") {
+    return `Add "${input}"`;
+  }
+
+  if (type === "toggleTodo" && typeof input === "string") {
+    const title = snapshot?.data.todos.find((todo) => todo.id === input)?.title;
+    return title ? `Toggle "${title}"` : "Toggle todo";
+  }
+
+  if (type === "removeTodo" && typeof input === "string") {
+    const title = snapshot?.data.todos.find((todo) => todo.id === input)?.title;
+    return title ? `Delete "${title}"` : "Delete todo";
+  }
+
+  if (type === "setFilter" && typeof input === "string") {
+    return `Show ${input}`;
+  }
+
+  if (type === "clearCompleted") {
+    return "Clear completed";
+  }
+
+  return type;
+}
+
+function formatQueueDetail(proposal: Proposal): string {
+  switch (proposal.intent.type) {
+    case "removeTodo":
+      return "Deletion stays in evaluating until a reviewer approves or rejects it.";
+    case "clearCompleted":
+      return "Bulk cleanup is gated so a reviewer can inspect the pending removal.";
+    default:
+      return "Proposal is waiting on governance review.";
+  }
+}
+
+function formatSettlementDetail(
+  settlement: TodoSettlement,
+  proposal: Proposal,
+): string {
+  switch (settlement.kind) {
+    case "completed":
+      return "Proposal was approved and sealed into the current visible snapshot.";
+    case "failed":
+      return settlement.error.summary;
+    case "rejected":
+      return "Reviewer rejected the proposal before it changed state.";
+    case "superseded":
+      return "Proposal became stale after the branch head changed.";
+    case "pending":
+      return `Proposal is still ${proposal.status} and waiting for governance.`;
+    case "timed_out":
+      return "Observation timed out. The proposal may still settle later.";
+  }
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return "Unexpected Manifesto runtime error";
+}
+
+export function useGovernedManifesto(): UseGovernedManifestoResult {
+  const runtimeRef = useRef<GovernanceInstance<TodoDomain> | null>(null);
+  const snapshotRef = useRef<TodoSnapshot | null>(null);
+  const activityRef = useRef<readonly ActivityEntry[]>([]);
+
+  const [state, setState] = useState<TodoSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [availableActions, setAvailableActions] = useState<readonly string[]>([]);
+  const [reviewQueue, setReviewQueue] = useState<readonly ReviewItem[]>([]);
+  const [activity, setActivity] = useState<readonly ActivityEntry[]>([]);
+
+  const syncSnapshot = useEffectEvent((nextSnapshot: TodoSnapshot) => {
+    snapshotRef.current = nextSnapshot;
+    const runtime = runtimeRef.current;
+    startTransition(() => {
+      setState(nextSnapshot);
+      setAvailableActions(runtime?.getAvailableActions() ?? []);
+    });
+  });
+
+  const syncActivity = useEffectEvent((nextActivity: readonly ActivityEntry[]) => {
+    activityRef.current = nextActivity;
+    startTransition(() => setActivity(nextActivity));
+  });
+
+  const refreshQueue = useEffectEvent(async (runtime: GovernanceInstance<TodoDomain>) => {
+    const snapshot = snapshotRef.current;
+    const nextQueue = sortBySubmittedAt(
+      (await runtime.getProposals()).filter((proposal) => proposal.status === "evaluating"),
+    ).map((proposal) => {
+      const existing = activityRef.current.find(
+        (entry) => entry.proposalId === proposal.proposalId,
+      );
+
+      return {
+        proposal,
+        label: existing?.label ?? formatTodoLabel(proposal.intent.type, proposal.intent.input, snapshot),
+        detail: formatQueueDetail(proposal),
+      } satisfies ReviewItem;
+    });
+
+    startTransition(() => setReviewQueue(nextQueue));
+  });
+
+  const upsertActivity = useEffectEvent((
+    proposal: Proposal,
+    settlement: TodoSettlement,
+    observedBy: ActivityEntry["observedBy"],
+    snapshotBefore: TodoSnapshot | null,
+  ) => {
+    const existing = activityRef.current.find((entry) => entry.proposalId === proposal.proposalId);
+    const nextEntry: ActivityEntry = {
+      proposalId: proposal.proposalId,
+      label: existing?.label ?? formatTodoLabel(proposal.intent.type, proposal.intent.input, snapshotBefore),
+      detail: formatSettlementDetail(settlement, settlement.proposal),
+      observedBy,
+      observedAt: Date.now(),
+      submittedAt: proposal.submittedAt,
+      settlement: settlement.kind,
+      resultWorld: settlement.kind === "completed" || settlement.kind === "failed"
+        ? settlement.resultWorld
+        : undefined,
+    };
+
+    const nextActivity = [
+      nextEntry,
+      ...activityRef.current.filter((entry) => entry.proposalId !== proposal.proposalId),
+    ].slice(0, 8);
+
+    syncActivity(nextActivity);
+  });
+
+  useEffect(() => {
+    const runtime = createGovernedRuntime();
+    runtimeRef.current = runtime;
+    syncSnapshot(runtime.getSnapshot());
+    void refreshQueue(runtime);
+
+    const unsubscribe = runtime.subscribe(
+      (snapshot) => snapshot,
+      (nextSnapshot) => syncSnapshot(nextSnapshot as TodoSnapshot),
+    );
+
+    return () => {
+      unsubscribe();
+      runtime.dispose();
+      runtimeRef.current = null;
+      snapshotRef.current = null;
+      activityRef.current = [];
+    };
+  }, []);
+
+  const withRuntime = useEffectEvent(async (
+    action: (runtime: GovernanceInstance<TodoDomain>) => Promise<void>,
+  ) => {
+    const runtime = runtimeRef.current;
+    if (!runtime) {
+      setError("Governed runtime is not ready");
+      return;
+    }
+
+    setError(null);
+
+    try {
+      await action(runtime);
+    } catch (nextError) {
+      setError(toErrorMessage(nextError));
+    }
+  });
+
+  const submitIntent = useEffectEvent(async (
+    buildIntent: (runtime: GovernanceInstance<TodoDomain>) => TypedIntent<TodoDomain>,
+    timeoutMs: number,
+  ) => {
+    await withRuntime(async (runtime) => {
+      const snapshotBefore = snapshotRef.current;
+      const proposal = await runtime.proposeAsync(buildIntent(runtime));
+      await refreshQueue(runtime);
+      const settlement = await waitForProposal(runtime, proposal, {
+        timeoutMs,
+        pollIntervalMs: 100,
+      });
+      upsertActivity(proposal, settlement, "requester", snapshotBefore);
+      await refreshQueue(runtime);
+    });
+  });
+
+  const settleReviewedProposal = useEffectEvent(async (
+    proposalId: string,
+    decision: "approve" | "reject",
+  ) => {
+    await withRuntime(async (runtime) => {
+      const proposal = decision === "approve"
+        ? await runtime.approve(proposalId)
+        : await runtime.reject(proposalId, "Rejected from the example reviewer panel");
+
+      const snapshotBefore = snapshotRef.current;
+      const settlement = await waitForProposal(runtime, proposal.proposalId, {
+        timeoutMs: 250,
+        pollIntervalMs: 50,
+      });
+
+      upsertActivity(proposal, settlement, "reviewer", snapshotBefore);
+      await refreshQueue(runtime);
+    });
+  });
+
+  return {
+    state,
+    ready: state !== null,
+    error,
+    availableActions,
+    reviewQueue,
+    activity,
+    addTodo: (title) =>
+      submitIntent(
+        (runtime) => runtime.createIntent(runtime.MEL.actions.addTodo, title),
+        250,
+      ),
+    toggleTodo: (id) =>
+      submitIntent(
+        (runtime) => runtime.createIntent(runtime.MEL.actions.toggleTodo, id),
+        250,
+      ),
+    removeTodo: (id) =>
+      submitIntent(
+        (runtime) => runtime.createIntent(runtime.MEL.actions.removeTodo, id),
+        1500,
+      ),
+    setFilter: (newFilter) =>
+      submitIntent(
+        (runtime) => runtime.createIntent(runtime.MEL.actions.setFilter, newFilter),
+        250,
+      ),
+    clearCompleted: () =>
+      submitIntent(
+        (runtime) => runtime.createIntent(runtime.MEL.actions.clearCompleted),
+        1500,
+      ),
+    approveProposal: (proposalId) => settleReviewedProposal(proposalId, "approve"),
+    rejectProposal: (proposalId) => settleReviewedProposal(proposalId, "reject"),
+  };
+}

--- a/examples/todo-governed-react/src/index.css
+++ b/examples/todo-governed-react/src/index.css
@@ -1,0 +1,79 @@
+@import "tailwindcss";
+
+@theme {
+  --color-sage-50: #f7f3ea;
+  --color-sage-100: #f2eee4;
+  --color-sage-200: #d8d4ca;
+  --color-sage-300: #a8b5b0;
+  --color-sage-400: #6c7d79;
+  --color-sage-500: #2e7d70;
+  --color-sage-600: #214d47;
+  --color-sage-700: #1e3d3a;
+  --color-sage-800: #183935;
+  --color-sage-900: #153531;
+
+  --color-ember-300: #f09878;
+  --color-ember-400: #e87048;
+  --color-ember-500: #b06456;
+  --color-ember-600: #9a4b38;
+
+  --color-sand-50: #fffef9;
+  --color-sand-100: #fff8ef;
+  --color-sand-200: #fffcf5;
+
+  --color-amber-400: #e0b02f;
+  --color-amber-600: #8b6200;
+
+  --font-serif: "Iowan Old Style", "Palatino Linotype", "Palatino", Georgia, serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Avenir Next", "Helvetica Neue", system-ui, sans-serif;
+  background:
+    radial-gradient(ellipse at 0% 0%, rgba(46, 125, 112, 0.1), transparent 50%),
+    radial-gradient(ellipse at 100% 0%, rgba(232, 112, 72, 0.08), transparent 40%),
+    linear-gradient(180deg, #f7f3ea 0%, #f2eee4 100%);
+  color: var(--color-sage-900);
+  -webkit-font-smoothing: antialiased;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.animate-fade-in {
+  animation: fade-in 400ms ease-out both;
+}
+
+.animate-fade-in-delay-1 {
+  animation: fade-in 400ms ease-out 100ms both;
+}
+
+.animate-fade-in-delay-2 {
+  animation: fade-in 400ms ease-out 200ms both;
+}
+
+.animate-pulse-dot {
+  animation: pulse-dot 2s ease-in-out infinite;
+}

--- a/examples/todo-governed-react/src/main.tsx
+++ b/examples/todo-governed-react/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./app";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/todo-governed-react/src/types.ts
+++ b/examples/todo-governed-react/src/types.ts
@@ -1,0 +1,55 @@
+import type {
+  Proposal,
+  ProposalSettlement,
+} from "@manifesto-ai/governance";
+
+export type Todo = {
+  readonly id: string;
+  readonly title: string;
+  readonly completed: boolean;
+};
+
+export type FilterMode = "all" | "active" | "completed";
+
+export type TodoData = {
+  readonly todos: readonly Todo[];
+  readonly filterMode: FilterMode;
+};
+
+export type TodoComputed = {
+  readonly todoCount: number;
+  readonly completedCount: number;
+  readonly activeCount: number;
+  readonly hasCompleted: boolean;
+};
+
+export type TodoDomain = {
+  readonly actions: {
+    readonly addTodo: (title: string) => void;
+    readonly toggleTodo: (id: string) => void;
+    readonly removeTodo: (id: string) => void;
+    readonly setFilter: (newFilter: FilterMode) => void;
+    readonly clearCompleted: () => void;
+  };
+  readonly state: TodoData;
+  readonly computed: TodoComputed;
+};
+
+export type TodoSettlement = ProposalSettlement<TodoDomain>;
+
+export type ReviewItem = {
+  readonly proposal: Proposal;
+  readonly label: string;
+  readonly detail: string;
+};
+
+export type ActivityEntry = {
+  readonly proposalId: string;
+  readonly label: string;
+  readonly detail: string;
+  readonly observedBy: "requester" | "reviewer";
+  readonly observedAt: number;
+  readonly submittedAt: number;
+  readonly settlement: TodoSettlement["kind"];
+  readonly resultWorld?: string;
+};

--- a/examples/todo-governed-react/tsconfig.json
+++ b/examples/todo-governed-react/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/examples/todo-governed-react/vite.config.ts
+++ b/examples/todo-governed-react/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { melPlugin } from "@manifesto-ai/compiler/vite";
+
+export default defineConfig({
+  plugins: [melPlugin(), tailwindcss(), react()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,52 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@25.5.2)(jsdom@27.4.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
 
+  examples/todo-governed-react:
+    dependencies:
+      '@manifesto-ai/governance':
+        specifier: workspace:*
+        version: link:../../packages/governance
+      '@manifesto-ai/lineage':
+        specifier: workspace:*
+        version: link:../../packages/lineage
+      '@manifesto-ai/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@tailwindcss/vite':
+        specifier: ^4.2.2
+        version: 4.2.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+      motion:
+        specifier: ^12.38.0
+        version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
+    devDependencies:
+      '@manifesto-ai/compiler':
+        specifier: workspace:*
+        version: link:../../packages/compiler
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+
   examples/todo-react:
     dependencies:
       '@manifesto-ai/sdk':
@@ -1198,6 +1244,100 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@tailwindcss/node@4.2.2':
+    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.2':
+    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.2':
+    resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@turbo/darwin-64@2.9.4':
     resolution: {integrity: sha512-ZSlPqJ5Vqg/wgVw8P3AOVCIosnbBilOxLq7TMz3MN/9U46DUYfdG2jtfevNDufyxyrg98pcPs/GBgDRaaids6g==}
     cpu: [x64]
@@ -2146,6 +2286,20 @@ packages:
   focus-trap@7.7.1:
     resolution: {integrity: sha512-Pkp8m55GjxBLnhBoT6OXdMvfRr4TjMAKLvFM566zlIryq5plbhaTmLAJWTGR0EkRwLjEte1lCOG9MxF1ipJrOg==}
 
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2516,6 +2670,26 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
+
+  motion@12.38.0:
+    resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2868,6 +3042,9 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
@@ -4003,6 +4180,74 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@tailwindcss/node@4.2.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.2
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-x64': 4.2.2
+      '@tailwindcss/oxide-freebsd-x64': 4.2.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
+
+  '@tailwindcss/vite@4.2.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      tailwindcss: 4.2.2
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+
   '@turbo/darwin-64@2.9.4':
     optional: true
 
@@ -4991,6 +5236,15 @@ snapshots:
     dependencies:
       tabbable: 6.4.0
 
+  framer-motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   fsevents@2.3.3:
     optional: true
 
@@ -5144,8 +5398,7 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jiti@2.6.1:
-    optional: true
+  jiti@2.6.1: {}
 
   joycon@3.1.1: {}
 
@@ -5401,6 +5654,20 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
+  motion-utils@12.36.0: {}
+
+  motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      framer-motion: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   ms@2.1.3: {}
 
@@ -5796,6 +6063,8 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
+  tailwindcss@4.2.2: {}
+
   tapable@2.3.2: {}
 
   terminal-size@4.0.1: {}
@@ -5868,8 +6137,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary
- Tailwind CSS v4 + Motion(Framer Motion) 도입으로 todo-governed-react 예제를 프로토타입 수준에서 세련된 Showcase Demo로 리디자인
- 컴포넌트를 `todo/`, `governance/` 디렉토리로 재구성하고, 거버넌스 개념을 코드 용어 대신 시각적 인터랙션으로 표현
- Proposal 제출/승인/거절 흐름에 실시간 애니메이션, 삭제 대기 상태에 "Pending" 배지 등 UX 강화

## Changes
- **Tailwind CSS v4** via `@tailwindcss/vite` — earth tone 커스텀 테마 (`sage`, `ember`, `sand`)
- **Motion** — Todo 추가/삭제 `AnimatePresence`, Proposal 카드 진입/퇴장, Settlement 배지 팝인
- **컴포넌트 구조**: `components/{todo,governance}/`로 관심사 분리
- **인라인 정책 표시**: 삭제 버튼에 주황 dot (리뷰 필요), 완료 체크에 초록 (자동 승인)
- **Compact 헤더**: Hero 섹션 → 앱 헤더 + 정책 범례 + Snapshot 버전 카운터
- 비즈니스 로직(`use-governed-manifesto.ts`), 스키마(`todo.mel`), 타입은 변경 없음

## Test plan
- [ ] `pnpm install && pnpm --filter @manifesto-ai/example-todo-governed-react dev`로 개발 서버 실행
- [ ] Todo 추가 → 즉시 반영 (auto-approve), Settlement Log에 "Approved" 기록
- [ ] Todo 삭제 → Review Inbox에 "Evaluating" Proposal 표시, 항목에 "Pending" 배지
- [ ] Approve 클릭 → Todo 삭제 + 애니메이션, Settlement Log 업데이트
- [ ] Reject 클릭 → Todo 유지, Settlement Log에 "Rejected" 기록
- [ ] 반응형: 1024px 이하에서 1열 레이아웃 전환
- [ ] `pnpm --filter @manifesto-ai/example-todo-governed-react build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)