### PR TITLE
feat(compiler): add bounded MEL sugar contract

### DIFF
--- a/docs/api/compiler.md
+++ b/docs/api/compiler.md
@@ -20,6 +20,7 @@ Current compiler responsibilities also include:
 - intent-level dispatchability via `dispatchable when`
 - rich schema-position lowering through `state.fieldTypes`, `action.inputType`, and `action.params`
 - pure collection builtins such as `filter`, `map`, `find`, `every`, and `some` in expression contexts
+- bounded lowering-only MEL sugar such as `absDiff`, `clamp`, `idiv`, `streak`, `match`, `argmax`, and `argmin`
 
 ---
 

--- a/docs/mel/ERROR-GUIDE.md
+++ b/docs/mel/ERROR-GUIDE.md
@@ -55,7 +55,7 @@ computed lowest = min(map(items, $item.price))
 
 **Error:** `SemanticError: Aggregation accepts only direct array references.`
 
-**Rule violated:** `sum()`, `min()`, `max()` accept only direct state references, not expressions.
+**Rule violated:** `sum()`, `min()`, `max()` accept only direct state or computed array references, not inline expressions.
 
 ```mel
 // ✅ FIXED: Use a computed intermediate, then aggregate
@@ -63,33 +63,24 @@ computed positivePrices = filter(prices, gt($item, 0))
 computed total = sum(positivePrices)
 ```
 
-**Why:** MEL expresses facts ("the sum of X"), not procedures ("how to compute sum"). See FDR-MEL-060.
+**Why:** MEL expresses facts ("the sum of X"), not procedures ("how to compute sum"). See FDR-MEL-062.
 
 ---
 
-### Error: $item outside effect
+### Error: $item outside collection/effect context
 
 ```mel
 // ❌ BROKEN
 computed doubled = mul($item, 2)
 ```
 
-**Error:** `SemanticError: '$item' is only valid inside effect iteration context.`
+**Error:** `SemanticError: '$item' is only valid inside a collection predicate/mapper or effect iteration context.`
 
-**Rule violated:** `$item` refers to the current element during effect iteration. It has no meaning outside effects.
+**Rule violated:** `$item` refers to the current element of a collection traversal. It is valid inside expression-level `filter()` / `map()` / `find()` / `every()` / `some()` predicates or mappers, and inside effect-level iteration payloads. It has no meaning outside those contexts.
 
 ```mel
-// ✅ FIXED: Use $item inside effect
-action doubleAll() {
-  once(doubling) {
-    patch doubling = $meta.intentId
-    effect array.map({
-      source: items,
-      select: mul($item, 2),
-      into: doubled
-    })
-  }
-}
+// ✅ FIXED: Use $item inside a collection mapper
+computed doubled = map(items, mul($item, 2))
 ```
 
 ---
@@ -134,6 +125,82 @@ computed arrayMin = min(prices)          // Array aggregation
 computed smaller = min(a, b)             // Value comparison
 computed smallest = min(a, b, c, d)      // Multi-value comparison
 ```
+
+---
+
+### Error: Wrong arity for bounded sugar
+
+```mel
+// ❌ BROKEN
+computed a = clamp(score, 0)
+computed b = idiv(total, buckets, extra)
+computed c = streak(previous)
+computed d = clamp(score, 10, 0)
+```
+
+**Error:** `SemanticError: 'clamp' expects 3 arguments, 'idiv' expects 2, and 'streak' expects 2. Literal clamp bounds must be ordered lo, hi.`
+
+**Rule violated:** These bounded sugar functions have fixed arity. They are ordinary function calls, not variadic helpers. `clamp()` also does not silently swap literal bounds for you.
+
+```mel
+// ✅ FIXED
+computed a = clamp(score, 0, 100)
+computed b = idiv(total, buckets)
+computed c = streak(previous, eq(kind, "miss"))
+computed d = clamp(score, 0, 10)
+```
+
+---
+
+### Error: Malformed match arm or missing default
+
+```mel
+// ❌ BROKEN
+computed label = match(status, ["open", "Open"], ["closed", "Closed"])
+computed code = match(status, "open", 1, 0)
+computed mixed = match(status, ["open", 1], ["closed", "Closed"], 0)
+computed duplicate = match(status, ["open", 1], ["open", 2], 0)
+```
+
+**Error:** `SemanticError: 'match' requires inline [key, value] arms and a final default value.`
+
+**Rule violated:** `match()` is only supported in function form: `match(key, [k1, v1], [k2, v2], ..., defaultValue)`. Arm keys must be literal primitives and duplicates are invalid.
+
+```mel
+// ✅ FIXED
+computed label = match(status, ["open", "Open"], ["closed", "Closed"], "Unknown")
+computed code = match(status, ["open", 1], ["closed", 0], -1)
+```
+
+**Additional rule:** All `match` keys must be the same primitive comparable type as the first argument, and all arm values must unify with the default value. Mixing result types such as `number` and `string` is invalid.
+
+---
+
+### Error: Invalid argmax/argmin candidate shape
+
+```mel
+// ❌ BROKEN
+computed best = argmax(candidates, "first")
+computed best = argmax(["a", true, 1], ["b", 2, 3], tieBreak)
+computed best = argmax(["a", true, 1], ["b", true, "high"], "last")
+```
+
+**Error:** `SemanticError: 'argmax'/'argmin' require inline [label, eligible, score] candidates and a literal tie-break.`
+
+**Rule violated:** `argmax()` and `argmin()` do not accept runtime arrays. Each candidate must be written inline as `[label, eligible, score]`, where `eligible` is boolean and `score` is number. The final argument must be the literal `"first"` or `"last"`.
+
+```mel
+// ✅ FIXED
+computed best = argmax(
+  ["a", candidateA, scoreA],
+  ["b", candidateB, scoreB],
+  "first"
+)
+```
+
+**Additional rule:** If all candidates are ineligible, the result is `null`, not an error.
+
+**Tie-break rule:** For equal eligible scores, `"first"` chooses the earliest source-order candidate and `"last"` chooses the latest one.
 
 ---
 
@@ -704,6 +771,7 @@ action processAll() {
 |----------------|--------------|-----|
 | Hidden iteration | Using effect-level `array.filter/map()` in computed | Use expression builtins `filter()` / `map()` |
 | Aggregation | Nested calls in sum/min/max | Prepare data with effect first |
+| Bounded sugar shape | Wrong arity or malformed `match` / `argmax` / `argmin` | Use the fixed function forms with inline tuple literals |
 | Effect in computed | Thinking computed can do IO | Move to action |
 | Unguarded statement | Missing when/once | Add guard |
 | Non-boolean condition | Truthy coercion assumption | Use explicit comparison |

--- a/docs/mel/EXAMPLES.md
+++ b/docs/mel/EXAMPLES.md
@@ -1,25 +1,26 @@
 # MEL Examples Directory Structure
 
-> **Purpose:** Guide for organizing and exploring MEL example files.
+> **Purpose:** Guide for organizing and exploring the example `.mel` files under `docs/mel/examples/`.
 
 ---
 
 ## Directory Layout
 
 ```
-examples/
+docs/mel/examples/
 ├── computed/
 │   ├── basic.mel          # Basic computed expressions
 │   ├── aggregation.mel    # sum, min, max, len
 │   ├── boolean.mel        # Boolean conditions
+│   ├── bounded-sugar.mel  # absDiff, clamp, idiv, streak
 │   ├── null-handling.mel  # coalesce, isNull patterns
-│   └── object.mel         # merge, keys, values, entries
+│   ├── object.mel         # merge, keys, values, entries
+│   └── selection-sugar.mel # match, argmax, argmin
 │
 ├── action/
 │   ├── basic.mel          # Simple actions with when
 │   ├── parameters.mel     # Actions with input parameters
 │   ├── available.mel      # available when preconditions
-│   ├── dispatchable.mel   # dispatchable when bound-intent legality
 │   └── multi-step.mel     # Multi-step pipelines with once
 │
 ├── control/
@@ -30,9 +31,8 @@ examples/
 │
 └── effects/
     ├── api.mel            # API fetch/post effects
-    ├── array.mel          # filter, map, sort, flatMap
-    ├── record.mel         # keys, values, entries
-    └── partition.mel      # Splitting arrays
+    ├── array.mel          # filter, map, find, every, some
+    └── record.mel         # keys, values, entries
 ```
 
 ---
@@ -43,8 +43,9 @@ examples/
 
 1. **New to MEL?** Start with `computed/basic.mel` and `action/basic.mel`
 2. **Understanding guards?** Read `control/when.mel` then `control/once.mel`
-3. **Working with arrays?** See `effects/array.mel` for iteration patterns
-4. **Handling errors?** Check `control/fail.mel` and `control/stop.mel`
+3. **Need bounded numeric helpers?** See `computed/bounded-sugar.mel`
+4. **Need finite branch or candidate selection?** See `computed/selection-sugar.mel`
+5. **Handling errors?** Check `control/fail.mel` and `control/stop.mel`
 
 ### Reading Order for Beginners
 
@@ -52,11 +53,13 @@ examples/
 1. computed/basic.mel       → Pure expressions
 2. action/basic.mel         → State mutations with guards
 3. control/when.mel         → Conditional execution
-4. effects/array.mel        → Declarative iteration
-5. control/once.mel         → Idempotency patterns
-6. computed/aggregation.mel → sum/min/max
-7. control/fail.mel         → Error handling
-8. action/multi-step.mel    → Complex flows
+4. computed/bounded-sugar.mel → Lowering-only arithmetic sugar
+5. computed/selection-sugar.mel → Finite branch and candidate selection
+6. effects/array.mel        → Declarative iteration
+7. control/once.mel         → Idempotency patterns
+8. computed/aggregation.mel → sum/min/max
+9. control/fail.mel         → Error handling
+10. action/multi-step.mel   → Complex flows
 ```
 
 ---
@@ -72,7 +75,10 @@ Pure expressions that derive values from state. No effects, no mutations.
 | `basic.mel` | Arithmetic, string concatenation, property access |
 | `aggregation.mel` | `sum(arr)`, `min(arr)`, `max(arr)`, `len(arr)` |
 | `boolean.mel` | `and`, `or`, `not`, comparison operators |
+| `bounded-sugar.mel` | `absDiff`, `clamp`, `idiv`, `streak` |
 | `null-handling.mel` | `coalesce`, `isNull`, `isNotNull`, ternary |
+| `object.mel` | `merge`, `keys`, `values`, `entries` |
+| `selection-sugar.mel` | `match`, `argmax`, `argmin` |
 
 ### `action/`
 
@@ -83,7 +89,6 @@ State transitions with guards, patches, and effects.
 | `basic.mel` | Simple `when` guards with `patch` |
 | `parameters.mel` | Using `$input` and parameter references |
 | `available.mel` | `available when` coarse preconditions |
-| `dispatchable.mel` | `dispatchable when` input-aware legality |
 | `multi-step.mel` | Sequential `once` blocks for pipelines |
 
 ### `control/`
@@ -104,9 +109,8 @@ Host-executed requirements.
 | File | Contents |
 |------|----------|
 | `api.mel` | `effect api.fetch`, `effect api.post` |
-| `array.mel` | `filter`, `map`, `sort`, `flatMap` with `$item` |
+| `array.mel` | `filter`, `map`, `find`, `every`, `some` with `$item` |
 | `record.mel` | `keys`, `values`, `entries` |
-| `partition.mel` | Splitting with `pass` and `fail` targets |
 
 ---
 
