### PR TITLE
feat(sdk): add defineEffects patch builder

### DIFF
--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -19,7 +19,7 @@ const app = manifesto.activate();
 | Parameter | Meaning |
 |-----------|---------|
 | `schema` | A compiled `DomainSchema` or MEL source string |
-| `effects` | A record of SDK effect handlers, keyed by effect type |
+| `effects` | A record of SDK effect handlers, keyed by effect type. You can author it directly or via `@manifesto-ai/sdk/effects`. |
 
 `createManifesto()` returns a composable object. Runtime verbs such as `dispatchAsync()` and `getSnapshot()` exist only after `activate()`.
 

--- a/docs/api/effects.md
+++ b/docs/api/effects.md
@@ -29,9 +29,33 @@ Register handlers before activation:
 const app = createManifesto(schema, effects).activate();
 ```
 
-## Return Patches
+## Builder-First Authoring
 
-Handlers return core patches. Patch paths are structured and rooted at domain state.
+`defineEffects()` gives handlers typed top-level `MEL.state.*` refs while keeping the runtime contract unchanged.
+
+```typescript
+import { defineEffects } from "@manifesto-ai/sdk/effects";
+import type { UserProfileDomain } from "./user-profile-types";
+
+const effects = defineEffects<UserProfileDomain>(({ set, unset }, MEL) => ({
+  "api.fetchUser": async (params) => {
+    const { id } = params as { id: string };
+    const user = await fetchUser(id);
+
+    return [
+      set(MEL.state.user, user),
+      set(MEL.state.loading, false),
+      unset(MEL.state.error),
+    ];
+  },
+}));
+```
+
+`defineEffects()` is an SDK authoring helper only. The returned value is still `Record<string, EffectHandler>`, and each handler still returns concrete `Patch[]`.
+
+## Low-Level Raw Patch Form
+
+If you need the low-level surface directly, raw patch literals remain supported.
 
 ```typescript
 const effects = {

--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -1097,6 +1097,18 @@ _Source: `packages/sdk/src/index.ts`_
 - `TypedSubscribe`
 - `Unsubscribe`
 
+### @manifesto-ai/sdk/effects
+
+_Source: `packages/sdk/src/effects.ts`_
+
+#### Values
+
+- `defineEffects`
+
+#### Types
+
+- `PatchBuilder`
+
 ### @manifesto-ai/sdk/extensions
 
 _Source: `packages/sdk/src/extensions.ts`_

--- a/docs/api/sdk.md
+++ b/docs/api/sdk.md
@@ -11,6 +11,7 @@ Use SDK when you want:
 - the shortest path to a running base runtime
 - a clear activation boundary before runtime execution
 - typed intent creation through `MEL.actions.*`
+- typed effect authoring through `@manifesto-ai/sdk/effects`
 - subscriptions, availability queries, dispatchability queries, intent explanation reads, action metadata inspection, static graph inspection, dry-run simulation, and snapshot reads in one package
 
 The current documented SDK contract is:
@@ -24,6 +25,10 @@ The current post-activation extension seam is:
 The current first-party hypothetical-session helper is:
 
 `@manifesto-ai/sdk/extensions -> createSimulationSession(app)`
+
+The current effect-authoring helper seam is:
+
+`@manifesto-ai/sdk/effects -> defineEffects()`
 
 ## SDK-Owned Surface
 
@@ -51,7 +56,18 @@ The current first-party hypothetical-session helper is:
   - `dispose`
 - SDK error types
 - `@manifesto-ai/sdk/extensions` for safe arbitrary-snapshot read-only helpers
+- `@manifesto-ai/sdk/effects` for typed effect authoring helpers
 - `@manifesto-ai/sdk/provider` for decorator/provider authoring seams
+
+## Effect Authoring Helper
+
+The root SDK story stays centered on `createManifesto()`. If you want typed top-level state refs when authoring effect handlers, import `defineEffects()` from the dedicated effects subpath.
+
+```typescript
+import { defineEffects } from "@manifesto-ai/sdk/effects";
+```
+
+`defineEffects()` is an authoring helper only. It still returns a plain `Record<string, EffectHandler>`, and handlers still return concrete `Patch[]`.
 
 ## Base Runtime Example
 

--- a/docs/concepts/effect.md
+++ b/docs/concepts/effect.md
@@ -35,20 +35,21 @@ It does not execute the fetch inline inside the domain.
 ## In TypeScript
 
 ```typescript
-import type { EffectHandler } from "@manifesto-ai/sdk";
+import { defineEffects } from "@manifesto-ai/sdk/effects";
+import type { UserProfileDomain } from "./user-profile-types";
 
-export const effects = {
+export const effects = defineEffects<UserProfileDomain>(({ set }, MEL) => ({
   "api.fetchUser": async (params) => {
     const { id } = params as { id: string };
     const response = await fetch(`https://example.com/users/${id}`);
     const user = await response.json();
 
     return [
-      { op: "set", path: [{ kind: "prop", name: "user" }], value: user },
-      { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
+      set(MEL.state.user, user),
+      set(MEL.state.loading, false),
     ];
   },
-} satisfies Record<string, EffectHandler>;
+}));
 ```
 
 The handler performs IO and returns patches that become part of the next snapshot.

--- a/docs/guide/essentials/creating-an-app.md
+++ b/docs/guide/essentials/creating-an-app.md
@@ -20,13 +20,19 @@ const app = createManifesto(CounterSchema, {}).activate();
 The first argument is your domain schema. The second argument is the effect handler map.
 
 ```typescript