@@ -149,6 +153,8 @@ domain Example {
 | Add two numbers | `computed/basic.mel` |
 | Check if array is empty | `computed/boolean.mel` |
 | Sum an array | `computed/aggregation.mel` |
+| Clamp a score or compute a streak | `computed/bounded-sugar.mel` |
+| Replace nested `cond(eq(...))` chains | `computed/selection-sugar.mel` |
 | Update state conditionally | `action/basic.mel` |
 | Prevent double execution | `control/once.mel` |
 | Filter an array | `effects/array.mel` |

--- a/docs/mel/LLM-CONTEXT.md
+++ b/docs/mel/LLM-CONTEXT.md
@@ -48,11 +48,14 @@ MEL (Manifesto Expression Language) is a **declarative domain language** for def
 
 1. `when` condition must be boolean — no truthy/falsy
 2. `eq`/`neq` only compare primitives (null, boolean, number, string)
-3. `len()` only works on arrays, not records
+3. `len()` works on strings, arrays, and records/objects
 4. `keys()`/`values()`/`entries()` work as expression builtins for object decomposition. `record.*` effects are for writing results to state in action flows.
 5. `sum()`/`min()`/`max()` with single arg = array aggregation
 6. `min(a,b)`/`max(a,b)` with multiple args = value comparison
-7. Complex object types in state must be named (`type X = { ... }`)
+7. `match()` is function-form only: `match(key, [k1, v1], ..., defaultValue)`
+8. `argmax()` / `argmin()` only accept inline `[label, eligible, score]` candidates plus a literal `"first"` or `"last"` tie-break
+9. `absDiff`, `clamp`, `idiv`, and `streak` are lowering-only sugar over existing arithmetic and conditional builtins
+10. Complex object types in state must be named (`type X = { ... }`)
 
 ---
 
@@ -133,6 +136,20 @@ computed min = min(values)           // Array<T> → T | null
 computed max = max(values)           // Array<T> → T | null
 computed length = len(items)         // Array<T> → number
 
+// Bounded sugar
+computed error = absDiff(observed, predicted)
+computed bounded = clamp(score, 0, 100)
+computed buckets = idiv(total, bucketSize)
+computed missStreak = streak(previousMissStreak, eq(kind, "miss"))
+
+// Finite branch / fixed candidate selection
+computed label = match(status, ["open", "Open"], ["closed", "Closed"], "Unknown")
+computed bestKind = argmax(
+  ["coarse", coarseOk, coarseDelta],
+  ["repair", repairOk, repairDelta],
+  "first"
+)
+
 // Object functions
 computed withDefaults = merge(config, { theme: "light" })  // Shallow merge (later wins)
 computed taskIds = keys(tasks)                              // Object keys
@@ -152,6 +169,12 @@ computed now = $system.timestamp
 
 // ❌ Nested aggregation
 computed total = sum(filter(prices))
+
+// ❌ Arrow-arm match syntax is not part of the current contract
+computed label = match(status, "open" => "Open", _ => "Unknown")
+
+// ❌ Runtime-array argmax/argmin forms are not supported
+computed best = argmax(candidates, "first")
 ```
 
 ---

--- a/docs/mel/REFERENCE.md
+++ b/docs/mel/REFERENCE.md
@@ -50,6 +50,8 @@ MEL source -> @manifesto-ai/compiler -> DomainSchema -> Core -> Host
 
 MEL is a **source format**. It does not execute. It produces data that Core computes on.
 
+The builtin meanings documented in this reference are the current MEL surface. If the compiler later admits extra source-level sugar, it must do so explicitly and lower through the existing MEL → Core boundary without silently changing the meaning of the builtins documented here.
+
 ### What MEL is NOT
 
 MEL is not a general-purpose programming language. Specifically:
@@ -344,11 +346,15 @@ All MEL operations are function calls. Operators (`+`, `-`, `==`, etc.) are synt
 | `mod(a, b)` | `(number, number) → number` | Modulo remainder. Equivalent to `a % b`. |
 | `neg(a)` | `number → number` | Negation. Equivalent to `-a`. |
 | `abs(n)` | `number → number` | Absolute value. |
+| `absDiff(a, b)` | `(number, number) → number` | Absolute difference. Sugar for `abs(sub(a, b))`. |
 | `floor(n)` | `number → number` | Round down to nearest integer. |
 | `ceil(n)` | `number → number` | Round up to nearest integer. |
 | `round(n)` | `number → number` | Round to nearest integer. |
 | `sqrt(n)` | `number → number \| null` | Square root. Returns `null` if `n` is negative. |
 | `pow(base, exp)` | `(number, number) → number` | Exponentiation. `pow(2, 10)` = 1024. |
+| `clamp(x, lo, hi)` | `(number, number, number) → number` | Clamp `x` into the inclusive range `[lo, hi]`. Sugar for `min(max(x, lo), hi)`. |
+| `idiv(a, b)` | `(number, number) → number \| null` | Integer division via `floor(div(a, b))`. Returns `null` when `b` is 0. |
+| `streak(prev, cond)` | `(number, boolean) → number` | Counter sugar: returns `add(prev, 1)` when `cond` is true, otherwise `0`. |
 | `min(a, b, ...)` | `(...number) → number` | Minimum of two or more values. See also: `min(arr)` in §5.8. |
 | `max(a, b, ...)` | `(...number) → number` | Maximum of two or more values. See also: `max(arr)` in §5.8. |
 
@@ -360,13 +366,23 @@ computed withTax = mul(subtotal, 1.1)
 computed average = div(sum(scores), len(scores))
 computed remainder = mod(count, 10)
 computed magnitude = abs(neg(value))
+computed error = absDiff(observed, predicted)
 computed rounded = round(div(total, 3))
 computed hypotenuse = sqrt(add(pow(a, 2), pow(b, 2)))
+computed bounded = clamp(score, 0, 100)
+computed buckets = idiv(total, bucketSize)
+computed missStreak = streak(previousMissStreak, and(eq(kind, "shoot"), eq(hit, false)))
 computed smaller = min(priceA, priceB)
 computed largest = max(x, y, z)
 ```
 
 > **`div` returns null on zero divisor.** If the divisor may be zero, guard with `when neq(divisor, 0)` before using the result, or use `coalesce(div(a, b), 0)`.
+
+> **`clamp`, `idiv`, `streak`, and `absDiff` are lowering-only sugar.** They do not change the meanings of existing builtins such as `abs`, `floor`, `ceil`, `min`, or `max`.
+
+> **`clamp` does not reorder bounds.** `clamp(x, 10, 0)` is malformed intent, not a shorthand for swapping the range. When both bounds are literal, write them in `lo, hi` order.
+
+> **`idiv` uses mathematical floor semantics.** `idiv(-3, 2)` behaves like `floor(div(-3, 2))`, not truncation toward zero.
 
 ---
 
@@ -403,6 +419,9 @@ computed inRange = and(gte(value, min), lte(value, max))
 | `or(a, b, ...)` | `(...boolean) → boolean` | Logical OR. All arguments must be boolean. Variadic. |
 | `not(a)` | `boolean → boolean` | Logical NOT. |
 | `cond(c, t, e)` | `(boolean, T, T) → T` | Conditional. Returns `t` if `c` is true, otherwise `e`. Alias: `if`. |
+| `match(key, [k, v], ..., default)` | Function-form only | Finite branch sugar. Each arm is an inline `[key, value]` pair and the last argument is the default value. |
+| `argmax([label, eligible, score], ..., tieBreak)` | Function-form only | Deterministic fixed-candidate max selection. `tieBreak` must be `"first"` or `"last"`. Returns `null` if no candidate is eligible. |
+| `argmin([label, eligible, score], ..., tieBreak)` | Function-form only | Deterministic fixed-candidate min selection. `tieBreak` must be `"first"` or `"last"`. Returns `null` if no candidate is eligible. |
 
 **Examples:**
 
@@ -411,6 +430,17 @@ computed canSubmit = and(isNotNull(email), neq(trim(email), ""))
 computed isInactive = or(eq(status, "idle"), eq(status, "error"))
 computed isActive = not(isInactive)
 computed label = cond(gt(count, 0), "Has items", "Empty")
+computed modeLabel = match(mode, ["open", "Open"], ["closed", "Closed"], "Unknown")
+computed bestKind = argmax(
+  ["coarse", coarseEligible, coarseScore],
+  ["repair", repairEligible, repairScore],
+  "first"
+)
+computed cheapestKind = argmin(
+  ["small", smallEligible, smallCost],
+  ["large", largeEligible, largeCost],
+  "last"
+)
 ```
 
 > **Ternary syntax is sugar for `cond`.** `x ? a : b` compiles to `cond(x, a, b)`.
@@ -418,6 +448,14 @@ computed label = cond(gt(count, 0), "Has items", "Empty")
 > **Truthy/falsy coercion does not exist.** `when items` (using an array as a boolean) is a compile error. Always write an explicit boolean expression: `when gt(len(items), 0)`.
 
 > **`and` and `or` are variadic.** `and(a, b, c)` is valid MEL. There is no `&&` operator between more than two expressions; use `and(a, and(b, c))` or the variadic form.
+
+> **`match` is function-form only.** Write `match(status, ["open", 1], ["closed", 0], -1)`, not `match(status, "open" => 1, _ => -1)`.
+
+> **`match` arms are literal and unique.** Each arm key must be a literal `string`, `number`, or `boolean`, the call must include at least one arm plus a default value, and duplicate keys are invalid.
+
+> **`argmax` and `argmin` require inline candidate tuples.** They do not accept a runtime array of candidates, and the final `tieBreak` argument must be the literal `"first"` or `"last"`.
+
+> **Tie-break follows source order.** For equal eligible scores, `"first"` selects the earliest candidate and `"last"` selects the latest candidate. If no candidate is eligible, the result is `null`.
 
 ---
 
@@ -642,6 +680,8 @@ computed itemCount = len(items)
 > ```
 
 > **Forbidden accumulation functions.** `reduce`, `fold`, `foldl`, `foldr`, and `scan` do not exist in MEL. Any construct implying hidden state progression is forbidden. Use `sum()`, `min()`, `max()` for primitive aggregation.
+
+> **`argmax` and `argmin` are not aggregation functions.** They operate only on statically enumerated candidate tuples such as `argmax(["a", okA, scoreA], ["b", okB, scoreB], "first")`.
 
 ---
 

--- a/docs/mel/SYNTAX.md
+++ b/docs/mel/SYNTAX.md
@@ -208,10 +208,9 @@ computed earliest = min(timestamps)
 computed mostExpensive = max(prices)
 computed latest = max(timestamps)
 
-// Len: Array<T> → number
+// Len: string | Array<T> | object -> number
 computed itemCount = len(items)
-// taskIds should be populated via record.keys effect
-computed taskCount = isNotNull(taskIds) ? len(taskIds) : 0
+computed taskCount = len(tasks)
 ```
 
 ### Value Comparison (Multiple Args)
@@ -221,6 +220,40 @@ computed taskCount = isNotNull(taskIds) ? len(taskIds) : 0
 computed smaller = min(a, b)
 computed largest = max(x, y, z)
 ```
+
+### Bounded Sugar and Finite Selection
+
+These forms are ordinary function calls in MEL source. They remain explicit through validation and lower only at the MEL → Core boundary.
+
+```mel
+// Arithmetic sugar
+computed error = absDiff(observed, predicted)
+computed boundedScore = clamp(score, 0, 100)
+computed bucket = idiv(total, bucketSize)
+computed missStreak = streak(previousMissStreak, eq(kind, "miss"))
+
+// Finite branch sugar
+computed label = match(status, ["open", "Open"], ["closed", "Closed"], "Unknown")
+
+// Fixed candidate selection sugar
+computed bestKind = argmax(
+  ["coarse", coarseOk, coarseDelta],
+  ["repair", repairOk, repairDelta],
+  "first"
+)
+
+computed cheapestKind = argmin(
+  ["coarse", coarseOk, coarseCost],
+  ["repair", repairOk, repairCost],
+  "last"
+)
+```
+
+Rules:
+- `match()` is function-form only. Each arm must be an inline `[key, value]` pair and the last argument is the default value.
+- `argmax()` / `argmin()` only accept inline `[label, eligible, score]` candidates.
+- `argmax()` / `argmin()` require a literal `"first"` or `"last"` tie-break as the final argument.
+- Runtime-array forms such as `argmax(candidates, "first")` are not supported.
 
 ### Forbidden Computed Examples
 
@@ -237,6 +270,12 @@ computed names = map(items, $item.name)
 computed total = sum(filter(prices))     // Error: No nested calls
 computed avg = div(sum(prices), len(prices))  // ✅ This IS allowed
 
+// ❌ COMPILE ERROR: Arrow-arm match syntax is not supported
+computed label = match(status, "open" => "Open", _ => "Unknown")
+
+// ❌ COMPILE ERROR: Runtime-array selection is not supported
+computed best = argmax(candidates, "first")
+
 // ❌ COMPILE ERROR: reduce/fold/scan (not in MEL)
 computed total = reduce(prices, add, 0)  // Error: reduce doesn't exist
 
@@ -246,8 +285,7 @@ computed sameRecord = eq(tasks, {})      // Error: Cannot compare Record
 
 // ✅ CORRECT: Check emptiness
 computed isEmpty = eq(len(items), 0)
-// For records, use record.keys effect + derived array
-computed hasNoTasks = isNotNull(taskIds) ? eq(len(taskIds), 0) : true
+computed hasNoTasks = eq(len(tasks), 0)
 
 // ❌ COMPILE ERROR: Method calls
 computed trimmed = email.trim()          // Error: No method calls

--- a/docs/mel/examples/computed/bounded-sugar.mel
+++ b/docs/mel/examples/computed/bounded-sugar.mel
@@ -1,0 +1,51 @@
+// ============================================
+// Title: Bounded Arithmetic Sugar
+// Description: absDiff, clamp, idiv, and streak
+// Prerequisites: computed/basic.mel
+// ============================================
+
+domain ComputedBoundedSugar {
+  // --- State ---
+  state {
+    observed: number = 8
+    predicted: number = 5
+    score: number = 14
+    totalAbs: number = 3
+    bucketSize: number = 2
+    missStreak: number = 2
+    highConfidenceMiss: boolean = true
+    penalty: number = 4
+  }
+
+  // --- Absolute difference ---
+  // Sugar for abs(sub(a, b))
+  computed predictionError = absDiff(observed, predicted)
+  computed penaltyGap = absDiff(score, penalty)
+
+  // --- Clamp ---
+  // Sugar for min(max(x, lo), hi)
+  computed boundedScore = clamp(score, 0, 10)
+  computed boundedPenalty = clamp(penalty, 0, 3)
+
+  // --- Integer division ---
+  // Uses mathematical floor semantics, not truncation toward zero
+  computed positiveBuckets = idiv(score, bucketSize)
+  computed negativeBuckets = idiv(neg(totalAbs), bucketSize)
+
+  // --- Streak counter ---
+  // Increments the previous counter when the condition holds, otherwise resets to 0
+  computed nextMissStreak = streak(missStreak, highConfidenceMiss)
+  computed resetMissStreak = streak(missStreak, false)
+}
+
+// ============================================
+// Notes:
+//   absDiff(a, b)   -> abs(sub(a, b))
+//   clamp(x, lo, hi) -> min(max(x, lo), hi)
+//   idiv(a, b)      -> floor(div(a, b))
+//   streak(prev, c) -> c ? add(prev, 1) : 0
+//
+// Anti-patterns:
+//   ❌ clamp(score, 10, 0)    // Literal bounds must be lo, hi
+//   ❌ idiv(score, 0)         // Returns null because div(score, 0) is null
+// ============================================

--- a/docs/mel/examples/computed/selection-sugar.mel
+++ b/docs/mel/examples/computed/selection-sugar.mel
@@ -1,0 +1,67 @@
+// ============================================
+// Title: Finite Branch and Selection Sugar
+// Description: match, argmax, and argmin in parser-free function form
+// Prerequisites: computed/boolean.mel
+// ============================================
+
+domain ComputedSelectionSugar {
+  // --- State ---
+  state {
+    status: "open" | "closed" | "pending" = "open"
+    coarseOk: boolean = true
+    repairOk: boolean = true
+    fallbackOk: boolean = false
+    coarseDelta: number = 5
+    repairDelta: number = 5
+    fallbackDelta: number = 9
+    coarseCost: number = 4
+    repairCost: number = 6
+  }
+
+  // --- Finite branch sugar ---
+  // match(key, [literalKey, value], ..., defaultValue)
+  computed statusCode = match(status, ["open", 1], ["closed", 0], -1)
+  computed statusLabel = match(status, ["open", "Open"], ["closed", "Closed"], "Unknown")
+
+  // --- Fixed candidate max selection ---
+  // argmax([label, eligible, score], ..., "first" | "last")
+  computed bestFirst = argmax(
+    ["coarse", coarseOk, coarseDelta],
+    ["repair", repairOk, repairDelta],
+    ["fallback", fallbackOk, fallbackDelta],
+    "first"
+  )
+
+  computed bestLast = argmax(
+    ["coarse", coarseOk, coarseDelta],
+    ["repair", repairOk, repairDelta],
+    ["fallback", fallbackOk, fallbackDelta],
+    "last"
+  )
+
+  // --- Fixed candidate min selection ---
+  computed cheapest = argmin(
+    ["coarse", coarseOk, coarseCost],
+    ["repair", repairOk, repairCost],
+    "first"
+  )
+
+  // --- Null-total behavior when no candidate is eligible ---
+  computed noSelection = argmax(
+    ["coarse", false, coarseDelta],
+    ["repair", false, repairDelta],
+    "first"
+  )
+}
+
+// ============================================
+// Rules:
+//   - match arms must be inline [key, value] pairs
+//   - match keys must be literal string/number/boolean values
+//   - argmax/argmin candidates must be inline [label, eligible, score] tuples
+//   - tie-break must be the literal "first" or "last"
+//
+// Anti-patterns:
+//   ❌ match(status, "open" => 1, _ => -1)
+//   ❌ argmax(candidates, "first")
+// ============================================

--- a/packages/compiler/__tests__/analyzer/analyzer.test.ts
+++ b/packages/compiler/__tests__/analyzer/analyzer.test.ts
@@ -470,6 +470,21 @@ describe("Semantic Analyzer", () => {
       }
     });
 