-const app = createManifesto(UserProfileSchema, {
-  "api.fetchUser": async (params) => {
-    return [
-      { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
-    ];
-  },
-}).activate();
+import { createManifesto } from "@manifesto-ai/sdk";
+import { defineEffects } from "@manifesto-ai/sdk/effects";
+import UserProfileSchema from "./user-profile.mel";
+import type { UserProfileDomain } from "./user-profile-types";
+
+const app = createManifesto(
+  UserProfileSchema,
+  defineEffects<UserProfileDomain>(({ set }, MEL) => ({
+    "api.fetchUser": async () => [
+      set(MEL.state.loading, false),
+    ],
+  })),
+).activate();
 ```
 
 Pass `{}` when the domain does not declare external effects.

--- a/docs/guide/essentials/effects.md
+++ b/docs/guide/essentials/effects.md
@@ -37,24 +37,27 @@ Start with a named effect when the work crosses a process boundary. Start with `
 ## Register a Handler
 
 ```typescript
-const app = createManifesto(UserProfileSchema, {
+import { defineEffects } from "@manifesto-ai/sdk/effects";
+import type { UserProfileDomain } from "./user-profile-types";
+
+const app = createManifesto(UserProfileSchema, defineEffects<UserProfileDomain>(({ set }, MEL) => ({
   "api.fetchUser": async (params) => {
     const { id } = params as { id: string };
     const user = await fetchUser(id);
 
     return [
-      { op: "set", path: [{ kind: "prop", name: "userName" }], value: user.name },
-      { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
+      set(MEL.state.userName, user.name),
+      set(MEL.state.loading, false),
     ];
   },
-}).activate();
+}))).activate();
 ```
 
 Handlers return patches. The next Snapshot carries the visible result.
 
-## Patch Ops Returned by Handlers
+## Low-Level Patch Ops Returned by Handlers
 
-Effect handlers return `Patch[]`. Use the smallest patch that describes the visible result:
+`defineEffects()` still lowers to concrete `Patch[]`. If you want the low-level form directly, use the smallest raw patch that describes the visible result:
 
 | Patch op | Use When | Example |
 |----------|----------|---------|

--- a/docs/guides/effect-handlers.md
+++ b/docs/guides/effect-handlers.md
@@ -17,7 +17,7 @@ action fetchUser(id: string) {
 }
 ```
 
-At that point you need to register a handler in `createManifesto({ effects })`.
+At that point you need to register a handler in `createManifesto(schema, effects)`.
 
 ---
 
@@ -46,9 +46,10 @@ Do not return raw values. Do not rely on a hidden callback channel.
 ## A Minimal Example
 
 ```typescript
-import type { EffectHandler } from "@manifesto-ai/sdk";
+import { defineEffects } from "@manifesto-ai/sdk/effects";
+import type { UserProfileDomain } from "./user-profile-types";
 
-export const effects = {
+export const effects = defineEffects<UserProfileDomain>(({ set, unset }, MEL) => ({
   "api.fetchUser": async (params) => {
     const { id } = params as { id: string };
 
@@ -61,22 +62,21 @@ export const effects = {
       const user = await response.json();
 
       return [
-        { op: "set", path: [{ kind: "prop", name: "user" }], value: user },
-        { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
-        { op: "unset", path: [{ kind: "prop", name: "error" }] },
+        set(MEL.state.user, user),
+        set(MEL.state.loading, false),
+        unset(MEL.state.error),
       ];
     } catch (error) {
       return [
-        { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
-        {
-          op: "set",
-          path: [{ kind: "prop", name: "error" }],
-          value: error instanceof Error ? error.message : "Unknown error",
-        },
+        set(MEL.state.loading, false),
+        set(
+          MEL.state.error,
+          error instanceof Error ? error.message : "Unknown error",
+        ),
       ];
     }
   },
-} satisfies Record<string, EffectHandler>;
+}));
 ```
 
 Register it:
@@ -86,10 +86,28 @@ import { createManifesto } from "@manifesto-ai/sdk";
 import DomainMel from "./domain.mel";
 import { effects } from "./effects";
 
-const manifesto = createManifesto({
-  schema: DomainMel,
-  effects,
-});
+const manifesto = createManifesto(DomainMel, effects);
+```
+
+`defineEffects()` is only an authoring helper. Each handler still returns concrete `Patch[]`, and raw patch literals are still valid when you want the low-level surface.
+
+## Low-Level Raw Patch Form
+
+```typescript
+import type { EffectHandler } from "@manifesto-ai/sdk";
+
+export const effects = {
+  "api.fetchUser": async (params) => {
+    const { id } = params as { id: string };
+    const user = await fetchUser(id);
+
+    return [
+      { op: "set", path: [{ kind: "prop", name: "user" }], value: user },
+      { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
+      { op: "unset", path: [{ kind: "prop", name: "error" }] },
+    ];
+  },
+} satisfies Record<string, EffectHandler>;
 ```
 
 ---

--- a/docs/tutorial/03-effects.md
+++ b/docs/tutorial/03-effects.md
@@ -75,9 +75,10 @@ That does not execute the request by itself. It declares a requirement for the H
 Create `effects.ts`:
 
 ```typescript
-import type { EffectHandler } from "@manifesto-ai/sdk";
+import { defineEffects } from "@manifesto-ai/sdk/effects";
+import type { UserProfileDomain } from "./user-profile-types";
 
-export const effects = {
+export const effects = defineEffects<UserProfileDomain>(({ set, unset }, MEL) => ({
   "api.fetchUser": async (params, ctx) => {
     const { id } = params as { id: string };
 
@@ -90,28 +91,27 @@ export const effects = {
       const user = (await response.json()) as { id: string; name: string };
 
       return [
-        { op: "set", path: [{ kind: "prop", name: "user" }], value: user },
-        { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
-        { op: "unset", path: [{ kind: "prop", name: "error" }] },
+        set(MEL.state.user, user),
+        set(MEL.state.loading, false),
+        unset(MEL.state.error),
       ];
     } catch (error) {
       return [
-        { op: "set", path: [{ kind: "prop", name: "loading" }], value: false },
-        {
-          op: "set",
-          path: [{ kind: "prop", name: "error" }],
-          value: error instanceof Error ? error.message : "Unknown error",
-        },
+        set(MEL.state.loading, false),
+        set(
+          MEL.state.error,
+          error instanceof Error ? error.message : "Unknown error",
+        ),
       ];
     }
   },
-} satisfies Record<string, EffectHandler>;
+}));
 ```
 
 Two details matter here:
 
 - The handler receives `params` plus `{ snapshot }`
-- The handler returns patches that update the domain
+- The handler returns concrete patches that update the domain
 
 It does not "return the fetched user to the action." The next snapshot carries that result.
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -12,6 +12,7 @@ Use the SDK when you want:
 
 - the shortest path to a running base runtime
 - typed intent creation through `MEL.actions.*`
+- optional typed effect authoring through `@manifesto-ai/sdk/effects`
 - `dispatchAsync`, subscriptions, legality queries, explanation reads, dry-run simulation, and snapshot reads in one package
 - projected Snapshot reads by default, with canonical inspection available explicitly
 - safe post-activation arbitrary-snapshot tooling through `@manifesto-ai/sdk/extensions`
@@ -30,6 +31,8 @@ console.log(instance.getSnapshot().data.count);
 ```
 
 Base runtime reads cover availability, dispatchability, intent explanation, dry-run simulation, subscriptions, events, and both projected and canonical snapshot access.
+
+Effect authoring helpers live on the dedicated `@manifesto-ai/sdk/effects` subpath. The root package stays centered on `createManifesto()`.
 
 If you need review, approval, or sealed history later, compose `@manifesto-ai/lineage` and `@manifesto-ai/governance` before `activate()`. If you need arbitrary-snapshot tooling after activation, use `@manifesto-ai/sdk/extensions`.
 

--- a/packages/sdk/docs/sdk-SPEC.md
+++ b/packages/sdk/docs/sdk-SPEC.md
@@ -206,7 +206,37 @@ type TypedMEL<T extends ManifestoDomainShape> = {
 };
 ```
 
-### 5.5 Runtime Helper Types
+### 5.5 Effect Authoring Subpath
+
+The root SDK contract remains centered on `createManifesto()`. Typed effect authoring helpers live on the adjunct `@manifesto-ai/sdk/effects` subpath.
+
+```typescript
+type MergeableObject<TValue> = TValue extends readonly unknown[]
+  ? never
+  : TValue extends object
+    ? TValue
+    : never;
+
+type PatchBuilder = {
+  set<TValue>(ref: FieldRef<TValue>, value: TValue): Patch;
+  unset<TValue>(ref: FieldRef<TValue>): Patch;
+  merge<TValue>(
+    ref: FieldRef<MergeableObject<TValue>>,
+    value: Partial<MergeableObject<TValue>>,
+  ): Patch;
+};
+
+declare function defineEffects<T extends ManifestoDomainShape>(
+  factory: (
+    ops: PatchBuilder,
+    MEL: TypedMEL<T>,
+  ) => Record<string, EffectHandler>,
+): Record<string, EffectHandler>;
+```
+
+`defineEffects()` is an authoring helper, not a runtime seam. It MUST return the same `Record<string, EffectHandler>` contract consumed by `createManifesto(schema, effects)`. v1 lowering is limited to top-level `MEL.state.*` refs via `FieldRef.name`. Implementations MAY attach runtime metadata to refs internally, but effect handlers MUST still return concrete `Patch[]`.
+
+### 5.6 Runtime Helper Types
 
 ```typescript
 type ActionArgs<
@@ -1124,6 +1154,8 @@ The following v2 surfaces are removed from the v3 SDK contract:
 - SDK thin world re-exports such as `createWorld()`
 - string-name canonical intent creation
 - v2 compatibility framing built around ready-to-use instances
+
+The additive `@manifesto-ai/sdk/effects` subpath does not revive the removed v2 helper-first runtime surface. `defineEffects()` is constrained to effect authoring and does not alter the root `createManifesto()` contract.
 
 This is an intentional hard cut. v2 usage patterns are not compatibility targets for the v3 spec.
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./effects": {
+      "types": "./dist/effects.d.ts",
+      "import": "./dist/effects.js"
+    },
     "./extensions": {
       "types": "./dist/extensions.d.ts",
       "import": "./dist/extensions.js"

--- a/packages/sdk/src/__tests__/effects.test.ts
+++ b/packages/sdk/src/__tests__/effects.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+import {
+  hashSchemaSync,
+  semanticPathToPatchPath,
+  type DomainSchema,
+} from "@manifesto-ai/core";
+
+import { createManifesto } from "../index.js";
+import { defineEffects } from "../effects.js";
+
+const pp = semanticPathToPatchPath;
+
+type User = {
+  id: string;
+  name: string;
+};
+
+type EffectsDomain = {
+  actions: {
+    fetchUser: (id: string) => void;
+    markRawHandled: () => void;
+  };
+  state: {
+    user: User | null;
+    loading: boolean;
+    error: string | null;
+    profile: {
+      name?: string;
+      source?: string;
+    };
+    rawHandled: boolean;
+  };
+  computed: {};
+};
+
+function withHash(schema: Omit<DomainSchema, "hash">): DomainSchema {
+  return {
+    ...schema,
+    hash: hashSchemaSync(schema),
+  };
+}
+
+function createEffectsSchema(): DomainSchema {
+  return withHash({
+    id: "manifesto:sdk-effects-builder",
+    version: "1.0.0",
+    types: {},
+    state: {
+      fields: {
+        user: {
+          type: "object",
+          required: false,
+          default: null,
+          fields: {
+            id: { type: "string", required: true },
+            name: { type: "string", required: true },
+          },
+        },
+        loading: { type: "boolean", required: false, default: false },
+        error: { type: "string", required: false, default: null },
+        profile: {
+          type: "object",
+          required: false,
+          default: {},
+          fields: {
+            name: { type: "string", required: false },
+            source: { type: "string", required: false },
+          },
+        },
+        rawHandled: { type: "boolean", required: false, default: false },
+      },
+    },
+    computed: { fields: {} },
+    actions: {
+      fetchUser: {
+        input: {
+          type: "object",
+          required: true,
+          fields: {
+            id: { type: "string", required: true },
+          },
+        },
+        flow: {
+          kind: "if",
+          cond: {
+            kind: "isNull",
+            arg: { kind: "get", path: "user" },
+          },
+          then: {
+            kind: "seq",
+            steps: [
+              {
+                kind: "patch",
+                op: "set",
+                path: pp("loading"),
+                value: { kind: "lit", value: true },
+              },
+              {
+                kind: "patch",
+                op: "set",
+                path: pp("error"),
+                value: { kind: "lit", value: "stale" },
+              },
+              {
+                kind: "effect",
+                type: "api.fetchUser",
+                params: {
+                  id: { kind: "get", path: "input.id" },
+                },
+              },
+            ],
+          },
+          else: { kind: "halt", reason: "user-loaded" },
+        },
+      },
+      markRawHandled: {
+        flow: {
+          kind: "if",
+          cond: {
+            kind: "not",
+            arg: { kind: "get", path: "rawHandled" },
+          },
+          then: {
+            kind: "effect",
+            type: "api.raw",
+            params: {},
+          },
+          else: { kind: "halt", reason: "raw-handled" },
+        },
+      },
+    },
+  });
+}
+
+describe("@manifesto-ai/sdk/effects", () => {
+  it("lowers set, unset, and merge to concrete top-level patch paths in order", async () => {
+    const user: User = { id: "123", name: "Ada" };
+    const effects = defineEffects<EffectsDomain>(({ set, unset, merge }, MEL) => ({
+      "api.fetchUser": async () => [
+        set(MEL.state.user, user),
+        set(MEL.state.loading, false),
+        unset(MEL.state.error),
+        merge(MEL.state.profile, { name: user.name, source: "api" }),
+      ],
+    }));
+
+    const patches = await effects["api.fetchUser"](
+      { id: "123" },
+      {
+        snapshot: {
+          data: {
+            user: null,
+            loading: true,
+            error: "stale",
+            profile: {},
+            rawHandled: false,
+          },
+          computed: {},
+          system: {
+            status: "pending",
+            lastError: null,
+          },
+          meta: {
+            schemaHash: "schema-hash",
+          },
+        },
+      },
+    );
+
+    expect(patches).toEqual([
+      {
+        op: "set",
+        path: [{ kind: "prop", name: "user" }],
+        value: user,
+      },
+      {
+        op: "set",
+        path: [{ kind: "prop", name: "loading" }],
+        value: false,
+      },
+      {
+        op: "unset",
+        path: [{ kind: "prop", name: "error" }],
+      },
+      {
+        op: "merge",
+        path: [{ kind: "prop", name: "profile" }],
+        value: { name: "Ada", source: "api" },
+      },
+    ]);
+  });
+
+  it("integrates with createManifesto while preserving raw patch handlers inside defineEffects", async () => {
+    const user: User = { id: "123", name: "Ada" };
+    const app = createManifesto<EffectsDomain>(
+      createEffectsSchema(),
+      defineEffects<EffectsDomain>(({ set, unset, merge }, MEL) => ({
+        "api.fetchUser": async (params) => {
+          const { id } = params as { id: string };
+
+          return [
+            set(MEL.state.user, { ...user, id }),
+            set(MEL.state.loading, false),
+            unset(MEL.state.error),
+            merge(MEL.state.profile, { name: user.name }),
+          ];
+        },
+        "api.raw": async () => [{
+          op: "set",
+          path: pp("rawHandled"),
+          value: true,
+        }],
+      })),
+    ).activate();
+
+    const loaded = await app.dispatchAsync(
+      app.createIntent(app.MEL.actions.fetchUser, "123"),
+    );
+
+    expect(loaded.data.user).toEqual(user);
+    expect(loaded.data.loading).toBe(false);
+    expect(loaded.data.profile).toEqual({ name: "Ada" });
+    expect(loaded.data).not.toHaveProperty("error");
+
+    const rawHandled = await app.dispatchAsync(
+      app.createIntent(app.MEL.actions.markRawHandled),
+    );
+
+    expect(rawHandled.data.rawHandled).toBe(true);
+
+    app.dispose();
+  });
+
+  it("rejects non-FieldRef inputs and reserved platform namespaces at runtime", () => {
+    const effects = defineEffects<EffectsDomain>(({ set, merge }, MEL) => {
+      expect(() => set(MEL.computed as never, true as never)).toThrowError(
+        expect.objectContaining({
+          code: "SCHEMA_ERROR",
+        }),
+      );
+
+      expect(() => set({ __kind: "FieldRef", name: "$host" } as never, true as never)).toThrowError(
+        expect.objectContaining({
+          code: "SCHEMA_ERROR",
+        }),
+      );
+
+      expect(() => merge(MEL.state.profile, [] as never)).toThrowError(
+        expect.objectContaining({
+          code: "SCHEMA_ERROR",
+        }),
+      );
+
+      return {};
+    });
+
+    expect(effects).toEqual({});
+  });
+
+  it("surfaces helpful ManifestoError messages for runtime misuse", async () => {
+    const effects = defineEffects<EffectsDomain>(({ set }, MEL) => ({
+      "api.fetchUser": async () => {
+        set(MEL.actions.fetchUser as never, null as never);
+        return [];
+      },
+    }));
+
+    await expect(effects["api.fetchUser"]({}, { snapshot: {} as never })).rejects.toMatchObject({
+      code: "SCHEMA_ERROR",
+      message: "PatchBuilder.set() expects a FieldRef from defineEffects(..., MEL.state.*)",
+    });
+  });
+});

--- a/packages/sdk/src/__tests__/public-exports.test.ts
+++ b/packages/sdk/src/__tests__/public-exports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import * as sdk from "../index.js";
+import * as effectHelpers from "../effects.js";
 import * as extensions from "../extensions.js";
 
 describe("SDK public runtime exports", () => {
@@ -18,8 +19,14 @@ describe("SDK public runtime exports", () => {
     expect("dispatchAsync" in sdk).toBe(false);
     expect("DispatchRejectedError" in sdk).toBe(false);
     expect("defineOps" in sdk).toBe(false);
+    expect("defineEffects" in sdk).toBe(false);
     expect("createWorld" in sdk).toBe(false);
     expect("createIntent" in sdk).toBe(false);
+  });
+
+  it("keeps effect authoring helpers on the dedicated effects subpath", () => {
+    expect(effectHelpers.defineEffects).toBeDefined();
+    expect("defineEffects" in sdk).toBe(false);
   });
 
   it("keeps the extension kernel on the extensions subpath", () => {

--- a/packages/sdk/src/__tests__/types/effects.typecheck.ts
+++ b/packages/sdk/src/__tests__/types/effects.typecheck.ts
@@ -38,6 +38,9 @@ defineEffects<EffectsDomain>(({ set, merge }, MEL) => {
   // @ts-expect-error wrong value type for boolean field
   void set(MEL.state.loading, "oops");
 
+  // @ts-expect-error set must derive its value type from the referenced field
+  void set(MEL.state.loading, undefined);
+
   // @ts-expect-error merge rejects primitive fields
   void merge(MEL.state.loading, { nope: true });
 

--- a/packages/sdk/src/__tests__/types/effects.typecheck.ts
+++ b/packages/sdk/src/__tests__/types/effects.typecheck.ts
@@ -1,0 +1,54 @@
+import { defineEffects } from "../../effects.ts";
+
+type User = {
+  id: string;
+  name: string;
+};
+
+type EffectsDomain = {
+  actions: {
+    fetchUser: (id: string) => void;
+  };
+  state: {
+    user: User | null;
+    loading: boolean;
+    profile: {
+      name?: string;
+      source?: string;
+    };
+    tags: string[];
+  };
+  computed: {
+    userCount: number;
+  };
+};
+
+const effects = defineEffects<EffectsDomain>(({ set, unset, merge }, MEL) => ({
+  "api.fetchUser": async () => [
+    set(MEL.state.loading, false),
+    set(MEL.state.user, { id: "123", name: "Ada" }),
+    unset(MEL.state.user),
+    merge(MEL.state.profile, { name: "Ada", source: "api" }),
+  ],
+}));
+
+void effects;
+
+defineEffects<EffectsDomain>(({ set, merge }, MEL) => {
+  // @ts-expect-error wrong value type for boolean field
+  void set(MEL.state.loading, "oops");
+
+  // @ts-expect-error merge rejects primitive fields
+  void merge(MEL.state.loading, { nope: true });
+
+  // @ts-expect-error merge rejects array fields
+  void merge(MEL.state.tags, { 0: "tag" });
+
+  // @ts-expect-error merge rejects computed refs
+  void merge(MEL.computed.userCount, { nope: true });
+
+  // @ts-expect-error set rejects action refs
+  void set(MEL.actions.fetchUser, { id: "123", name: "Ada" });
+
+  return {};
+});

--- a/packages/sdk/src/effects.ts
+++ b/packages/sdk/src/effects.ts
@@ -1,0 +1,146 @@
+import {
+  mergePatch,
+  propSegment,
+  setPatch,
+  unsetPatch,
+  type Patch,
+  type PatchPath,
+} from "@manifesto-ai/core";
+
+import type {
+  ComputedRef,
+  EffectHandler,
+  FieldRef,
+  ManifestoDomainShape,
+  TypedActionRef,
+  TypedMEL,
+} from "./types.js";
+import { ManifestoError } from "./errors.js";
+
+type RefLike = {
+  readonly __kind: string;
+  readonly name: string;
+};
+
+type MergeableObject<TValue> = TValue extends readonly unknown[]
+  ? never
+  : TValue extends object
+    ? TValue
+    : never;
+
+export type PatchBuilder = {
+  set<TValue>(ref: FieldRef<TValue>, value: TValue): Patch;
+  unset<TValue>(ref: FieldRef<TValue>): Patch;
+  merge<TValue>(
+    ref: FieldRef<MergeableObject<TValue>>,
+    value: Partial<MergeableObject<TValue>>,
+  ): Patch;
+};
+
+type DefineEffectsFactory<T extends ManifestoDomainShape> = (
+  ops: PatchBuilder,
+  MEL: TypedMEL<T>,
+) => Record<string, EffectHandler>;
+
+function isPlainObjectRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertFieldRef(op: keyof PatchBuilder, ref: unknown): asserts ref is FieldRef<unknown> {
+  if (!ref || typeof ref !== "object") {
+    throw new ManifestoError(
+      "SCHEMA_ERROR",
+      `PatchBuilder.${op}() expects a FieldRef from defineEffects(..., MEL.state.*)`,
+    );
+  }
+
+  const candidate = ref as Partial<FieldRef<unknown>>;
+  if (candidate.__kind !== "FieldRef" || typeof candidate.name !== "string" || candidate.name.length === 0) {
+    throw new ManifestoError(
+      "SCHEMA_ERROR",
+      `PatchBuilder.${op}() expects a FieldRef from defineEffects(..., MEL.state.*)`,
+    );
+  }
+
+  if (candidate.name.startsWith("$")) {
+    throw new ManifestoError(
+      "SCHEMA_ERROR",
+      `PatchBuilder.${op}() does not allow reserved platform namespaces such as "${candidate.name}"`,
+    );
+  }
+}
+
+function assertMergeValue(value: unknown): asserts value is Record<string, unknown> {
+  if (!isPlainObjectRecord(value)) {
+    throw new ManifestoError(
+      "SCHEMA_ERROR",
+      "PatchBuilder.merge() expects a plain object value",
+    );
+  }
+}
+
+function createRefNamespace<TRef extends RefLike>(
+  kind: TRef["__kind"],
+): Record<string, TRef> {
+  const cache = new Map<string, TRef>();
+  const target = Object.freeze(Object.create(null)) as Record<string, TRef>;
+
+  return new Proxy(target, {
+    get(currentTarget, property, receiver) {
+      if (typeof property !== "string") {
+        return Reflect.get(currentTarget, property, receiver);
+      }
+
+      const existing = cache.get(property);
+      if (existing) {
+        return existing;
+      }
+
+      const ref = Object.freeze({
+        __kind: kind,
+        name: property,
+      }) as TRef;
+
+      cache.set(property, ref);
+      return ref;
+    },
+  });
+}
+
+function toPatchPath(ref: FieldRef<unknown>): PatchPath {
+  return [propSegment(ref.name)];
+}
+
+const PATCH_BUILDER: PatchBuilder = Object.freeze({
+  set<TValue>(ref: FieldRef<TValue>, value: TValue): Patch {
+    assertFieldRef("set", ref);
+    return setPatch(toPatchPath(ref), value);
+  },
+  unset<TValue>(ref: FieldRef<TValue>): Patch {
+    assertFieldRef("unset", ref);
+    return unsetPatch(toPatchPath(ref));
+  },
+  merge<TValue>(
+    ref: FieldRef<MergeableObject<TValue>>,
+    value: Partial<MergeableObject<TValue>>,
+  ): Patch {
+    assertFieldRef("merge", ref);
+    assertMergeValue(value);
+    return mergePatch(
+      toPatchPath(ref),
+      value,
+    );
+  },
+});
+
+const AUTHORING_MEL = Object.freeze({
+  actions: createRefNamespace<TypedActionRef<ManifestoDomainShape>>("ActionRef"),
+  state: createRefNamespace<FieldRef<unknown>>("FieldRef"),
+  computed: createRefNamespace<ComputedRef<unknown>>("ComputedRef"),
+}) as TypedMEL<ManifestoDomainShape>;
+
+export function defineEffects<T extends ManifestoDomainShape>(
+  factory: DefineEffectsFactory<T>,
+): Record<string, EffectHandler> {
+  return factory(PATCH_BUILDER, AUTHORING_MEL as TypedMEL<T>);
+}

--- a/packages/sdk/src/effects.ts
+++ b/packages/sdk/src/effects.ts
@@ -28,12 +28,18 @@ type MergeableObject<TValue> = TValue extends readonly unknown[]
     ? TValue
     : never;
 
+type RefValue<TRef extends FieldRef<unknown>> = TRef extends FieldRef<infer TValue>
+  ? TValue
+  : never;
+
+type MergeValue<TRef extends FieldRef<unknown>> = Partial<MergeableObject<RefValue<TRef>>>;
+
 export type PatchBuilder = {
-  set<TValue>(ref: FieldRef<TValue>, value: TValue): Patch;
-  unset<TValue>(ref: FieldRef<TValue>): Patch;
-  merge<TValue>(
-    ref: FieldRef<MergeableObject<TValue>>,
-    value: Partial<MergeableObject<TValue>>,
+  set<TRef extends FieldRef<unknown>>(ref: TRef, value: RefValue<TRef>): Patch;
+  unset<TRef extends FieldRef<unknown>>(ref: TRef): Patch;
+  merge<TRef extends FieldRef<unknown>>(
+    ref: TRef,
+    value: MergeValue<TRef>,
   ): Patch;
 };
 
@@ -112,17 +118,17 @@ function toPatchPath(ref: FieldRef<unknown>): PatchPath {
 }
 
 const PATCH_BUILDER: PatchBuilder = Object.freeze({
-  set<TValue>(ref: FieldRef<TValue>, value: TValue): Patch {
+  set<TRef extends FieldRef<unknown>>(ref: TRef, value: RefValue<TRef>): Patch {
     assertFieldRef("set", ref);
     return setPatch(toPatchPath(ref), value);
   },
-  unset<TValue>(ref: FieldRef<TValue>): Patch {
+  unset<TRef extends FieldRef<unknown>>(ref: TRef): Patch {
     assertFieldRef("unset", ref);
     return unsetPatch(toPatchPath(ref));
   },
-  merge<TValue>(
-    ref: FieldRef<MergeableObject<TValue>>,
-    value: Partial<MergeableObject<TValue>>,
+  merge<TRef extends FieldRef<unknown>>(
+    ref: TRef,
+    value: MergeValue<TRef>,
   ): Patch {
     assertFieldRef("merge", ref);
     assertMergeValue(value);

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsup";
 const release = process.env.MANIFESTO_RELEASE === "1";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/extensions.ts", "src/provider.ts"],
+  entry: ["src/index.ts", "src/effects.ts", "src/extensions.ts", "src/provider.ts"],
   format: "esm",
   tsconfig: "tsconfig.build.json",
   dts: false,


### PR DESCRIPTION
## Summary
- add `@manifesto-ai/sdk/effects` with `defineEffects` and typed top-level patch builder helpers
- harden builder misuse with runtime guards for invalid refs, reserved namespaces, and invalid merge payloads
- migrate canonical SDK/effects docs to builder-first examples while keeping raw patch literals documented

## Why
SDK effect handlers previously forced users to hand-author raw patch literals even for simple top-level state updates. This keeps the Core/Host patch contract unchanged while improving SDK authoring DX.

## Developer Impact
Consumers can now write effect maps with typed `MEL.state.*` refs through `defineEffects`, while existing raw `Patch[]` handlers continue to work unchanged.

## Validation
- `pnpm --filter @manifesto-ai/sdk test:runtime`
- `pnpm --filter @manifesto-ai/sdk test:types`
- `pnpm --filter @manifesto-ai/sdk build`
- `pnpm docs:api:inventory`
- `pnpm docs:api:check`
- `pnpm docs:build`