+    it("accepts unary negative numeric match keys", () => {
+      const { program } = parseSource(`
+        domain Test {
+          state { score: number = 0 }
+          computed label = match(score, [-1, "neg"], [0, "zero"], "other")
+        }
+      `);
+
+      if (program) {
+        const { diagnostics } = validateSemantics(program);
+        expect(diagnostics.some((d) => d.code === "E050")).toBe(false);
+        expect(diagnostics.some((d) => d.code === "E_TYPE_MISMATCH")).toBe(false);
+      }
+    });
+
     it("reports E051 for duplicate match keys", () => {
       const { program } = parseSource(`
         domain Test {

--- a/packages/compiler/__tests__/analyzer/analyzer.test.ts
+++ b/packages/compiler/__tests__/analyzer/analyzer.test.ts
@@ -402,7 +402,7 @@ describe("Semantic Analyzer", () => {
     it("accepts all known builtin functions", () => {
       const { program } = parseSource(`
         domain Test {
-          state { x: number = 0, items: Array<number> = [], obj: object = {} }
+          state { x: number = 0, y: number = 1, items: Array<number> = [], obj: object = {}, ok: boolean = true, status: string = "open" }
           computed a = add(x, 1)
           computed b = mul(x, 2)
           computed c = isNull(x)
@@ -410,12 +410,77 @@ describe("Semantic Analyzer", () => {
           computed e = keys(obj)
           computed f = len(items)
           computed g = coalesce(x, 0)
+          computed h = absDiff(x, y)
+          computed i = clamp(x, 0, 10)
+          computed j = idiv(x, y)
+          computed k = streak(x, ok)
+          computed l = match(status, ["open", 1], ["closed", 0], -1)
+          computed m = argmax(["a", ok, x], ["b", ok, y], "first")
+          computed n = argmin(["a", ok, x], ["b", ok, y], "last")
         }
       `);
 
       if (program) {
         const { diagnostics } = validateSemantics(program);
         expect(diagnostics.filter(d => d.code === "E_UNKNOWN_FN")).toHaveLength(0);
+      }
+    });
+  });
+
+  describe("bounded sugar validation", () => {
+    it("reports E049 for reversed literal clamp bounds", () => {
+      const { program } = parseSource(`
+        domain Test {
+          state { score: number = 0 }
+          computed bounded = clamp(score, 10, 0)
+        }
+      `);
+
+      if (program) {
+        const { diagnostics } = validateSemantics(program);
+        expect(diagnostics.some((d) => d.code === "E049")).toBe(true);
+      }
+    });
+
+    it("reports E050 for malformed match arms", () => {
+      const { program } = parseSource(`
+        domain Test {
+          state { status: string = "open" }
+          computed label = match(status, "open", 1, 0)
+        }
+      `);
+
+      if (program) {
+        const { diagnostics } = validateSemantics(program);
+        expect(diagnostics.some((d) => d.code === "E050")).toBe(true);
+      }
+    });
+
+    it("reports E051 for duplicate match keys", () => {
+      const { program } = parseSource(`
+        domain Test {
+          state { status: string = "open" }
+          computed label = match(status, ["open", 1], ["open", 2], 0)
+        }
+      `);
+
+      if (program) {
+        const { diagnostics } = validateSemantics(program);
+        expect(diagnostics.some((d) => d.code === "E051")).toBe(true);
+      }
+    });
+
+    it("reports E052 for malformed arg selection calls", () => {
+      const { program } = parseSource(`
+        domain Test {
+          state { score: number = 1 }
+          computed best = argmax(["a", true, score], "later")
+        }
+      `);
+
+      if (program) {
+        const { diagnostics } = validateSemantics(program);
+        expect(diagnostics.some((d) => d.code === "E052")).toBe(true);
       }
     });
   });

--- a/packages/compiler/__tests__/analyzer/analyzer.test.ts
+++ b/packages/compiler/__tests__/analyzer/analyzer.test.ts
@@ -442,6 +442,20 @@ describe("Semantic Analyzer", () => {
       }
     });
 
+    it("reports E049 for reversed clamp bounds with unary negative literals", () => {
+      const { program } = parseSource(`
+        domain Test {
+          state { score: number = 0 }
+          computed bounded = clamp(score, 10, -1)
+        }
+      `);
+
+      if (program) {
+        const { diagnostics } = validateSemantics(program);
+        expect(diagnostics.some((d) => d.code === "E049")).toBe(true);
+      }
+    });
+
     it("reports E050 for malformed match arms", () => {
       const { program } = parseSource(`
         domain Test {

--- a/packages/compiler/__tests__/analyzer/analyzer.test.ts
+++ b/packages/compiler/__tests__/analyzer/analyzer.test.ts
@@ -485,6 +485,19 @@ describe("Semantic Analyzer", () => {
       }
     });
 
+    it("rejects null selectors in match()", () => {
+      const { program } = parseSource(`
+        domain Test {
+          computed label = match(null, [1, "one"], "other")
+        }
+      `);
+
+      if (program) {
+        const { diagnostics } = validateSemantics(program);
+        expect(diagnostics.some((d) => d.code === "E_TYPE_MISMATCH")).toBe(true);
+      }
+    });
+
     it("reports E051 for duplicate match keys", () => {
       const { program } = parseSource(`
         domain Test {
@@ -510,6 +523,23 @@ describe("Semantic Analyzer", () => {
       if (program) {
         const { diagnostics } = validateSemantics(program);
         expect(diagnostics.some((d) => d.code === "E052")).toBe(true);
+      }
+    });
+
+    it("rejects arg selection labels that are not one primitive kind", () => {
+      const { program } = parseSource(`
+        domain Test {
+          state {
+            flag: boolean = true
+            score: number = 1
+          }
+          computed best = argmax([flag ? "a" : 1, true, score], ["b", true, score], "first")
+        }
+      `);
+
+      if (program) {
+        const { diagnostics } = validateSemantics(program);
+        expect(diagnostics.some((d) => d.code === "E_TYPE_MISMATCH")).toBe(true);
       }
     });
   });

--- a/packages/compiler/__tests__/analyzer/analyzer.test.ts
+++ b/packages/compiler/__tests__/analyzer/analyzer.test.ts
@@ -542,6 +542,23 @@ describe("Semantic Analyzer", () => {
         expect(diagnostics.some((d) => d.code === "E_TYPE_MISMATCH")).toBe(true);
       }
     });
+
+    it("rejects nullable idiv() scores in arg selection", () => {
+      const { program } = parseSource(`
+        domain Test {
+          state {
+            total: number = 10
+            divisor: number = 0
+          }
+          computed best = argmax(["a", true, idiv(total, divisor)], ["b", true, 1], "first")
+        }
+      `);
+
+      if (program) {
+        const { diagnostics } = validateSemantics(program);
+        expect(diagnostics.some((d) => d.code === "E_TYPE_MISMATCH")).toBe(true);
+      }
+    });
   });
 
   describe("duplicate state field detection (#252)", () => {

--- a/packages/compiler/docs/FDR-v0.5.0.md
+++ b/packages/compiler/docs/FDR-v0.5.0.md
@@ -1995,6 +1995,34 @@ Prior to v0.4.0, the lowering boundary was implicit. It was unclear who transfor
 A34. Compiler is the single boundary between MEL IR and Core IR. [v0.4.0]
 ```
 
+### Extension Rule for Additional MEL Surface Forms
+
+Future additive MEL surface forms are acceptable only when they preserve this boundary rather than bypassing it.
+
+That means:
+
+- the source form stays explicit at the MEL surface
+- validation and type checking still operate on a MEL-level representation
+- lowering to Core/runtime forms happens only at the compiler-owned MEL → Core boundary
+- the lowered form uses existing Core/runtime kinds only
+- existing builtin meanings remain stable and are not silently reinterpreted
+
+This is the reason bounded sugar can be admissible while general computation features are not.
+
+Examples of acceptable expansion shape:
+
+- explicit surface alias over existing MEL calls
+- finite branch sugar that lowers to existing conditional structure
+- fixed-candidate selection sugar that lowers to existing comparisons
+
+This is why bounded function-form sugar such as `absDiff`, `clamp`, `idiv`, and `streak` is admissible, and why parser-free finite forms such as `match(key, [k, v], ..., default)` and `argmax([label, eligible, score], ..., "first" | "last")` can also fit the contract. They remain explicit MEL calls through validation and type checking, they are finite and source-enumerated, and they lower only into existing conditionals, comparisons, and arithmetic forms at the established compiler boundary.
+
+Examples of unacceptable expansion shape:
+
+- user-defined accumulation
+- runtime-array-driven best-candidate selection that behaves like a reducer
+- dynamic dispatch or any construct that changes the evaluation model rather than improving surface ergonomics
+
 ---
 
 ## FDR-MEL-065: Host Must Use Compiler

--- a/packages/compiler/docs/SPEC-v1.0.0.md
+++ b/packages/compiler/docs/SPEC-v1.0.0.md
@@ -3,7 +3,7 @@
 > **Version:** 1.0.0
 > **Type:** Full
 > **Status:** Normative
-> **Date:** 2026-04-08
+> **Date:** 2026-04-14
 > **Supersedes:** [SPEC-v0.7.0.md](SPEC-v0.7.0.md), [SPEC-v0.8.0.md](SPEC-v0.8.0.md), [SPEC-v0.9.0.md](SPEC-v0.9.0.md) as the current compiler contract
 > **Compatible with:** Core SPEC v4.2.0, SDK living spec v3.5.0
 
@@ -20,6 +20,7 @@ It rolls up the last active baseline plus addenda into one current surface:
 - v0.9.0 `dispatchable when` addendum
 - current landed compiler/runtime alignment for `Record<string, T>` and `T | null` in schema positions
 - current landed support for pure collection builtins in expression contexts
+- current clarification that additive MEL surface forms must preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary
 
 Historical compiler docs remain useful for archaeology, but **this file is the current truth**.
 
@@ -182,6 +183,99 @@ computed allDone = every(tasks, eq($item.done, true))
 computed bad = sum(filter(prices, gt($item, 0)))
 ```
 
+### 5.1 Additional Explicit MEL Surface Forms
+
+The builtin and collection surface defined in this spec is the **current** MEL source contract.
+
+Any additive MEL surface form beyond the builtin set explicitly defined here MUST satisfy all of the following:
+
+- it MUST be admitted explicitly at the MEL source level rather than appearing as an undocumented parser or lowering convenience
+- it MUST preserve the current meanings of existing builtin names such as `floor`, `ceil`, `min`, `max`, `filter`, `map`, `find`, `every`, and `some`
+- it MUST remain representable as an explicit MEL canonical expression or flow form through validation and type checking
+- lowering to Core Runtime IR MUST occur only at the existing MEL → Core lowering boundary
+- the lowered result MUST use existing Core/runtime expression and flow kinds only
+- user-defined accumulation, runtime-shaped iteration, dynamic dispatch, and other general-computation constructs remain forbidden
+
+Entity primitives are the current precedent for this pattern: they remain explicit MEL surface forms until the lowering boundary and then lower into existing Core/runtime kinds without changing the underlying runtime model.
+
+Only ordinary function-call forms are part of this contract. No new arm syntax, named arguments, or parser-only shorthand is implied here.
+
+The following bounded function forms are admitted under that rule:
+
+#### `absDiff(a, b)`
+
+- signature: `(number, number) -> number`
+- lowering: `abs(sub(a, b))`
+- both arguments MUST be numbers
+
+#### `clamp(x, lo, hi)`
+
+- signature: `(number, number, number) -> number`
+- lowering: `min(max(x, lo), hi)`
+- all arguments MUST be numbers
+- bounds MUST NOT be reordered implicitly
+- when both bounds are statically literal numbers and `lo > hi`, the compiler MUST reject the call
+- this does NOT change the existing meanings of unary `floor()` or `ceil()`
+
+#### `idiv(a, b)`
+
+- signature: `(number, number) -> number | null`
+- lowering: `floor(div(a, b))`
+- both arguments MUST be numbers
+- negative results MUST follow mathematical floor semantics, not truncation toward zero
+- zero-divisor behavior MUST inherit existing `div()` semantics, including `null` on zero
+
+#### `streak(prev, cond)`
+
+- signature: `(number, boolean) -> number`
+- lowering: `cond(cond, add(prev, 1), 0)`
+- `prev` MUST be a number
+- `cond` MUST be a boolean
+
+#### `match(key, [k1, v1], [k2, v2], ..., defaultValue)`
+
+- source form example: `match(status, ["open", 1], ["closed", 0], -1)`
+- the call MUST contain at least one arm and one default value
+- each arm MUST be an inline 2-item array literal `[matchKey, value]`
+- each `matchKey` MUST be a literal `string`, `number`, or `boolean`
+- the final positional argument MUST be the default value
+- `key` and every `matchKey` MUST have the same comparable primitive type: `string`, `number`, or `boolean`
+- duplicate literal arm keys MUST be rejected
+- all arm values and the default value MUST unify to one result type
+- lowering: nested `cond(eq(key, kN), vN, ...)` in source order
+
+#### `argmax([label, eligible, score], ..., tieBreak)`
+
+- source form example: `argmax(["a", aOk, aScore], ["b", bOk, bScore], "first")`
+- the call MUST contain at least one candidate and one tie-break literal
+- each candidate MUST be an inline 3-item array literal `[label, eligible, score]`
+- `eligible` MUST be boolean
+- `score` MUST be number
+- all labels MUST unify to one primitive scalar type: `string`, `number`, or `boolean`
+- the final positional argument MUST be the literal `"first"` or `"last"`
+- runtime-array forms such as `argmax(items, "first")` are NOT part of this contract
+- if no candidate is eligible, the result MUST be `null`
+- `"first"` MUST select the earliest source-order candidate among equal eligible maxima
+- `"last"` MUST select the latest source-order candidate among equal eligible maxima
+- lowering MUST use only existing conditional and comparison structure; tie-break determinism MUST be expressed through `gt`/`gte` selection order
+
+#### `argmin([label, eligible, score], ..., tieBreak)`
+
+- source form example: `argmin(["a", aOk, aScore], ["b", bOk, bScore], "last")`
+- candidate shape, label rules, and tie-break rules are identical to `argmax`
+- runtime-array forms are NOT part of this contract
+- if no candidate is eligible, the result MUST be `null`
+- `"first"` MUST select the earliest source-order candidate among equal eligible minima
+- `"last"` MUST select the latest source-order candidate among equal eligible minima
+- lowering MUST use only existing conditional and comparison structure; tie-break determinism MUST be expressed through `lt`/`lte` selection order
+
+Non-goals of this admission rule:
+
+- no `match(expr, "k" => v)` arrow-arm syntax
+- no `tieBreak: "first"` named-argument syntax
+- no runtime-array `argmax(items, scoreFn)` or `argmin(items, scoreFn)`
+- no reinterpretation of existing builtin meanings such as `floor`, `ceil`, `min`, `max`, `filter`, `map`, `find`, `every`, or `some`
+
 ---
 
 ## 6. Intent Dispatchability
@@ -242,6 +336,7 @@ The current compiler contract is:
 - compatibility `FieldSpec` remains available for coarse tooling and legacy consumers
 - nullable and record schema-position types are supported
 - pure collection builtins are supported in expressions
+- additive MEL surface expansions MUST preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary
 - `dispatchable when` is part of the full action contract
 - `SchemaGraph` remains availability-only and input-independent
 

--- a/packages/compiler/docs/VERSION-INDEX.md
+++ b/packages/compiler/docs/VERSION-INDEX.md
@@ -1,7 +1,7 @@
 # MEL Compiler Documentation Index
 
 > **Package:** `@manifesto-ai/compiler`
-> **Last Updated:** 2026-04-08
+> **Last Updated:** 2026-04-14
 
 ---
 
@@ -10,7 +10,7 @@
 - **Current Full SPEC:** [v1.0.0](SPEC-v1.0.0.md) (Full)
 - **FDR:** [v0.5.0](FDR-v0.5.0.md) (Full)
 
-**Note:** [v1.0.0](SPEC-v1.0.0.md) is the current integrated compiler contract. It rolls up the old v0.7.0 baseline plus the v0.8.0 `SchemaGraph` and v0.9.0 `dispatchable when` addenda, and it reflects the landed `TypeDefinition`-backed support for nullable and record schema-position types.
+**Note:** [v1.0.0](SPEC-v1.0.0.md) is the current integrated compiler contract. It rolls up the old v0.7.0 baseline plus the v0.8.0 `SchemaGraph` and v0.9.0 `dispatchable when` addenda, reflects the landed `TypeDefinition`-backed support for nullable and record schema-position types, clarifies that any future additive MEL surface forms must preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary, and records the admitted bounded sugar function forms in parser-free function-call shape.
 
 ---
 

--- a/packages/compiler/src/__tests__/compliance/ccts-coverage.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-coverage.ts
@@ -50,6 +50,10 @@ export const CCTS_CASES = {
   IR_PURITY_SNAPSHOT_BOUNDARY: "CCTS-IR-007",
   IR_EVALUATION_ORDER: "CCTS-IR-008",
   IR_PRIMITIVE_EQUALITY: "CCTS-IR-009",
+  IR_BOUNDED_SUGAR_ARITH: "CCTS-IR-010",
+  IR_MATCH_SUGAR: "CCTS-IR-011",
+  IR_ARG_SELECTION_SUGAR: "CCTS-IR-012",
+  IR_SUGAR_DIAGNOSTICS: "CCTS-IR-013",
 
   FLOW_COMPOSITION: "CCTS-FLOW-001",
   FLOW_VALIDATION: "CCTS-FLOW-002",
@@ -101,6 +105,10 @@ export const COMPILER_COMPLIANCE_CASES: readonly CompilerComplianceCase[] = [
   complianceCase(CCTS_CASES.IR_PURITY_SNAPSHOT_BOUNDARY, "lowering-and-ir", "Expression roots stay explicit and snapshot-bounded."),
   complianceCase(CCTS_CASES.IR_EVALUATION_ORDER, "lowering-and-ir", "Expression evaluation order stays left-to-right and key-sorted."),
   complianceCase(CCTS_CASES.IR_PRIMITIVE_EQUALITY, "lowering-and-ir", "eq/neq stay limited to primitive operands."),
+  complianceCase(CCTS_CASES.IR_BOUNDED_SUGAR_ARITH, "lowering-and-ir", "Bounded arithmetic sugar lowers to existing runtime arithmetic/conditional nodes."),
+  complianceCase(CCTS_CASES.IR_MATCH_SUGAR, "lowering-and-ir", "match() remains finite literal-key branch sugar with source-order lowering."),
+  complianceCase(CCTS_CASES.IR_ARG_SELECTION_SUGAR, "lowering-and-ir", "argmax()/argmin() remain fixed-candidate deterministic selection sugar."),
+  complianceCase(CCTS_CASES.IR_SUGAR_DIAGNOSTICS, "lowering-and-ir", "Bounded sugar shape diagnostics remain visible."),
 
   complianceCase(CCTS_CASES.FLOW_COMPOSITION, "flow-composition", "flow/include remains compile-time composition only."),
   complianceCase(CCTS_CASES.FLOW_VALIDATION, "flow-composition", "Flow declaration and include contracts are tracked."),
@@ -141,6 +149,9 @@ export const COMPILER_RULE_COVERAGE: readonly CompilerComplianceCoverageEntry[] 
   ...coverMany(["A31", "ADR-013a"], [CCTS_CASES.FLOW_COMPOSITION]),
   ...coverMany(["A32", "E009", "E010", "E011"], [CCTS_CASES.ACTIONS_AGGREGATION]),
   ...coverMany(["A33", "E012", "TYPE-LOWER-5"], [CCTS_CASES.STATE_INLINE_OBJECTS]),
+  ...coverMany(["MEL-SUGAR-1", "MEL-SUGAR-2"], [CCTS_CASES.IR_BOUNDED_SUGAR_ARITH]),
+  ...coverMany(["MEL-SUGAR-3"], [CCTS_CASES.IR_MATCH_SUGAR]),
+  ...coverMany(["MEL-SUGAR-4"], [CCTS_CASES.IR_ARG_SELECTION_SUGAR]),
 
   ...coverMany(["ACTION-INPUT-1", "ACTION-INPUT-2", "TYPE-LOWER-1", "TYPE-LOWER-2", "TYPE-LOWER-3", "TYPE-LOWER-4"], [CCTS_CASES.STATE_ACTION_INPUT_FIELDS]),
   ...coverMany(["ACTION-INPUT-3"], [CCTS_CASES.STATE_ACTION_INPUT_OMISSION]),
@@ -164,6 +175,7 @@ export const COMPILER_RULE_COVERAGE: readonly CompilerComplianceCoverageEntry[] 
 
   ...coverMany(["E003"], [CCTS_CASES.GRAMMAR_INVALID_SYSTEM_REF]),
   ...coverMany(["E006", "E007", "E008"], [CCTS_CASES.ACTIONS_FAIL_STOP_DIAGNOSTICS]),
+  ...coverMany(["E049", "E050", "E051", "E052"], [CCTS_CASES.IR_SUGAR_DIAGNOSTICS]),
 ];
 
 export function caseTitle(caseId: string, description: string): string {

--- a/packages/compiler/src/__tests__/compliance/ccts-rules.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-rules.ts
@@ -50,6 +50,7 @@ export const COMPILER_COMPLIANCE_RULES: readonly CompilerComplianceRule[] = [
   ...registryMany(["COMPILER-MEL-1", "COMPILER-MEL-2", "COMPILER-MEL-3"], "blocking"),
   registry("COMPILER-MEL-2a", "informational"),
   registry("COMPILER-MEL-4", "blocking"),
+  ...registryMany(["MEL-SUGAR-1", "MEL-SUGAR-2", "MEL-SUGAR-3", "MEL-SUGAR-4"], "blocking"),
 
   registry("AD-COMP-LOW-001", "blocking"),
   registry("AD-COMP-LOW-002", "blocking"),
@@ -58,7 +59,7 @@ export const COMPILER_COMPLIANCE_RULES: readonly CompilerComplianceRule[] = [
 
   ...registryMany(["E001", "E002", "E003", "E004", "E005", "E009", "E010", "E011"], "blocking"),
   ...registryMany(["E006", "E007", "E008"], "blocking"),
-  ...registryMany(["E012", "E013", "E014", "E015", "E016", "E017", "E018", "E019", "E020", "E021", "E022", "E023", "E024", "E030", "E030a", "E030b", "E031", "E032", "E033", "E034", "E035", "E041", "E042", "E043", "E044"], "blocking"),
+  ...registryMany(["E012", "E013", "E014", "E015", "E016", "E017", "E018", "E019", "E020", "E021", "E022", "E023", "E024", "E030", "E030a", "E030b", "E031", "E032", "E033", "E034", "E035", "E041", "E042", "E043", "E044", "E049", "E050", "E051", "E052"], "blocking"),
   registry("E045", "informational"),
   registry("E046", "informational"),
   registry("E040", "blocking"),

--- a/packages/compiler/src/__tests__/compliance/ccts-spec-inventory.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-spec-inventory.ts
@@ -90,6 +90,8 @@ export const COMPILER_SPEC_INVENTORY: readonly CompilerComplianceInventoryItem[]
     notes: "Optional lowering strategy equivalent to COMPILER-MEL-2.",
   }),
 
+  ...inventoryMany(["MEL-SUGAR-1", "MEL-SUGAR-2", "MEL-SUGAR-3", "MEL-SUGAR-4"], "§5.1", "MUST", "lowering-and-ir"),
+
   ...inventoryMany(["AD-COMP-LOW-001", "AD-COMP-LOW-002", "AD-COMP-LOW-003"], "§16", "MUST", "lowering-and-ir"),
   inventory("SCHEMA-RESERVED-1", "§17.4 / §21", "MUST", "lowering-and-ir"),
 
@@ -101,6 +103,7 @@ export const COMPILER_SPEC_INVENTORY: readonly CompilerComplianceInventoryItem[]
   ...inventoryMany(["E013", "E014", "E015", "E016", "E017", "E018", "E019", "E020", "E021", "E022", "E023", "E024"], "§13.6", "MUST", "flow-composition"),
   ...inventoryMany(["E030", "E030a", "E030b", "E031", "E032", "E033", "E034", "E035"], "§13.6", "MUST", "entity-primitives"),
   ...inventoryMany(["E040", "E041", "E042", "E043", "E044"], "§13.6", "MUST", "state-and-computed"),
+  ...inventoryMany(["E049", "E050", "E051", "E052"], "§13.6", "MUST", "lowering-and-ir"),
   inventory("E045", "§13.6", "MUST", "state-and-computed", {
     lifecycle: "superseded",
     notes: "Superseded when nullable schema-position types became supported through TypeDefinition-backed runtime validation.",

--- a/packages/compiler/src/__tests__/compliance/suite/lowering-and-ir.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/lowering-and-ir.spec.ts
@@ -9,6 +9,7 @@ import { createEvaluationContext, evaluateExpr } from "../../../index.js";
 import type { MelExprNode } from "../../../lowering/lower-expr.js";
 import { createCompilerComplianceAdapter } from "../ccts-adapter.js";
 import {
+  diagnosticEvidence,
   evaluateRule,
   expectAllCompliance,
   hasDiagnosticCode,
@@ -940,6 +941,264 @@ describe("CCTS Lowering and IR Suite", () => {
           noteEvidence("Entity return diagnostics", entityReturn.errors.map((diagnostic) => diagnostic.code)),
           noteEvidence("Primitive comparison diagnostics", primitiveComparisons.errors.map((diagnostic) => diagnostic.code)),
         ],
+      }),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.IR_BOUNDED_SUGAR_ARITH, "(MEL-SUGAR-1/2) bounded arithmetic sugar stays explicit until lowering"), () => {
+    const source = `
+      domain Demo {
+        state {
+          observed: number = 8
+          predicted: number = 5
+          score: number = 14
+          totalAbs: number = 3
+          divisor: number = 2
+          prev: number = 2
+          locked: boolean = true
+        }
+        computed error = absDiff(observed, predicted)
+        computed bounded = clamp(score, 0, 10)
+        computed buckets = idiv(neg(totalAbs), divisor)
+        computed lockStreak = streak(prev, locked)
+      }
+    `;
+    const canonical = adapter.canonical(source);
+    const compiled = adapter.compile(source);
+
+    const canonicalFns = canonical.success
+      ? Object.values(canonical.value!.computed.fields).map((field) =>
+          field.expr.kind === "call" ? field.expr.fn : field.expr.kind
+        )
+      : [];
+    const runtimeKinds = compiled.success
+      ? Object.values(compiled.value!.computed.fields).map((field) => field.expr.kind)
+      : [];
+    const ctx = createEvaluationContext({
+      meta: { intentId: "i1" },
+      snapshot: {
+        data: {
+          observed: 8,
+          predicted: 5,
+          score: 14,
+          totalAbs: 3,
+          divisor: 2,
+          prev: 2,
+          locked: true,
+        },
+        computed: {},
+      },
+    });
+    const values = compiled.success
+      ? {
+          error: evaluateExpr(compiled.value!.computed.fields["error"].expr, ctx),
+          bounded: evaluateExpr(compiled.value!.computed.fields["bounded"].expr, ctx),
+          buckets: evaluateExpr(compiled.value!.computed.fields["buckets"].expr, ctx),
+          lockStreak: evaluateExpr(compiled.value!.computed.fields["lockStreak"].expr, ctx),
+        }
+      : null;
+
+    expectAllCompliance([
+      evaluateRule(
+        getRuleOrThrow("MEL-SUGAR-1"),
+        canonical.success &&
+          [...canonicalFns].sort().join(",") === "absDiff,clamp,idiv,streak",
+        {
+          passMessage: "Bounded arithmetic sugar remains explicit as canonical MEL call nodes.",
+          failMessage: "Bounded arithmetic sugar did not remain explicit through canonical MEL IR.",
+          evidence: [noteEvidence(`Observed canonical success=${canonical.success} diagnostics=${JSON.stringify(canonical.errors.map((diagnostic) => diagnostic.code))} functionNames=${JSON.stringify(canonicalFns)}`)],
+        }
+      ),
+      evaluateRule(
+        getRuleOrThrow("MEL-SUGAR-2"),
+        compiled.success &&
+          runtimeKinds.every((kind) => ["abs", "min", "floor", "if"].includes(kind)) &&
+          values?.error === 3 &&
+          values?.bounded === 10 &&
+          values?.buckets === -2 &&
+          values?.lockStreak === 3,
+        {
+          passMessage: "Bounded arithmetic sugar lowers only to existing runtime kinds and preserves semantics.",
+          failMessage: "Bounded arithmetic sugar lowering or semantics regressed.",
+          evidence: [
+            noteEvidence(`Observed runtime root kinds: ${JSON.stringify(runtimeKinds)}`),
+            noteEvidence(`Observed evaluated values: ${JSON.stringify(values)}`),
+          ],
+        }
+      ),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.IR_MATCH_SUGAR, "(MEL-SUGAR-3) match() stays finite literal-key branch sugar"), () => {
+    const source = `
+      domain Demo {
+        state { status: string = "open" }
+        computed code = match(status, ["open", 1], ["closed", 0], -1)
+      }
+    `;
+    const canonical = adapter.canonical(source);
+    const compiled = adapter.compile(source);
+    const expr = compiled.value?.computed.fields["code"]?.expr as
+      | { kind?: string; cond?: { kind?: string; left?: { kind?: string; path?: string }; right?: { kind?: string; value?: unknown } } }
+      | undefined;
+    const openCode = compiled.success
+      ? evaluateExpr(
+          compiled.value!.computed.fields["code"].expr,
+          createEvaluationContext({
+            meta: { intentId: "i1" },
+            snapshot: { data: { status: "open" }, computed: {} },
+          })
+        )
+      : null;
+    const unknownCode = compiled.success
+      ? evaluateExpr(
+          compiled.value!.computed.fields["code"].expr,
+          createEvaluationContext({
+            meta: { intentId: "i1" },
+            snapshot: { data: { status: "pending" }, computed: {} },
+          })
+        )
+      : null;
+
+    expectAllCompliance([
+      evaluateRule(
+        getRuleOrThrow("MEL-SUGAR-3"),
+        canonical.success &&
+          canonical.value!.computed.fields["code"]?.expr.kind === "call" &&
+          (canonical.value!.computed.fields["code"]?.expr as { fn?: string }).fn === "match" &&
+          compiled.success &&
+          expr?.kind === "if" &&
+          expr.cond?.kind === "eq" &&
+          expr.cond.left?.kind === "get" &&
+          expr.cond.left.path === "status" &&
+          openCode === 1 &&
+          unknownCode === -1,
+        {
+          passMessage: "match() remains explicit in canonical IR and lowers to finite source-order conditional structure.",
+          failMessage: "match() no longer behaves as finite literal-key branch sugar.",
+          evidence: [
+            noteEvidence("Observed canonical expr", canonical.value?.computed.fields["code"]?.expr),
+            noteEvidence("Observed lowered expr", expr),
+            noteEvidence("Observed evaluated codes", { openCode, unknownCode }),
+          ],
+        }
+      ),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.IR_ARG_SELECTION_SUGAR, "(MEL-SUGAR-4) argmax()/argmin() stay fixed-candidate deterministic selection sugar"), () => {
+    const source = `
+      domain Demo {
+        state {
+          aOk: boolean = true
+          bOk: boolean = true
+          cOk: boolean = false
+          aScore: number = 5
+          bScore: number = 5
+          cScore: number = 9
+        }
+        computed bestFirst = argmax(["a", aOk, aScore], ["b", bOk, bScore], ["c", cOk, cScore], "first")
+        computed bestLast = argmax(["a", aOk, aScore], ["b", bOk, bScore], ["c", cOk, cScore], "last")
+        computed worstFirst = argmin(["a", aOk, aScore], ["b", bOk, bScore], "first")
+        computed none = argmax(["a", false, aScore], ["b", false, bScore], "first")
+      }
+    `;
+    const canonical = adapter.canonical(source);
+    const compiled = adapter.compile(source);
+    const runtimeKinds = compiled.success
+      ? Object.values(compiled.value!.computed.fields).map((field) => field.expr.kind)
+      : [];
+    const ctx = createEvaluationContext({
+      meta: { intentId: "i1" },
+      snapshot: {
+        data: {
+          aOk: true,
+          bOk: true,
+          cOk: false,
+          aScore: 5,
+          bScore: 5,
+          cScore: 9,
+        },
+        computed: {},
+      },
+    });
+    const values = compiled.success
+      ? {
+          bestFirst: evaluateExpr(compiled.value!.computed.fields["bestFirst"].expr, ctx),
+          bestLast: evaluateExpr(compiled.value!.computed.fields["bestLast"].expr, ctx),
+          worstFirst: evaluateExpr(compiled.value!.computed.fields["worstFirst"].expr, ctx),
+          none: evaluateExpr(compiled.value!.computed.fields["none"].expr, ctx),
+        }
+      : null;
+
+    expectAllCompliance([
+      evaluateRule(
+        getRuleOrThrow("MEL-SUGAR-4"),
+        canonical.success &&
+          runtimeKinds.every((kind) => kind === "if") &&
+          values?.bestFirst === "a" &&
+          values?.bestLast === "b" &&
+          values?.worstFirst === "a" &&
+          values?.none === null,
+        {
+          passMessage: "argmax()/argmin() stay source-enumerated, deterministic, and null-total when nothing is eligible.",
+          failMessage: "argmax()/argmin() lowering or deterministic tie-break semantics regressed.",
+          evidence: [
+            noteEvidence("Observed canonical function names", canonical.success ? Object.values(canonical.value!.computed.fields).map((field) => (field.expr.kind === "call" ? field.expr.fn : field.expr.kind)) : []),
+            noteEvidence("Observed runtime kinds", runtimeKinds),
+            noteEvidence("Observed selection values", values),
+          ],
+        }
+      ),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.IR_SUGAR_DIAGNOSTICS, "(E049/E050/E051/E052) bounded sugar diagnostics remain visible"), () => {
+    const clampResult = adapter.compile(`
+      domain Demo {
+        state { score: number = 0 }
+        computed bounded = clamp(score, 10, 0)
+      }
+    `);
+    const matchShape = adapter.compile(`
+      domain Demo {
+        state { status: string = "open" }
+        computed code = match(status, "open", 1, 0)
+      }
+    `);
+    const matchDuplicate = adapter.compile(`
+      domain Demo {
+        state { status: string = "open" }
+        computed code = match(status, ["open", 1], ["open", 2], 0)
+      }
+    `);
+    const argShape = adapter.compile(`
+      domain Demo {
+        state { score: number = 1 }
+        computed best = argmax(["a", true, score], "later")
+      }
+    `);
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("E049"), hasDiagnosticCode(clampResult.errors, "E049"), {
+        passMessage: "Literal clamp bound inversion emits E049.",
+        failMessage: "Literal clamp bound inversion no longer emits E049.",
+        evidence: diagnosticEvidence(clampResult.errors),
+      }),
+      evaluateRule(getRuleOrThrow("E050"), hasDiagnosticCode(matchShape.errors, "E050"), {
+        passMessage: "Malformed match() forms emit E050.",
+        failMessage: "Malformed match() forms no longer emit E050.",
+        evidence: diagnosticEvidence(matchShape.errors),
+      }),
+      evaluateRule(getRuleOrThrow("E051"), hasDiagnosticCode(matchDuplicate.errors, "E051"), {
+        passMessage: "Duplicate match() keys emit E051.",
+        failMessage: "Duplicate match() keys no longer emit E051.",
+        evidence: diagnosticEvidence(matchDuplicate.errors),
+      }),
+      evaluateRule(getRuleOrThrow("E052"), hasDiagnosticCode(argShape.errors, "E052"), {
+        passMessage: "Malformed argmax()/argmin() forms emit E052.",
+        failMessage: "Malformed argmax()/argmin() forms no longer emit E052.",
+        evidence: diagnosticEvidence(argShape.errors),
       }),
     ]);
   });

--- a/packages/compiler/src/__tests__/compliance/suite/lowering-and-ir.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/lowering-and-ir.spec.ts
@@ -1160,6 +1160,12 @@ describe("CCTS Lowering and IR Suite", () => {
         computed bounded = clamp(score, 10, 0)
       }
     `);
+    const clampUnaryResult = adapter.compile(`
+      domain Demo {
+        state { score: number = 0 }
+        computed bounded = clamp(score, 10, -1)
+      }
+    `);
     const matchShape = adapter.compile(`
       domain Demo {
         state { status: string = "open" }
@@ -1180,11 +1186,19 @@ describe("CCTS Lowering and IR Suite", () => {
     `);
 
     expectAllCompliance([
-      evaluateRule(getRuleOrThrow("E049"), hasDiagnosticCode(clampResult.errors, "E049"), {
-        passMessage: "Literal clamp bound inversion emits E049.",
-        failMessage: "Literal clamp bound inversion no longer emits E049.",
-        evidence: diagnosticEvidence(clampResult.errors),
-      }),
+      evaluateRule(
+        getRuleOrThrow("E049"),
+        hasDiagnosticCode(clampResult.errors, "E049") &&
+          hasDiagnosticCode(clampUnaryResult.errors, "E049"),
+        {
+          passMessage: "Literal clamp bound inversion emits E049, including unary negative bounds.",
+          failMessage: "Literal clamp bound inversion no longer emits E049 for direct or unary-negative bounds.",
+          evidence: [
+            ...diagnosticEvidence(clampResult.errors),
+            ...diagnosticEvidence(clampUnaryResult.errors),
+          ],
+        }
+      ),
       evaluateRule(getRuleOrThrow("E050"), hasDiagnosticCode(matchShape.errors, "E050"), {
         passMessage: "Malformed match() forms emit E050.",
         failMessage: "Malformed match() forms no longer emit E050.",

--- a/packages/compiler/src/__tests__/docs-examples.test.ts
+++ b/packages/compiler/src/__tests__/docs-examples.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { compileMelDomain } from "../api/compile-mel.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+
+const EXAMPLE_FILES = [
+  "docs/mel/examples/computed/bounded-sugar.mel",
+  "docs/mel/examples/computed/selection-sugar.mel",
+] as const;
+
+describe("docs MEL examples", () => {
+  for (const relativePath of EXAMPLE_FILES) {
+    it(`compiles ${relativePath}`, () => {
+      const fullPath = path.join(REPO_ROOT, relativePath);
+      const source = readFileSync(fullPath, "utf8");
+      const result = compileMelDomain(source, { mode: "domain" });
+
+      expect(result.errors).toEqual([]);
+      expect(result.schema).not.toBeNull();
+    });
+  }
+});

--- a/packages/compiler/src/__tests__/evaluation.test.ts
+++ b/packages/compiler/src/__tests__/evaluation.test.ts
@@ -450,6 +450,54 @@ describe("evaluateExpr", () => {
         )
       ).toBe(null);
     });
+
+    it("should evaluate extended arithmetic operators", () => {
+      const ctx = createTestContext();
+
+      expect(
+        evaluateExpr({ kind: "abs", arg: { kind: "lit", value: -3 } }, ctx)
+      ).toBe(3);
+      expect(
+        evaluateExpr(
+          {
+            kind: "min",
+            args: [{ kind: "lit", value: 9 }, { kind: "lit", value: 4 }],
+          },
+          ctx
+        )
+      ).toBe(4);
+      expect(
+        evaluateExpr(
+          {
+            kind: "max",
+            args: [{ kind: "lit", value: 9 }, { kind: "lit", value: 4 }],
+          },
+          ctx
+        )
+      ).toBe(9);
+      expect(
+        evaluateExpr({ kind: "floor", arg: { kind: "lit", value: -1.2 } }, ctx)
+      ).toBe(-2);
+      expect(
+        evaluateExpr({ kind: "ceil", arg: { kind: "lit", value: -1.2 } }, ctx)
+      ).toBe(-1);
+      expect(
+        evaluateExpr({ kind: "round", arg: { kind: "lit", value: 1.6 } }, ctx)
+      ).toBe(2);
+      expect(
+        evaluateExpr({ kind: "sqrt", arg: { kind: "lit", value: 9 } }, ctx)
+      ).toBe(3);
+      expect(
+        evaluateExpr(
+          {
+            kind: "pow",
+            base: { kind: "lit", value: 2 },
+            exponent: { kind: "lit", value: 3 },
+          },
+          ctx
+        )
+      ).toBe(8);
+    });
   });
 
   describe("string operators", () => {
@@ -507,6 +555,20 @@ describe("evaluateExpr", () => {
           ctx
         )
       ).toBe(2);
+    });
+
+    it("should evaluate numeric array aggregation helpers", () => {
+      const ctx = createTestContext();
+
+      expect(
+        evaluateExpr({ kind: "sumArray", array: { kind: "get", path: "items" } }, ctx)
+      ).toBe(6);
+      expect(
+        evaluateExpr({ kind: "minArray", array: { kind: "get", path: "items" } }, ctx)
+      ).toBe(1);
+      expect(
+        evaluateExpr({ kind: "maxArray", array: { kind: "get", path: "items" } }, ctx)
+      ).toBe(3);
     });
 
     it("should return null for out-of-bounds at", () => {

--- a/packages/compiler/src/__tests__/lowering.test.ts
+++ b/packages/compiler/src/__tests__/lowering.test.ts
@@ -501,7 +501,26 @@ describe("lowerExprNode", () => {
         then: { kind: "lit", value: "a" },
         else: {
           kind: "if",
-          cond: { kind: "get", path: "bOk" },
+          cond: {
+            kind: "and",
+            args: [
+              { kind: "get", path: "bOk" },
+              {
+                kind: "or",
+                args: [
+                  {
+                    kind: "not",
+                    arg: { kind: "get", path: "aOk" },
+                  },
+                  {
+                    kind: "gt",
+                    left: { kind: "get", path: "bScore" },
+                    right: { kind: "get", path: "aScore" },
+                  },
+                ],
+              },
+            ],
+          },
           then: { kind: "lit", value: "b" },
           else: { kind: "lit", value: null },
         },
@@ -532,7 +551,26 @@ describe("lowerExprNode", () => {
         then: { kind: "lit", value: "a" },
         else: {
           kind: "if",
-          cond: { kind: "get", path: "bOk" },
+          cond: {
+            kind: "and",
+            args: [
+              { kind: "get", path: "bOk" },
+              {
+                kind: "or",
+                args: [
+                  {
+                    kind: "not",
+                    arg: { kind: "get", path: "aOk" },
+                  },
+                  {
+                    kind: "lte",
+                    left: { kind: "get", path: "bScore" },
+                    right: { kind: "get", path: "aScore" },
+                  },
+                ],
+              },
+            ],
+          },
           then: { kind: "lit", value: "b" },
           else: { kind: "lit", value: null },
         },

--- a/packages/compiler/src/__tests__/lowering.test.ts
+++ b/packages/compiler/src/__tests__/lowering.test.ts
@@ -323,6 +323,222 @@ describe("lowerExprNode", () => {
       });
     });
 
+    it("should lower absDiff(), clamp(), idiv(), and streak() as bounded sugar", () => {
+      expect(
+        lowerExprNode(
+          {
+            kind: "call",
+            fn: "absDiff",
+            args: [
+              { kind: "get", path: [{ kind: "prop", name: "observed" }] },
+              { kind: "get", path: [{ kind: "prop", name: "predicted" }] },
+            ],
+          },
+          DEFAULT_SCHEMA_CONTEXT
+        )
+      ).toEqual({
+        kind: "abs",
+        arg: {
+          kind: "sub",
+          left: { kind: "get", path: "observed" },
+          right: { kind: "get", path: "predicted" },
+        },
+      });
+
+      expect(
+        lowerExprNode(
+          {
+            kind: "call",
+            fn: "clamp",
+            args: [
+              { kind: "get", path: [{ kind: "prop", name: "score" }] },
+              { kind: "lit", value: 0 },
+              { kind: "lit", value: 10 },
+            ],
+          },
+          DEFAULT_SCHEMA_CONTEXT
+        )
+      ).toEqual({
+        kind: "min",
+        args: [
+          {
+            kind: "max",
+            args: [
+              { kind: "get", path: "score" },
+              { kind: "lit", value: 0 },
+            ],
+          },
+          { kind: "lit", value: 10 },
+        ],
+      });
+
+      expect(
+        lowerExprNode(
+          {
+            kind: "call",
+            fn: "idiv",
+            args: [
+              { kind: "get", path: [{ kind: "prop", name: "total" }] },
+              { kind: "lit", value: 2 },
+            ],
+          },
+          DEFAULT_SCHEMA_CONTEXT
+        )
+      ).toEqual({
+        kind: "floor",
+        arg: {
+          kind: "div",
+          left: { kind: "get", path: "total" },
+          right: { kind: "lit", value: 2 },
+        },
+      });
+
+      expect(
+        lowerExprNode(
+          {
+            kind: "call",
+            fn: "streak",
+            args: [
+              { kind: "get", path: [{ kind: "prop", name: "prev" }] },
+              { kind: "get", path: [{ kind: "prop", name: "flag" }] },
+            ],
+          },
+          DEFAULT_SCHEMA_CONTEXT
+        )
+      ).toEqual({
+        kind: "if",
+        cond: { kind: "get", path: "flag" },
+        then: {
+          kind: "add",
+          left: { kind: "get", path: "prev" },
+          right: { kind: "lit", value: 1 },
+        },
+        else: { kind: "lit", value: 0 },
+      });
+    });
+
+    it("should lower match() into nested if/eq expressions in source order", () => {
+      const input: MelExprNode = {
+        kind: "call",
+        fn: "match",
+        args: [
+          { kind: "get", path: [{ kind: "prop", name: "status" }] },
+          { kind: "arr", elements: [{ kind: "lit", value: "open" }, { kind: "lit", value: 1 }] },
+          { kind: "arr", elements: [{ kind: "lit", value: "closed" }, { kind: "lit", value: 0 }] },
+          { kind: "lit", value: -1 },
+        ],
+      };
+
+      expect(lowerExprNode(input, DEFAULT_SCHEMA_CONTEXT)).toEqual({
+        kind: "if",
+        cond: {
+          kind: "eq",
+          left: { kind: "get", path: "status" },
+          right: { kind: "lit", value: "open" },
+        },
+        then: { kind: "lit", value: 1 },
+        else: {
+          kind: "if",
+          cond: {
+            kind: "eq",
+            left: { kind: "get", path: "status" },
+            right: { kind: "lit", value: "closed" },
+          },
+          then: { kind: "lit", value: 0 },
+          else: { kind: "lit", value: -1 },
+        },
+      });
+    });
+
+    it("should lower argmax()/argmin() into deterministic selection trees", () => {
+      const argmax = lowerExprNode(
+        {
+          kind: "call",
+          fn: "argmax",
+          args: [
+            { kind: "arr", elements: [{ kind: "lit", value: "a" }, { kind: "get", path: [{ kind: "prop", name: "aOk" }] }, { kind: "get", path: [{ kind: "prop", name: "aScore" }] }] },
+            { kind: "arr", elements: [{ kind: "lit", value: "b" }, { kind: "get", path: [{ kind: "prop", name: "bOk" }] }, { kind: "get", path: [{ kind: "prop", name: "bScore" }] }] },
+            { kind: "lit", value: "first" },
+          ],
+        },
+        DEFAULT_SCHEMA_CONTEXT
+      );
+      const argmin = lowerExprNode(
+        {
+          kind: "call",
+          fn: "argmin",
+          args: [
+            { kind: "arr", elements: [{ kind: "lit", value: "a" }, { kind: "get", path: [{ kind: "prop", name: "aOk" }] }, { kind: "get", path: [{ kind: "prop", name: "aScore" }] }] },
+            { kind: "arr", elements: [{ kind: "lit", value: "b" }, { kind: "get", path: [{ kind: "prop", name: "bOk" }] }, { kind: "get", path: [{ kind: "prop", name: "bScore" }] }] },
+            { kind: "lit", value: "last" },
+          ],
+        },
+        DEFAULT_SCHEMA_CONTEXT
+      );
+
+      expect(argmax).toEqual({
+        kind: "if",
+        cond: {
+          kind: "and",
+          args: [
+            { kind: "get", path: "aOk" },
+            {
+              kind: "or",
+              args: [
+                {
+                  kind: "not",
+                  arg: { kind: "get", path: "bOk" },
+                },
+                {
+                  kind: "gte",
+                  left: { kind: "get", path: "aScore" },
+                  right: { kind: "get", path: "bScore" },
+                },
+              ],
+            },
+          ],
+        },
+        then: { kind: "lit", value: "a" },
+        else: {
+          kind: "if",
+          cond: { kind: "get", path: "bOk" },
+          then: { kind: "lit", value: "b" },
+          else: { kind: "lit", value: null },
+        },
+      });
+
+      expect(argmin).toEqual({
+        kind: "if",
+        cond: {
+          kind: "and",
+          args: [
+            { kind: "get", path: "aOk" },
+            {
+              kind: "or",
+              args: [
+                {
+                  kind: "not",
+                  arg: { kind: "get", path: "bOk" },
+                },
+                {
+                  kind: "lt",
+                  left: { kind: "get", path: "aScore" },
+                  right: { kind: "get", path: "bScore" },
+                },
+              ],
+            },
+          ],
+        },
+        then: { kind: "lit", value: "a" },
+        else: {
+          kind: "if",
+          cond: { kind: "get", path: "bOk" },
+          then: { kind: "lit", value: "b" },
+          else: { kind: "lit", value: null },
+        },
+      });
+    });
+
     it("should lower variadic merge() with 3+ objects", () => {
       const input: MelExprNode = {
         kind: "call",

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -51,7 +51,6 @@ const PRIMITIVE_NUMBER_CALLS = new Set([
   "clamp",
   "floor",
   "ceil",
-  "idiv",
   "round",
   "sqrt",
   "pow",
@@ -541,6 +540,13 @@ function inferFunctionCallType(
 
   if (PRIMITIVE_NUMBER_CALLS.has(expr.name)) {
     return simpleType("number", expr.location);
+  }
+
+  if (expr.name === "idiv") {
+    return joinTypeCandidates(
+      [simpleType("number", expr.location), simpleType("null", expr.location)],
+      expr.location
+    );
   }
 
   if (PRIMITIVE_STRING_CALLS.has(expr.name)) {

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -46,15 +46,19 @@ const PRIMITIVE_NUMBER_CALLS = new Set([
   "mul",
   "div",
   "mod",
+  "absDiff",
   "abs",
+  "clamp",
   "floor",
   "ceil",
+  "idiv",
   "round",
   "sqrt",
   "pow",
   "len",
   "strlen",
   "indexOf",
+  "streak",
   "sum",
   "min",
   "max",
@@ -627,6 +631,14 @@ function inferFunctionCallType(
     );
   }
 
+  if (expr.name === "match") {
+    return inferMatchType(expr, env, symbols);
+  }
+
+  if (expr.name === "argmax" || expr.name === "argmin") {
+    return inferArgSelectionType(expr, env, symbols);
+  }
+
   if (expr.name === "slice" && expr.args.length >= 1) {
     return inferExprType(expr.args[0], env, symbols);
   }
@@ -697,6 +709,53 @@ function joinTypeCandidates(
     types: deduped,
     location,
   };
+}
+
+function inferMatchType(
+  expr: Extract<ExprNode, { kind: "functionCall" }>,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols
+): TypeExprNode | null {
+  if (expr.args.length < 3) {
+    return null;
+  }
+
+  const valueTypes: Array<TypeExprNode | null> = [];
+  for (let index = 1; index < expr.args.length - 1; index += 1) {
+    const arm = expr.args[index];
+    if (arm.kind !== "arrayLiteral" || arm.elements.length !== 2) {
+      return null;
+    }
+    valueTypes.push(inferExprType(arm.elements[1], env, symbols));
+  }
+  valueTypes.push(inferExprType(expr.args[expr.args.length - 1], env, symbols));
+  return joinTypeCandidates(valueTypes, expr.location);
+}
+
+function inferArgSelectionType(
+  expr: Extract<ExprNode, { kind: "functionCall" }>,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols
+): TypeExprNode | null {
+  if (expr.args.length < 2) {
+    return null;
+  }
+
+  const labelTypes: Array<TypeExprNode | null> = [];
+  for (let index = 0; index < expr.args.length - 1; index += 1) {
+    const candidate = expr.args[index];
+    if (candidate.kind !== "arrayLiteral" || candidate.elements.length !== 3) {
+      return null;
+    }
+    labelTypes.push(inferExprType(candidate.elements[0], env, symbols));
+  }
+
+  const labelType = joinTypeCandidates(labelTypes, expr.location);
+  if (!labelType) {
+    return null;
+  }
+
+  return joinTypeCandidates([labelType, simpleType("null", expr.location)], expr.location);
 }
 
 function literalTypeFromValue(

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -403,6 +403,17 @@ function getLiteralPrimitiveValue(expr: ExprNode): string | number | boolean | n
     : undefined;
 }
 
+function getStaticNumericLiteralValue(expr: ExprNode): number | undefined {
+  if (expr.kind === "literal" && expr.literalType === "number" && typeof expr.value === "number") {
+    return expr.value;
+  }
+  if (expr.kind === "unary" && expr.operator === "-") {
+    const operand = getStaticNumericLiteralValue(expr.operand);
+    return typeof operand === "number" ? -operand : undefined;
+  }
+  return undefined;
+}
+
 function resolvePathType(path: PathNode, symbols: DomainTypeSymbols): TypeExprNode | null {
   const [first, ...rest] = path.segments;
   if (!first || first.kind !== "propertySegment") {
@@ -1613,8 +1624,8 @@ export class SemanticValidator {
             args[2].location,
             "Function 'clamp' expects a numeric third argument"
           );
-          const clampLoLiteral = getLiteralPrimitiveValue(args[1]);
-          const clampHiLiteral = getLiteralPrimitiveValue(args[2]);
+          const clampLoLiteral = getStaticNumericLiteralValue(args[1]);
+          const clampHiLiteral = getStaticNumericLiteralValue(args[2]);
           if (
             typeof clampLoLiteral === "number" &&
             typeof clampHiLiteral === "number" &&

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -1617,7 +1617,13 @@ export class SemanticValidator {
             args[2].location,
             "Function 'clamp' expects a numeric third argument"
           );
-          if (isNumericLiteralExpr(args[1]) && isNumericLiteralExpr(args[2]) && args[1].value > args[2].value) {
+          const clampLoLiteral = getLiteralPrimitiveValue(args[1]);
+          const clampHiLiteral = getLiteralPrimitiveValue(args[2]);
+          if (
+            typeof clampLoLiteral === "number" &&
+            typeof clampHiLiteral === "number" &&
+            clampLoLiteral > clampHiLiteral
+          ) {
             this.error(
               "Function 'clamp' requires literal bounds in lo, hi order",
               location,

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -393,6 +393,10 @@ function extendCollectionTypeEnv(baseEnv: TypeEnv, itemType: TypeExprNode): Type
 }
 
 function getLiteralPrimitiveValue(expr: ExprNode): string | number | boolean | null | undefined {
+  const numericLiteral = getStaticNumericLiteralValue(expr);
+  if (typeof numericLiteral === "number") {
+    return numericLiteral;
+  }
   if (expr.kind !== "literal") {
     return undefined;
   }

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -403,10 +403,6 @@ function getLiteralPrimitiveValue(expr: ExprNode): string | number | boolean | n
     : undefined;
 }
 
-function isNumericLiteralExpr(expr: ExprNode): expr is Extract<ExprNode, { kind: "literal"; literalType: "number" }> {
-  return expr.kind === "literal" && expr.literalType === "number" && typeof expr.value === "number";
-}
-
 function resolvePathType(path: PathNode, symbols: DomainTypeSymbols): TypeExprNode | null {
   const [first, ...rest] = path.segments;
   if (!first || first.kind !== "propertySegment") {

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -251,6 +251,25 @@ function collectPrimitiveKinds(
   }
 }
 
+function getSingleNonNullPrimitiveKind(
+  typeExpr: TypeExprNode | null,
+  symbols: DomainTypeSymbols
+): Exclude<PrimitiveKind, "null"> | "invalid" | null {
+  const kinds = collectPrimitiveKinds(typeExpr, symbols);
+  if (kinds === null) {
+    return null;
+  }
+  if (kinds === "nonprimitive") {
+    return "invalid";
+  }
+
+  const nonNullKinds = [...kinds].filter((kind): kind is Exclude<PrimitiveKind, "null"> => kind !== "null");
+  if (nonNullKinds.length !== 1 || kinds.has("null")) {
+    return "invalid";
+  }
+  return nonNullKinds[0]!;
+}
+
 function areComparableTypesCompatible(
   leftType: TypeExprNode | null,
   rightType: TypeExprNode | null,
@@ -1933,6 +1952,14 @@ export class SemanticValidator {
     }
 
     const selectorType = argTypes[0];
+    const selectorKind = getSingleNonNullPrimitiveKind(selectorType, this.symbols);
+    if (selectorKind === "invalid") {
+      this.error(
+        `Function 'match' requires a selector of type string, number, or boolean, got ${describeTypeExpr(selectorType, this.symbols)}`,
+        args[0]!.location,
+        "E_TYPE_MISMATCH"
+      );
+    }
     const seenKeys = new Set<string>();
     const valueTypes: Array<TypeExprNode | null> = [];
 
@@ -1969,10 +1996,10 @@ export class SemanticValidator {
       }
 
       const keyType = this.inferType(keyExpr, env);
-      const comparable = areComparableTypesCompatible(selectorType, keyType, this.symbols);
-      if (comparable === false) {
+      const keyKind = getSingleNonNullPrimitiveKind(keyType, this.symbols);
+      if (keyKind === "invalid" || (selectorKind !== null && keyKind !== null && selectorKind !== keyKind)) {
         this.error(
-          `Function 'match' selector and arm keys must be comparable primitive types, got ${describeTypeExpr(selectorType, this.symbols)} and ${describeTypeExpr(keyType, this.symbols)}`,
+          `Function 'match' selector and arm keys must use the same primitive type, got ${describeTypeExpr(selectorType, this.symbols)} and ${describeTypeExpr(keyType, this.symbols)}`,
           keyExpr.location,
           "E_TYPE_MISMATCH"
         );
@@ -2018,6 +2045,7 @@ export class SemanticValidator {
     }
 
     const labelTypes: Array<TypeExprNode | null> = [];
+    let labelKind: Exclude<PrimitiveKind, "null"> | null = null;
     for (let index = 0; index < args.length - 1; index += 1) {
       const candidate = args[index];
       if (candidate.kind !== "arrayLiteral" || candidate.elements.length !== 3) {
@@ -2031,14 +2059,18 @@ export class SemanticValidator {
 
       const [labelExpr, eligibleExpr, scoreExpr] = candidate.elements;
       const labelType = this.inferType(labelExpr, env);
-      const labelKinds = collectPrimitiveKinds(labelType, this.symbols);
-      if (
-        labelKinds === "nonprimitive" ||
-        !(labelKinds instanceof Set) ||
-        labelKinds.has("null")
-      ) {
+      const candidateLabelKind = getSingleNonNullPrimitiveKind(labelType, this.symbols);
+      if (candidateLabelKind === "invalid") {
         this.error(
-          `Function '${fnName}' requires primitive scalar labels, got ${describeTypeExpr(labelType, this.symbols)}`,
+          `Function '${fnName}' requires labels with exactly one primitive scalar type, got ${describeTypeExpr(labelType, this.symbols)}`,
+          labelExpr.location,
+          "E_TYPE_MISMATCH"
+        );
+      } else if (labelKind === null) {
+        labelKind = candidateLabelKind;
+      } else if (candidateLabelKind !== null && candidateLabelKind !== labelKind) {
+        this.error(
+          `Function '${fnName}' candidate labels must share one primitive scalar type, got ${labelKind} and ${candidateLabelKind}`,
           labelExpr.location,
           "E_TYPE_MISMATCH"
         );

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -392,6 +392,21 @@ function extendCollectionTypeEnv(baseEnv: TypeEnv, itemType: TypeExprNode): Type
   return next;
 }
 
+function getLiteralPrimitiveValue(expr: ExprNode): string | number | boolean | null | undefined {
+  if (expr.kind !== "literal") {
+    return undefined;
+  }
+  return expr.literalType === "null"
+    ? null
+    : typeof expr.value === "string" || typeof expr.value === "number" || typeof expr.value === "boolean"
+    ? expr.value
+    : undefined;
+}
+
+function isNumericLiteralExpr(expr: ExprNode): expr is Extract<ExprNode, { kind: "literal"; literalType: "number" }> {
+  return expr.kind === "literal" && expr.literalType === "number" && typeof expr.value === "number";
+}
+
 function resolvePathType(path: PathNode, symbols: DomainTypeSymbols): TypeExprNode | null {
   const [first, ...rest] = path.segments;
   if (!first || first.kind !== "propertySegment") {
@@ -1279,6 +1294,8 @@ export class SemanticValidator {
       case "mul":
       case "div":
       case "mod":
+      case "absDiff":
+      case "idiv":
       case "gt":
       case "gte":
       case "lt":
@@ -1357,6 +1374,7 @@ export class SemanticValidator {
         break;
 
       case "updateById":
+      case "clamp":
         if (args.length !== 3) {
           this.error(
             `Function '${name}' expects 3 arguments, got ${args.length}`,
@@ -1367,6 +1385,7 @@ export class SemanticValidator {
         break;
 
       case "removeById":
+      case "streak":
         if (args.length !== 2) {
           this.error(
             `Function '${name}' expects 2 arguments, got ${args.length}`,
@@ -1415,6 +1434,27 @@ export class SemanticValidator {
             `Function '${name}' expects at least 1 argument`,
             location,
             "E_ARG_COUNT"
+          );
+        }
+        break;
+
+      case "match":
+        if (args.length < 3) {
+          this.error(
+            "Function 'match' expects a selector, at least one [key, value] arm, and a default value",
+            location,
+            "E050"
+          );
+        }
+        break;
+
+      case "argmax":
+      case "argmin":
+        if (args.length < 2) {
+          this.error(
+            `Function '${name}' expects at least one [label, eligible, score] candidate and a tie-break literal`,
+            location,
+            "E052"
           );
         }
         break;
@@ -1479,6 +1519,8 @@ export class SemanticValidator {
       case "mul":
       case "div":
       case "mod":
+      case "absDiff":
+      case "idiv":
       case "pow":
         if (args.length === 2) {
           this.requireAssignable(
@@ -1551,6 +1593,53 @@ export class SemanticValidator {
             simpleTypeNode("number", args[0].location),
             args[0].location,
             `Function '${name}' expects a numeric argument`
+          );
+        }
+        break;
+
+      case "clamp":
+        if (args.length === 3) {
+          this.requireAssignable(
+            argTypes[0],
+            simpleTypeNode("number", args[0].location),
+            args[0].location,
+            "Function 'clamp' expects a numeric first argument"
+          );
+          this.requireAssignable(
+            argTypes[1],
+            simpleTypeNode("number", args[1].location),
+            args[1].location,
+            "Function 'clamp' expects a numeric second argument"
+          );
+          this.requireAssignable(
+            argTypes[2],
+            simpleTypeNode("number", args[2].location),
+            args[2].location,
+            "Function 'clamp' expects a numeric third argument"
+          );
+          if (isNumericLiteralExpr(args[1]) && isNumericLiteralExpr(args[2]) && args[1].value > args[2].value) {
+            this.error(
+              "Function 'clamp' requires literal bounds in lo, hi order",
+              location,
+              "E049"
+            );
+          }
+        }
+        break;
+
+      case "streak":
+        if (args.length === 2) {
+          this.requireAssignable(
+            argTypes[0],
+            simpleTypeNode("number", args[0].location),
+            args[0].location,
+            "Function 'streak' expects a numeric first argument"
+          );
+          this.requireAssignable(
+            argTypes[1],
+            simpleTypeNode("boolean", args[1].location),
+            args[1].location,
+            "Function 'streak' expects a boolean second argument"
           );
         }
         break;
@@ -1670,6 +1759,15 @@ export class SemanticValidator {
 
       case "coalesce":
         this.validateCoalesceTypes(argTypes, location);
+        break;
+
+      case "match":
+        this.validateMatchCall(args, argTypes, location, env);
+        break;
+
+      case "argmax":
+      case "argmin":
+        this.validateArgSelectionCall(name, args, location, env);
         break;
 
       case "if":
@@ -1798,6 +1896,159 @@ export class SemanticValidator {
         if (compatible === false) {
           this.error(
             `coalesce arguments must have compatible non-null types, got ${describeTypeExpr(concreteTypes[i], this.symbols)} and ${describeTypeExpr(concreteTypes[j], this.symbols)}`,
+            location,
+            "E_TYPE_MISMATCH"
+          );
+          return;
+        }
+      }
+    }
+  }
+
+  private validateMatchCall(
+    args: ExprNode[],
+    argTypes: Array<TypeExprNode | null>,
+    location: SourceLocation,
+    env: TypeEnv
+  ): void {
+    if (!this.symbols || args.length < 3) {
+      return;
+    }
+
+    const selectorType = argTypes[0];
+    const seenKeys = new Set<string>();
+    const valueTypes: Array<TypeExprNode | null> = [];
+
+    for (let index = 1; index < args.length - 1; index += 1) {
+      const arm = args[index];
+      if (arm.kind !== "arrayLiteral" || arm.elements.length !== 2) {
+        this.error(
+          "Function 'match' requires each arm to be an inline [key, value] array literal",
+          arm.location,
+          "E050"
+        );
+        continue;
+      }
+
+      const [keyExpr, valueExpr] = arm.elements;
+      const literalKey = getLiteralPrimitiveValue(keyExpr);
+      if (literalKey === undefined || literalKey === null) {
+        this.error(
+          "Function 'match' requires literal string, number, or boolean arm keys",
+          keyExpr.location,
+          "E050"
+        );
+      } else {
+        const dedupeKey = `${typeof literalKey}:${String(literalKey)}`;
+        if (seenKeys.has(dedupeKey)) {
+          this.error(
+            `Function 'match' has duplicate arm key ${JSON.stringify(literalKey)}`,
+            keyExpr.location,
+            "E051"
+          );
+        } else {
+          seenKeys.add(dedupeKey);
+        }
+      }
+
+      const keyType = this.inferType(keyExpr, env);
+      const comparable = areComparableTypesCompatible(selectorType, keyType, this.symbols);
+      if (comparable === false) {
+        this.error(
+          `Function 'match' selector and arm keys must be comparable primitive types, got ${describeTypeExpr(selectorType, this.symbols)} and ${describeTypeExpr(keyType, this.symbols)}`,
+          keyExpr.location,
+          "E_TYPE_MISMATCH"
+        );
+      }
+
+      valueTypes.push(this.inferType(valueExpr, env));
+    }
+
+    valueTypes.push(argTypes[argTypes.length - 1]);
+    for (let i = 0; i < valueTypes.length; i += 1) {
+      for (let j = i + 1; j < valueTypes.length; j += 1) {
+        const compatible = areTypesCompatible(valueTypes[i], valueTypes[j], this.symbols);
+        if (compatible === false) {
+          this.error(
+            `Function 'match' arm values and default must have compatible types, got ${describeTypeExpr(valueTypes[i], this.symbols)} and ${describeTypeExpr(valueTypes[j], this.symbols)}`,
+            location,
+            "E_TYPE_MISMATCH"
+          );
+          return;
+        }
+      }
+    }
+  }
+
+  private validateArgSelectionCall(
+    fnName: "argmax" | "argmin",
+    args: ExprNode[],
+    location: SourceLocation,
+    env: TypeEnv
+  ): void {
+    if (!this.symbols || args.length < 2) {
+      return;
+    }
+
+    const tieBreakExpr = args[args.length - 1];
+    const tieBreakValue = getLiteralPrimitiveValue(tieBreakExpr);
+    if (tieBreakValue !== "first" && tieBreakValue !== "last") {
+      this.error(
+        `Function '${fnName}' requires a final tie-break literal of "first" or "last"`,
+        tieBreakExpr.location,
+        "E052"
+      );
+    }
+
+    const labelTypes: Array<TypeExprNode | null> = [];
+    for (let index = 0; index < args.length - 1; index += 1) {
+      const candidate = args[index];
+      if (candidate.kind !== "arrayLiteral" || candidate.elements.length !== 3) {
+        this.error(
+          `Function '${fnName}' requires inline [label, eligible, score] array literal candidates`,
+          candidate.location,
+          "E052"
+        );
+        continue;
+      }
+
+      const [labelExpr, eligibleExpr, scoreExpr] = candidate.elements;
+      const labelType = this.inferType(labelExpr, env);
+      const labelKinds = collectPrimitiveKinds(labelType, this.symbols);
+      if (
+        labelKinds === "nonprimitive" ||
+        !(labelKinds instanceof Set) ||
+        labelKinds.has("null")
+      ) {
+        this.error(
+          `Function '${fnName}' requires primitive scalar labels, got ${describeTypeExpr(labelType, this.symbols)}`,
+          labelExpr.location,
+          "E_TYPE_MISMATCH"
+        );
+      }
+
+      this.requireAssignable(
+        this.inferType(eligibleExpr, env),
+        simpleTypeNode("boolean", eligibleExpr.location),
+        eligibleExpr.location,
+        `Function '${fnName}' expects a boolean eligible value`
+      );
+      this.requireAssignable(
+        this.inferType(scoreExpr, env),
+        simpleTypeNode("number", scoreExpr.location),
+        scoreExpr.location,
+        `Function '${fnName}' expects a numeric score value`
+      );
+
+      labelTypes.push(labelType);
+    }
+
+    for (let i = 0; i < labelTypes.length; i += 1) {
+      for (let j = i + 1; j < labelTypes.length; j += 1) {
+        const compatible = areTypesCompatible(labelTypes[i], labelTypes[j], this.symbols);
+        if (compatible === false) {
+          this.error(
+            `Function '${fnName}' candidate labels must have compatible scalar types, got ${describeTypeExpr(labelTypes[i], this.symbols)} and ${describeTypeExpr(labelTypes[j], this.symbols)}`,
             location,
             "E_TYPE_MISMATCH"
           );

--- a/packages/compiler/src/diagnostics/codes.ts
+++ b/packages/compiler/src/diagnostics/codes.ts
@@ -219,6 +219,26 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticCode> = {
     message: "Transform primitive in dispatchable condition",
     category: "semantic",
   },
+  E049: {
+    code: "E049",
+    message: "Invalid literal clamp bounds",
+    category: "semantic",
+  },
+  E050: {
+    code: "E050",
+    message: "Invalid match() form",
+    category: "semantic",
+  },
+  E051: {
+    code: "E051",
+    message: "Duplicate match() key",
+    category: "semantic",
+  },
+  E052: {
+    code: "E052",
+    message: "Invalid argmax()/argmin() form",
+    category: "semantic",
+  },
 
   // ============ Scope Errors (E1xx) ============
   E_UNDEFINED: {

--- a/packages/compiler/src/evaluation/evaluate-expr.ts
+++ b/packages/compiler/src/evaluation/evaluate-expr.ts
@@ -99,6 +99,30 @@ function evaluateNode(expr: ExprNode, ctx: EvaluationContext): unknown {
     case "neg":
       return evaluateNeg(expr.arg, ctx);
 
+    case "min":
+      return evaluateMin(expr.args, ctx);
+
+    case "max":
+      return evaluateMax(expr.args, ctx);
+
+    case "abs":
+      return evaluateAbs(expr.arg, ctx);
+
+    case "floor":
+      return evaluateFloor(expr.arg, ctx);
+
+    case "ceil":
+      return evaluateCeil(expr.arg, ctx);
+
+    case "round":
+      return evaluateRound(expr.arg, ctx);
+
+    case "sqrt":
+      return evaluateSqrt(expr.arg, ctx);
+
+    case "pow":
+      return evaluatePow(expr.base, expr.exponent, ctx);
+
     // String
     case "concat":
       return evaluateConcat(expr.args, ctx);
@@ -145,6 +169,15 @@ function evaluateNode(expr: ExprNode, ctx: EvaluationContext): unknown {
 
     case "append":
       return evaluateAppend(expr.array, expr.items, ctx);
+
+    case "sumArray":
+      return evaluateSumArray(expr.array, ctx);
+
+    case "minArray":
+      return evaluateMinArray(expr.array, ctx);
+
+    case "maxArray":
+      return evaluateMaxArray(expr.array, ctx);
 
     // Object
     case "object":
@@ -422,6 +455,80 @@ function evaluateMod(left: ExprNode, right: ExprNode, ctx: EvaluationContext): n
 function evaluateNeg(arg: ExprNode, ctx: EvaluationContext): number | null {
   const value = evaluateNode(arg, ctx);
   return typeof value === "number" ? -value : null;
+}
+
+function evaluateMin(args: ExprNode[], ctx: EvaluationContext): number | null {
+  if (args.length === 0) {
+    return null;
+  }
+
+  let min: number | null = null;
+  for (const arg of args) {
+    const value = evaluateNode(arg, ctx);
+    if (typeof value !== "number") {
+      return null;
+    }
+    min = min === null ? value : Math.min(min, value);
+  }
+
+  return min;
+}
+
+function evaluateMax(args: ExprNode[], ctx: EvaluationContext): number | null {
+  if (args.length === 0) {
+    return null;
+  }
+
+  let max: number | null = null;
+  for (const arg of args) {
+    const value = evaluateNode(arg, ctx);
+    if (typeof value !== "number") {
+      return null;
+    }
+    max = max === null ? value : Math.max(max, value);
+  }
+
+  return max;
+}
+
+function evaluateAbs(arg: ExprNode, ctx: EvaluationContext): number | null {
+  const value = evaluateNode(arg, ctx);
+  return typeof value === "number" ? Math.abs(value) : null;
+}
+
+function evaluateFloor(arg: ExprNode, ctx: EvaluationContext): number | null {
+  const value = evaluateNode(arg, ctx);
+  return typeof value === "number" ? Math.floor(value) : null;
+}
+
+function evaluateCeil(arg: ExprNode, ctx: EvaluationContext): number | null {
+  const value = evaluateNode(arg, ctx);
+  return typeof value === "number" ? Math.ceil(value) : null;
+}
+
+function evaluateRound(arg: ExprNode, ctx: EvaluationContext): number | null {
+  const value = evaluateNode(arg, ctx);
+  return typeof value === "number" ? Math.round(value) : null;
+}
+
+function evaluateSqrt(arg: ExprNode, ctx: EvaluationContext): number | null {
+  const value = evaluateNode(arg, ctx);
+  if (typeof value !== "number" || value < 0) {
+    return null;
+  }
+  return Math.sqrt(value);
+}
+
+function evaluatePow(base: ExprNode, exponent: ExprNode, ctx: EvaluationContext): number | null {
+  const left = evaluateNode(base, ctx);
+  const right = evaluateNode(exponent, ctx);
+
+  if (typeof left !== "number" || typeof right !== "number") {
+    return null;
+  }
+
+  const value = Math.pow(left, right);
+  return Number.isFinite(value) ? value : null;
 }
 
 // ============ String Operators ============
@@ -705,6 +812,60 @@ function evaluateAppend(
 
   const itemValues = items.map((item) => evaluateNode(item, ctx));
   return [...arr, ...itemValues];
+}
+
+function evaluateSumArray(array: ExprNode, ctx: EvaluationContext): number | null {
+  const arr = evaluateNode(array, ctx);
+
+  if (!Array.isArray(arr)) {
+    return null;
+  }
+
+  let sum = 0;
+  for (const value of arr) {
+    if (typeof value !== "number") {
+      return null;
+    }
+    sum += value;
+  }
+
+  return sum;
+}
+
+function evaluateMinArray(array: ExprNode, ctx: EvaluationContext): number | null {
+  const arr = evaluateNode(array, ctx);
+
+  if (!Array.isArray(arr) || arr.length === 0) {
+    return null;
+  }
+
+  let min: number | null = null;
+  for (const value of arr) {
+    if (typeof value !== "number") {
+      return null;
+    }
+    min = min === null ? value : Math.min(min, value);
+  }
+
+  return min;
+}
+
+function evaluateMaxArray(array: ExprNode, ctx: EvaluationContext): number | null {
+  const arr = evaluateNode(array, ctx);
+
+  if (!Array.isArray(arr) || arr.length === 0) {
+    return null;
+  }
+
+  let max: number | null = null;
+  for (const value of arr) {
+    if (typeof value !== "number") {
+      return null;
+    }
+    max = max === null ? value : Math.max(max, value);
+  }
+
+  return max;
 }
 
 // ============ Object Operators ============

--- a/packages/compiler/src/lowering/lower-expr.ts
+++ b/packages/compiler/src/lowering/lower-expr.ts
@@ -230,6 +230,77 @@ function lowerCall(
 ): CoreExprNode {
   const { fn, args } = input;
 
+  if (fn === "absDiff") {
+    if (args.length !== 2) {
+      throw unknownCallFn(fn);
+    }
+    return {
+      kind: "abs",
+      arg: {
+        kind: "sub",
+        left: lowerExprNode(args[0], ctx),
+        right: lowerExprNode(args[1], ctx),
+      },
+    };
+  }
+
+  if (fn === "clamp") {
+    if (args.length !== 3) {
+      throw unknownCallFn(fn);
+    }
+    return {
+      kind: "min",
+      args: [
+        {
+          kind: "max",
+          args: [
+            lowerExprNode(args[0], ctx),
+            lowerExprNode(args[1], ctx),
+          ],
+        },
+        lowerExprNode(args[2], ctx),
+      ],
+    };
+  }
+
+  if (fn === "idiv") {
+    if (args.length !== 2) {
+      throw unknownCallFn(fn);
+    }
+    return {
+      kind: "floor",
+      arg: {
+        kind: "div",
+        left: lowerExprNode(args[0], ctx),
+        right: lowerExprNode(args[1], ctx),
+      },
+    };
+  }
+
+  if (fn === "streak") {
+    if (args.length !== 2) {
+      throw unknownCallFn(fn);
+    }
+    return {
+      kind: "if",
+      cond: lowerExprNode(args[1], ctx),
+      then: {
+        kind: "add",
+        left: lowerExprNode(args[0], ctx),
+        right: { kind: "lit", value: 1 },
+      },
+      else: { kind: "lit", value: 0 },
+    };
+  }
+
+  if (fn === "match") {
+    return lowerMatchCall(args, ctx);
+  }
+
+  if (fn === "argmax" || fn === "argmin") {
+    return lowerArgSelectionCall(fn, args, ctx);
+  }
+
   // Binary operators: left, right
   if (isBinaryOp(fn)) {
     if (args.length !== 2) {
@@ -561,6 +632,153 @@ function lowerArr(
     array: { kind: "lit", value: [] },
     items: loweredElements,
   };
+}
+
+type LoweredArgCandidate = {
+  label: CoreExprNode;
+  eligible: CoreExprNode;
+  score: CoreExprNode;
+};
+
+function lowerMatchCall(args: MelExprNode[], ctx: ExprLoweringContext): CoreExprNode {
+  if (args.length < 3) {
+    throw unknownCallFn("match");
+  }
+
+  const selector = lowerExprNode(args[0], ctx);
+  let current = lowerExprNode(args[args.length - 1], ctx);
+
+  for (let index = args.length - 2; index >= 1; index -= 1) {
+    const arm = args[index];
+    if (arm.kind !== "arr" || arm.elements.length !== 2) {
+      throw unknownCallFn("match");
+    }
+    current = {
+      kind: "if",
+      cond: {
+        kind: "eq",
+        left: selector,
+        right: lowerExprNode(arm.elements[0], ctx),
+      },
+      then: lowerExprNode(arm.elements[1], ctx),
+      else: current,
+    };
+  }
+
+  return current;
+}
+
+function lowerArgSelectionCall(
+  fn: "argmax" | "argmin",
+  args: MelExprNode[],
+  ctx: ExprLoweringContext
+): CoreExprNode {
+  if (args.length < 2) {
+    throw unknownCallFn(fn);
+  }
+
+  const tieBreak = args[args.length - 1];
+  if (tieBreak.kind !== "lit" || (tieBreak.value !== "first" && tieBreak.value !== "last")) {
+    throw unknownCallFn(fn);
+  }
+
+  const candidates = args.slice(0, -1).map((candidate) => lowerArgCandidate(candidate, ctx, fn));
+  if (candidates.length === 0) {
+    throw unknownCallFn(fn);
+  }
+
+  return buildArgSelection(fn, candidates, tieBreak.value);
+}
+
+function lowerArgCandidate(
+  candidate: MelExprNode,
+  ctx: ExprLoweringContext,
+  fn: "argmax" | "argmin"
+): LoweredArgCandidate {
+  if (candidate.kind !== "arr" || candidate.elements.length !== 3) {
+    throw unknownCallFn(fn);
+  }
+
+  return {
+    label: lowerExprNode(candidate.elements[0], ctx),
+    eligible: lowerExprNode(candidate.elements[1], ctx),
+    score: lowerExprNode(candidate.elements[2], ctx),
+  };
+}
+
+function buildArgSelection(
+  fn: "argmax" | "argmin",
+  candidates: LoweredArgCandidate[],
+  tieBreak: "first" | "last"
+): CoreExprNode {
+  return buildArgSelectionState(fn, candidates, tieBreak, 0).label;
+}
+
+function buildArgSelectionState(
+  fn: "argmax" | "argmin",
+  candidates: LoweredArgCandidate[],
+  tieBreak: "first" | "last",
+  index: number
+): { eligible: CoreExprNode; score: CoreExprNode; label: CoreExprNode } {
+  const current = candidates[index];
+  if (index === candidates.length - 1) {
+    return {
+      eligible: current.eligible,
+      score: current.score,
+      label: {
+        kind: "if",
+        cond: current.eligible,
+        then: current.label,
+        else: { kind: "lit", value: null },
+      },
+    };
+  }
+
+  const rest = buildArgSelectionState(fn, candidates, tieBreak, index + 1);
+  const compareKind = selectionCompareKind(fn, tieBreak);
+  const chooseCurrent: CoreExprNode = {
+    kind: "and",
+    args: [
+      current.eligible,
+      {
+        kind: "or",
+        args: [
+          { kind: "not", arg: rest.eligible },
+          {
+            kind: compareKind,
+            left: current.score,
+            right: rest.score,
+          },
+        ],
+      },
+    ],
+  };
+
+  return {
+    eligible: { kind: "or", args: [current.eligible, rest.eligible] },
+    score: {
+      kind: "if",
+      cond: chooseCurrent,
+      then: current.score,
+      else: rest.score,
+    },
+    label: {
+      kind: "if",
+      cond: chooseCurrent,
+      then: current.label,
+      else: rest.label,
+    },
+  };
+}
+
+function selectionCompareKind(
+  fn: "argmax" | "argmin",
+  tieBreak: "first" | "last"
+): "gt" | "gte" | "lt" | "lte" {
+  if (fn === "argmax") {
+    return tieBreak === "first" ? "gte" : "gt";
+  }
+  return tieBreak === "first" ? "lte" : "lt";
 }
 
 // ============ Operator Classification ============

--- a/packages/compiler/src/lowering/lower-expr.ts
+++ b/packages/compiler/src/lowering/lower-expr.ts
@@ -711,74 +711,66 @@ function buildArgSelection(
   candidates: LoweredArgCandidate[],
   tieBreak: "first" | "last"
 ): CoreExprNode {
-  return buildArgSelectionState(fn, candidates, tieBreak, 0).label;
+  let current: CoreExprNode = { kind: "lit", value: null };
+  for (let index = candidates.length - 1; index >= 0; index -= 1) {
+    current = {
+      kind: "if",
+      cond: buildArgSelectionCondition(fn, candidates, tieBreak, index),
+      then: candidates[index]!.label,
+      else: current,
+    };
+  }
+  return current;
 }
 
-function buildArgSelectionState(
+function buildArgSelectionCondition(
   fn: "argmax" | "argmin",
   candidates: LoweredArgCandidate[],
   tieBreak: "first" | "last",
   index: number
-): { eligible: CoreExprNode; score: CoreExprNode; label: CoreExprNode } {
-  const current = candidates[index];
-  if (index === candidates.length - 1) {
-    return {
-      eligible: current.eligible,
-      score: current.score,
-      label: {
-        kind: "if",
-        cond: current.eligible,
-        then: current.label,
-        else: { kind: "lit", value: null },
-      },
-    };
+): CoreExprNode {
+  const current = candidates[index]!;
+  const comparisons: CoreExprNode[] = [];
+
+  for (let otherIndex = 0; otherIndex < candidates.length; otherIndex += 1) {
+    if (otherIndex === index) {
+      continue;
+    }
+    const other = candidates[otherIndex]!;
+    comparisons.push({
+      kind: "or",
+      args: [
+        { kind: "not", arg: other.eligible },
+        {
+          kind: selectionCompareKind(fn, tieBreak, index, otherIndex),
+          left: current.score,
+          right: other.score,
+        },
+      ],
+    });
   }
 
-  const rest = buildArgSelectionState(fn, candidates, tieBreak, index + 1);
-  const compareKind = selectionCompareKind(fn, tieBreak);
-  const chooseCurrent: CoreExprNode = {
-    kind: "and",
-    args: [
-      current.eligible,
-      {
-        kind: "or",
-        args: [
-          { kind: "not", arg: rest.eligible },
-          {
-            kind: compareKind,
-            left: current.score,
-            right: rest.score,
-          },
-        ],
-      },
-    ],
-  };
+  if (comparisons.length === 0) {
+    return current.eligible;
+  }
 
   return {
-    eligible: { kind: "or", args: [current.eligible, rest.eligible] },
-    score: {
-      kind: "if",
-      cond: chooseCurrent,
-      then: current.score,
-      else: rest.score,
-    },
-    label: {
-      kind: "if",
-      cond: chooseCurrent,
-      then: current.label,
-      else: rest.label,
-    },
+    kind: "and",
+    args: [current.eligible, ...comparisons],
   };
 }
 
 function selectionCompareKind(
   fn: "argmax" | "argmin",
-  tieBreak: "first" | "last"
+  tieBreak: "first" | "last",
+  index: number,
+  otherIndex: number
 ): "gt" | "gte" | "lt" | "lte" {
+  const prefersCurrentOnTie = tieBreak === "first" ? index < otherIndex : index > otherIndex;
   if (fn === "argmax") {
-    return tieBreak === "first" ? "gte" : "gt";
+    return prefersCurrentOnTie ? "gte" : "gt";
   }
-  return tieBreak === "first" ? "lte" : "lt";
+  return prefersCurrentOnTie ? "lte" : "lt";
 }
 
 // ============ Operator Classification ============


### PR DESCRIPTION
## Summary
- add bounded parser-free MEL sugar for `absDiff`, `clamp`, `idiv`, `streak`, `match`, `argmax`, and `argmin`
- extend validator, type inference, diagnostics, lowering, and compiler-side evaluation to support the new contract without adding new Core IR kinds
- sync compiler/MEL docs, examples, and CCTS coverage to the current bounded sugar surface

## Why
The MEL docs and RFC work identified a bounded set of source-level sugar forms that can be admitted safely because they remain explicit MEL calls until the compiler-owned lowering boundary and lower entirely into existing runtime expression kinds.

Closes #425

## Validation
- `pnpm --filter @manifesto-ai/compiler test`
- CCTS coverage added for bounded sugar lowering and diagnostics
- docs example smoke coverage added for the new MEL examples
