### PR TITLE
docs: align current sdk and compiler contract guidance

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,14 +1,14 @@
 # API Reference
 
-> Lookup the app-facing runtime surface first. Drop into package overviews only when you need the owning package boundary.
+> Lookup the application-facing runtime surface first. Drop into package overviews only when you need the owning package boundary.
 
 If you are learning Manifesto for the first time, start with the [Guide](/guide/introduction). Use this section when you know what you want to call.
 
-## App Runtime APIs
+## Application Runtime APIs
 
 | Area | Start Here |
 |------|------------|
-| Create an app | [Application](./application) |
+| Create and activate a runtime | [Application](./application) |
 | Inspect the activated handle | [Runtime Instance](./runtime) |
 | Show legal actions to UI or agents | [Actions and Availability](./actions-and-availability) |
 | Request a transition | [Intents](./intents) |

--- a/docs/internals/adr/002-dx-improvement-mel-namespace-onceIntent.md
+++ b/docs/internals/adr/002-dx-improvement-mel-namespace-onceIntent.md
@@ -10,7 +10,7 @@
 - **Date:** 2026-01-27
 - **Status:** Implemented
 - **Implemented-by:**
-  - [Compiler SPEC v0.7.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v0.7.0.md)
+  - [Compiler current contract (SPEC-v1.0.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md)
   - historical SDK v1.0.0 contract (removed from the working tree; see Git history)
   - `packages/compiler/src/parser/parser.ts`, `packages/compiler/src/api/compile-mel-patch-collector.ts`, `packages/compiler/src/__tests__/once-intent.test.ts`, `packages/sdk/src/create-manifesto.ts`
 - **Owners:** 정성우

--- a/docs/internals/adr/009-structured-patch-path.md
+++ b/docs/internals/adr/009-structured-patch-path.md
@@ -6,7 +6,7 @@
 > **Scope:** Core, Compiler, Host, Runtime, World
 > **Resolves:** [#108](https://github.com/manifesto-ai/core/issues/108), [#189](https://github.com/manifesto-ai/core/issues/189)
 > **Supersedes:** None
-> **Implemented-by:** [Core SPEC v3.0.0](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler SPEC v0.7.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v0.7.0.md), [Host SPEC v3.0.0](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC.md), [World SPEC v3.0.0](https://github.com/manifesto-ai/core/blob/main/packages/world/docs/world-SPEC.md), and concrete code in `packages/core/src/schema/patch.ts`, `packages/core/src/core/apply.ts`, `packages/compiler/src/lowering/lower-runtime-patch.ts`, `packages/world/src/persistence/memory.ts`
+> **Implemented-by:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler current contract (SPEC-v1.0.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md), [host-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC.md), and concrete code in `packages/core/src/schema/patch.ts`, `packages/core/src/core/apply.ts`, `packages/compiler/src/lowering/lower-runtime-patch.ts`, plus historical pre-split world/store code paths
 > **Strengthens:** FDR-015 (Static Patch Paths), FDR-MEL-032 (Dynamic Path Segments)
 > **Breaking:** Yes — Major version bump required for Core, Compiler
 

--- a/docs/internals/adr/012-remove-computed-prefix.md
+++ b/docs/internals/adr/012-remove-computed-prefix.md
@@ -5,7 +5,7 @@
 > **Deciders:** Manifesto Core/Compiler Design Group
 > **Scope:** Core, Compiler, Host, SDK, Docs
 > **Breaking:** Yes
-> **Implemented-by:** [Core SPEC v3.0.0](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler SPEC v0.7.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v0.7.0.md), and concrete code in `packages/core/src/evaluator/expr.ts`, `packages/core/src/core/explain.ts`
+> **Implemented-by:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler current contract (SPEC-v1.0.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md), and concrete code in `packages/core/src/evaluator/expr.ts`, `packages/core/src/core/explain.ts`
 > **Related:** ADR-001 (Layer Separation), ADR-006 (Canonical rules), ADR-009 (Structured PatchPath), ADR-011 (Boundary contract)
 > **Reason for change:** Developer Ergonomics / API consistency
 

--- a/docs/internals/adr/013a-mel-statement-composition-flow-and-include.md
+++ b/docs/internals/adr/013a-mel-statement-composition-flow-and-include.md
@@ -9,7 +9,7 @@
 > **Related:** ADR-013b (Entity Collection Primitives — separate approval gate)
 > **Supersedes:** ADR-013 (Withdrawn — mixed three independent decisions)
 > **Breaking:** No — additive syntax via contextual keywords; runtime layers unchanged
-> **Implemented In:** Compiler SPEC v0.7.0, `packages/compiler/src/analyzer/flow-composition.ts`, analyzer/generator/integration/compliance test suites
+> **Implemented In:** Compiler current contract ([SPEC-v1.0.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md)), `packages/compiler/src/analyzer/flow-composition.ts`, analyzer/generator/integration/compliance test suites
 
 ---
 

--- a/docs/internals/adr/013b-entity-collection-primitives.md
+++ b/docs/internals/adr/013b-entity-collection-primitives.md
@@ -10,7 +10,7 @@
 > **Supersedes:** ADR-013 (Withdrawn — mixed three independent decisions)
 > **Breaking:** No — additive builtin functions only; existing syntax unaffected; Core IR unchanged; runtime layers unchanged
 > **Internal Structure:** §4 Query Primitives (013b-1) and §5 Transform Primitives (013b-2) have **separate acceptance criteria** and may be approved independently.
-> **Implemented In:** Compiler SPEC v0.7.0, entity primitive lowering/analyzer paths, generator/integration/compliance test suites
+> **Implemented In:** Compiler current contract ([SPEC-v1.0.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md)), entity primitive lowering/analyzer paths, generator/integration/compliance test suites
 
 ---
 

--- a/docs/internals/adr/020-intent-level-dispatchability.md
+++ b/docs/internals/adr/020-intent-level-dispatchability.md
@@ -1,11 +1,13 @@
 # ADR-020: Intent-Level Dispatchability — `dispatchable when` Clause
 
-> **Status:** Proposed
+> **Status:** Implemented
 > **Date:** 2026-04-07
 > **Deciders:** 정성우 (Architect), Manifesto Architecture Team
 > **Scope:** Compiler, Core, SDK, Studio/Introspection, Docs
 > **Related ADRs:** ADR-017 (Capability Decorator Pattern), ADR-018 (Public Snapshot Boundary)
-> **Related SPECs:** Core SPEC v4, SDK SPEC v3.1.0, Compiler SPEC v0.8.0
+> **Related SPECs:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), [SPEC-v1.0.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md)
+
+> **Current Contract Authority:** This ADR is implemented. The current behavior now lives in the owning package specs and current MEL docs. This document remains the architectural decision record and original design rationale.
 
 ---
 
@@ -26,7 +28,7 @@ isActionAvailable(schema, snapshot, actionName): boolean     // AVAIL-Q-1..7
 getAvailableActions(schema, snapshot): readonly string[]      // AVAIL-Q-5
 ```
 
-SDK v3.1.0 delegates to Core for these reads (§7.3) and checks availability at `dispatchAsync()` dequeue time. `simulate()` throws `ACTION_UNAVAILABLE` for unavailable actions (SIM-7).
+The current SDK contract delegates to Core for these reads and checks availability at `dispatchAsync()` dequeue time. `simulate()` throws `ACTION_UNAVAILABLE` for unavailable actions (SIM-7).
 
 This contract is sound. Nothing in this ADR changes it.
 
@@ -214,10 +216,10 @@ This fulfills Manifesto's promise that semantic legality is **readable, not opaq
 
 **Execution semantics update:**
 
-`dispatchAsync()` dequeue-time check is extended:
+`dispatchAsync()` dequeue-time check is now:
 
-| Step | Current (v3.1.0) | Proposed |
-|------|-----------------|----------|
+| Step | Before adoption | Current contract |
+|------|-----------------|------------------|
 | 1 | Check `isActionAvailable()` | Check `isActionAvailable()` |
 | 2 | — | Check `isIntentDispatchable()` |
 | 3 | Execute via Host | Execute via Host |
@@ -230,7 +232,7 @@ If dispatchability fails at dequeue time:
 
 **`simulate()` update:**
 
-`simulate()` currently throws `ACTION_UNAVAILABLE` when the action is unavailable (SIM-7). The proposed extension:
+`simulate()` throws `ACTION_UNAVAILABLE` when the action is unavailable (SIM-7). The current extension is:
 
 | Rule ID | Level | Description |
 |---------|-------|-------------|
@@ -332,7 +334,7 @@ action shoot(cellIndex: number) available when canShoot {
 }
 ```
 
-### After (proposed pattern)
+### After (current pattern)
 
 ```mel
 action shoot(cellIndex: number)
@@ -357,7 +359,7 @@ This is a syntactically additive change. No existing MEL source requires modific
 
 ---
 
-## 8. Open Questions
+## 8. Historical Open Questions
 
 ### OQ-1: `getActionMetadata()` dispatchable expression exposure
 
@@ -379,35 +381,35 @@ Should `dispatchable when` support `and()` / `or()` composition for multi-condit
 
 ---
 
-## 9. SPEC Diff Summary
+## 9. Landed SPEC Surface
 
-This section summarizes the normative changes required across package SPECs if this ADR is accepted.
+This section summarizes the landed normative changes across the owning package specs.
 
 ### Compiler SPEC
 
-- Add `DispatchableExpr` context definition (§13.1 companion).
-- Add constraint for `dispatchable when` scope rules (next free constraint ID).
-- Extend `ActionDecl` grammar: `AvailableClause? DispatchableClause?`.
-- Add `ActionSpec.dispatchable?: ExprNode` to compiled output.
+- Defines the `dispatchable when` expression context.
+- Defines scope rules for `dispatchable when`.
+- Extends action declarations with `AvailableClause? DispatchableClause?`.
+- Emits `ActionSpec.dispatchable?: ExprNode`.
 
 ### Core SPEC
 
-- Add `isIntentDispatchable()` function (§16.6 companion).
-- Add rules DISP-Q-1 through DISP-Q-6.
-- Clarify that `compute()` initial invocation checks availability only (not dispatchability) — dispatchability is a pre-`compute()` gate owned by the caller (SDK/Host).
+- Exposes `isIntentDispatchable()`.
+- Defines the dispatchability query rules.
+- Clarifies that `compute()` initial invocation checks availability only; dispatchability remains a pre-`compute()` gate owned by the caller.
 
 ### SDK SPEC
 
-- Add `isIntentDispatchable()` and `getIntentBlockers()` to activated base surface (§7 extension).
-- Extend `dispatchAsync()` dequeue semantics to include dispatchability check.
-- Add `INTENT_NOT_DISPATCHABLE` error code.
-- Extend `simulate()` with SIM-9.
-- Extend `getActionMetadata()` with `hasDispatchableGate` flag.
+- Exposes `isIntentDispatchable()` and `getIntentBlockers()` on the activated base surface.
+- Extends `dispatchAsync()` dequeue semantics to include dispatchability checks.
+- Defines `INTENT_NOT_DISPATCHABLE`.
+- Extends `simulate()` with the dispatchability rejection path.
+- Exposes `hasDispatchableGate` through `getActionMetadata()`.
 
 ### MEL Language Docs
 
 - Document `dispatchable when` syntax and semantics.
-- Add Battleship example as canonical illustration.
+- Use Battleship as the canonical illustration.
 - Clarify the three-layer legality model.
 
 ---

--- a/docs/internals/adr/index.md
+++ b/docs/internals/adr/index.md
@@ -50,7 +50,7 @@ These ADRs affect multiple packages across the monorepo:
 | [ADR-017](./017-capability-decorator-pattern) | Capability Decorator Pattern — Semantic Transformation of SDK Surface | Implemented | 2026-04-01 | SDK, Lineage, Governance |
 | [ADR-018](./018-public-snapshot-boundary) | Public Snapshot Boundary — User-Facing Snapshot Projection and CanonicalSnapshot Separation | Implemented | 2026-04-03 | SDK, Core (docs), Docs, Lineage, Governance |
 | [ADR-019](./019-post-activation-extension-kernel) | Post-Activation Extension Kernel — Safe Public Seam for Arbitrary-Snapshot Operations | Implemented | 2026-04-07 | SDK |
-| [ADR-020](./020-intent-level-dispatchability) | Intent-Level Dispatchability — `dispatchable when` Clause | Proposed | 2026-04-07 | Compiler, Core, SDK, Studio/Introspection, Docs |
+| [ADR-020](./020-intent-level-dispatchability) | Intent-Level Dispatchability — `dispatchable when` Clause | Implemented | 2026-04-07 | Compiler, Core, SDK, Studio/Introspection, Docs |
 
 ### ADR-006 Companion Evidence (Non-Normative)
 
@@ -78,7 +78,8 @@ These ADRs affect multiple packages across the monorepo:
 - ADR-010 defines the protocol-first reconstruction of the SDK as a thin composition layer with `createManifesto()` as its sole owned concept.
 - This ADR explicitly removes App-layer semantic coupling in product-facing APIs. ActionHandle, Session, Hook, Plugin, and 20+ binding-layer concepts are retired.
 - ADR-010 lifts the old SDK SPEC v0.1.0 kickoff lock for `submitProposal`, `createApp`, and legacy `App` aliases.
-- Public migration contract for v1 is `createManifesto()` returning `ManifestoInstance` with `dispatch()` as the single action entrypoint.
+- The original hard-cut migration contract was `createManifesto()` returning a runtime directly with `dispatch()` as the single action entrypoint.
+- The current SDK contract is the activation-first `createManifesto() -> activate()` model documented in [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md).
 - ADR-010 supersedes SDK SPEC v0.1.0 and v0.2.0 via SDK SPEC v1.0.0.
 - ADR-010 retires Runtime SPEC v0.1.0 and v0.2.0 (no successor — responsibilities absorbed into `createManifesto`).
 - ADR-010 is now implemented in the current SDK/package layout; the remaining split-related work belongs to ADR-014 rather than this hard-cut.
@@ -88,21 +89,21 @@ These ADRs affect multiple packages across the monorepo:
 - ADR-011 defines Host boundary baseline-completeness policy for reset/Bootstrap entry.
 - It is the host-runtime contract companion to #198, scoped to full-canonical snapshot continuity at boundary entry.
 - executionKey serialization and timeout-slot release remain Host SPEC v2.0.3 enforcement work, not architecture decisions in this ADR.
-- 011 is implemented via Host SPEC v3.0.0 and boundary-entry hardening; §2.2/§2.3 remains enforced as Host SPEC behavior, not extra ADR text.
+- ADR-011 is implemented via the current Host contract and boundary-entry hardening; §2.2/§2.3 remains enforced as Host SPEC behavior, not extra ADR text.
 
 ### ADR-013 Split Notes
 
 - There is no standalone `ADR-013` file in the repository.
 - The original mixed ADR-013 draft was withdrawn and split into `ADR-013a` (`flow`/`include`) and `ADR-013b` (entity collection primitives).
-- Both split tracks are now implemented in the compiler current contract and reflected in Compiler SPEC v0.7.0 plus the compiler compliance suites.
+- Both split tracks are now implemented in the compiler current contract, reflected in [SPEC-v1.0.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md), and covered by the compiler compliance suites.
 
 ### ADR-014 Companion Notes
 
 - ADR-014 is the implemented protocol split of `@manifesto-ai/world` into `@manifesto-ai/governance` and `@manifesto-ai/lineage`.
-- [Lineage SPEC v2.0.0](https://github.com/manifesto-ai/core/blob/main/packages/lineage/docs/lineage-SPEC-2.0.0v.md) is now the canonical continuity-engine document.
-- [Governance SPEC v2.0.0](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/governance-SPEC-2.0.0v.md) is now the canonical legitimacy-engine document.
-- [World Facade SPEC v2.0.0](https://github.com/manifesto-ai/core/blob/main/packages/world/docs/world-facade-spec-v2.0.0.md) is now the canonical governed-facade document.
-- [World SPEC](../spec/#world) remains the legacy monolith reference during staged transition.
+- The current continuity contract now lives in [lineage-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/lineage/docs/lineage-SPEC.md).
+- The current legitimacy contract now lives in [governance-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/governance-SPEC.md).
+- Historical split-era landing docs remain available in `lineage-SPEC-2.0.0v.md`, `governance-SPEC-2.0.0v.md`, and `world-facade-spec-v2.0.0.md`.
+- There is no separate current `@manifesto-ai/world` package surface; world-facade materials are historical split context only.
 
 ### ADR-015 Companion Notes
 
@@ -116,11 +117,17 @@ These ADRs affect multiple packages across the monorepo:
 
 - ADR-016 is implemented as the lineage identity rewrite companion to ADR-015: WorldId becomes parent-linked positional identity instead of content-only identity.
 - The landed contract introduces `tip` / `headAdvancedAt`, idempotent reuse for same-parent same-snapshot seals, and `SealAttempt` as the per-attempt chronology substrate.
-- The original service-first landing for this ADR is preserved in [lineage-SPEC-2.0.0v.md](https://github.com/manifesto-ai/core/blob/main/packages/lineage/docs/lineage-SPEC-2.0.0v.md).
-- The original legitimacy-side landing for this ADR is preserved in [governance-SPEC-2.0.0v.md](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/governance-SPEC-2.0.0v.md).
-- The historical pre-landing Host execution-side draft remains available in [host-SPEC-v4.0.0-draft.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC-v4.0.0-draft.md), but the current package contract is [host-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC.md) at v4.0.0.
-- The historical facade contract remains available in [world-facade-spec-v2.0.0.md](https://github.com/manifesto-ai/core/blob/main/packages/world/docs/world-facade-spec-v2.0.0.md).
-- The original version impact for ADR-016 landed as Lineage v2.0.0, Governance v2.0.0, Host v4.0.0, and World facade v2.0.0. The current decorator supersession is tracked separately by [ADR-017](./017-capability-decorator-pattern) and the v3.0.0 package version indexes.
+- The original service-first landing is preserved in [lineage-SPEC-2.0.0v.md](https://github.com/manifesto-ai/core/blob/main/packages/lineage/docs/lineage-SPEC-2.0.0v.md) and [governance-SPEC-2.0.0v.md](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/governance-SPEC-2.0.0v.md).
+- The current continuity and legitimacy contracts now live in [lineage-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/lineage/docs/lineage-SPEC.md) and [governance-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/governance-SPEC.md).
+- The historical pre-landing Host execution-side draft remains available in [host-SPEC-v4.0.0-draft.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC-v4.0.0-draft.md), while the current Host contract lives in [host-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC.md).
+- The historical world-facade contract remains available in [world-facade-spec-v2.0.0.md](https://github.com/manifesto-ai/core/blob/main/packages/world/docs/world-facade-spec-v2.0.0.md), but it is no longer a current package authority.
+- The current decorator-era routing is tracked by [ADR-017](./017-capability-decorator-pattern), the current package specs, and the current version indexes.
+
+### ADR-020 Companion Notes
+
+- ADR-020 is implemented in the current compiler, core, and SDK contracts.
+- The current behavior now lives in [SPEC-v1.0.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md), [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), and the maintained MEL docs.
+- This ADR remains the architectural rationale for `dispatchable when`; the owning package specs define the current runtime and compiler behavior.
 
 ### ADR-017 Version Notes
 

--- a/docs/internals/fdr/index.md
+++ b/docs/internals/fdr/index.md
@@ -23,7 +23,7 @@ FDR documents explain **why** design decisions were made. They complement SPECs 
 | Package | Latest FDR | Scope | Package Docs |
 |---------|------------|-------|--------------|
 | **App facade (retired)** | Removed (R2) | Legacy compatibility rationale | [Retired Page](/internals/retired/app) |
-| **@manifesto-ai/compiler** | v0.5.0-patch | MEL syntax, IR design | [FDR-v0.5.0-patch.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/FDR-v0.5.0-patch.md) |
+| **@manifesto-ai/compiler** | v0.5.0 | MEL syntax, IR design | [FDR-v0.5.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/FDR-v0.5.0.md) |
 | **@manifesto-ai/sdk** | v3.1.0 (draft) | Projected schema graph, full-transition dry-run simulation, and introspection rationale staged into the living SDK spec | [FDR-v3.1.0-draft.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/FDR-v3.1.0-draft.md) |
 
 > Core/Host rationale is primarily available in each package SPEC `Rationale` block. The former `@manifesto-ai/world` rationale is retained only as historical split context. SDK currently has a draft additive rationale track for projected introspection APIs; its accepted contract now also appears in the living SDK spec.

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -47,15 +47,15 @@ Records of significant architectural decisions:
 | [ADR-010](./adr/010-major-hard-cut) | Protocol-First SDK Reconstruction | Implemented |
 | [ADR-011](./adr/011-host-boundary-reset-and-executionkey-serialization) | Host Boundary Reset Completeness Policy | Implemented |
 | [ADR-012](./adr/012-remove-computed-prefix) | Remove `computed.` Prefix from Computed Snapshot Keys | Implemented |
-| [ADR-013a](./adr/013a-mel-statement-composition-flow-and-include) | MEL Statement Composition — `flow` and `include` | Proposed |
-| [ADR-013b](./adr/013b-entity-collection-primitives) | Entity Collection Primitives — `findById`, `existsById`, `updateById`, `removeById` | Proposed |
+| [ADR-013a](./adr/013a-mel-statement-composition-flow-and-include) | MEL Statement Composition — `flow` and `include` | Implemented |
+| [ADR-013b](./adr/013b-entity-collection-primitives) | Entity Collection Primitives — `findById`, `existsById`, `updateById`, `removeById` | Implemented |
 | [ADR-014](./adr/014-split-world-protocol) | Split World Protocol into Governance and Lineage Packages | Implemented |
 | [ADR-015](./adr/015-snapshot-ontological-purification) | Snapshot Ontological Purification — Remove Accumulated History from Point-in-Time State | Implemented |
 | [ADR-016](./adr/016-merkle-tree-lineage) | Merkle Tree Lineage — Positional World Identity via Parent-Linked Hashing | Implemented |
 | [ADR-017](./adr/017-capability-decorator-pattern) | Capability Decorator Pattern — Semantic Transformation of SDK Surface | Implemented |
 | [ADR-018](./adr/018-public-snapshot-boundary) | Public Snapshot Boundary — User-Facing Snapshot Projection and CanonicalSnapshot Separation | Implemented |
 | [ADR-019](./adr/019-post-activation-extension-kernel) | Post-Activation Extension Kernel — Safe Public Seam for Arbitrary-Snapshot Operations | Implemented |
-| [ADR-020](./adr/020-intent-level-dispatchability) | Intent-Level Dispatchability — `dispatchable when` Clause | Proposed |
+| [ADR-020](./adr/020-intent-level-dispatchability) | Intent-Level Dispatchability — `dispatchable when` Clause | Implemented |
 
 Status meanings (Proposed, Accepted, Implemented, Withdrawn, etc.) are defined in [ADR Status Definitions](./adr/#adr-status-definitions).
 

--- a/docs/internals/spec/current-contract.md
+++ b/docs/internals/spec/current-contract.md
@@ -1,7 +1,7 @@
 # Current Contract
 
 > **Status:** Living Document
-> **Last Updated:** 2026-04-13
+> **Last Updated:** 2026-04-14
 > **Purpose:** Single-source current contract for external consumers, canonical-doc exports, and current-surface onboarding
 
 This document is the current-only contract summary for the active Manifesto workspace.
@@ -124,6 +124,16 @@ Current expression support includes:
 - `every(arr, pred)`
 - `some(arr, pred)`
 
+Current bounded sugar support includes:
+
+- `absDiff(a, b)`
+- `clamp(x, lo, hi)`
+- `idiv(a, b)` with `number | null` result semantics
+- `streak(prev, condition)`
+- `match(key, [k, v], ..., default)` in parser-free function form
+- `argmax([label, eligible, score], ..., "first" | "last")`
+- `argmin([label, eligible, score], ..., "first" | "last")`
+
 Current schema-position support includes:
 
 - `Record<string, T>`
@@ -165,7 +175,7 @@ Do not use archived or superseded material to infer the current surface in these
 
 - pre-activation SDK or runtime-helper stories
 - `@manifesto-ai/world` as a current package
-- compiler `v0.7.0 + addendum` as the current MEL contract
+- an older compiler baseline plus addenda as the current MEL contract
 - nullable rejection or record rejection in current schema positions
 - "collection functions are not builtins" guidance
 

--- a/docs/mel/ERROR-GUIDE.md
+++ b/docs/mel/ERROR-GUIDE.md
@@ -545,7 +545,7 @@ state {
 ### Error: System value in state initializer
 
 ```mel
-// ❌ BROKEN (v0.3.0+)
+// ❌ BROKEN
 state {
   id: string = $system.uuid
   createdAt: number = $system.timestamp

--- a/docs/mel/LLM-CONTEXT.md
+++ b/docs/mel/LLM-CONTEXT.md
@@ -130,7 +130,7 @@ computed displayName = coalesce(user.name, "Anonymous")
 // Ternary
 computed label = gt(count, 0) ? "Positive" : "Zero or negative"
 
-// Aggregation (v0.3.2)
+// Aggregation
 computed sum = sum(prices)           // Array<number> → number
 computed min = min(values)           // Array<T> → T | null
 computed max = max(values)           // Array<T> → T | null
@@ -497,7 +497,7 @@ effect array.map({
 })
 ```
 
-### System Values (v0.3.0+)
+### System Values
 
 System values are IO and only allowed inside action bodies.
 

--- a/docs/mel/SYNTAX.md
+++ b/docs/mel/SYNTAX.md
@@ -44,7 +44,7 @@ domain Counter {
 
 State declares the domain's mutable fields with types and default values.
 
-### Named Types (v0.3.3)
+### Named Types
 
 Complex object types in state must be declared via `type`.
 
@@ -122,7 +122,7 @@ state {
   my$count: number = 0   // Error: $ prohibited anywhere
 }
 
-// ❌ COMPILE ERROR: System value in initializer (v0.3.0+)
+// ❌ COMPILE ERROR: System value in initializer
 state {
   id: string = $system.uuid          // Error: Must be deterministic
   createdAt: number = $system.timestamp // Error: Must be deterministic
@@ -191,7 +191,7 @@ effect array.map({
 })
 ```
 
-### Aggregation Functions (v0.3.2)
+### Aggregation Functions
 
 MEL supports primitive aggregation over arrays:
 
@@ -422,7 +422,7 @@ patch settings merge $input.partialSettings
 
 > **`patch merge` vs `merge()` expression:** `patch path merge expr` is a flow-level state operation that shallow-merges into state at `path`. `merge(a, b)` is a pure expression function that returns a new merged object without modifying state. See [Object Functions](#object-functions) below.
 
-### System Values (v0.3.0+)
+### System Values
 
 System values are IO and only allowed inside action bodies.
 

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -19,7 +19,7 @@ MEL source -> Compiler -> DomainSchema -> Core
 | Responsibility | Description |
 | --- | --- |
 | Parse MEL | Tokenize and parse MEL into an AST |
-| Validate | Scope and semantic checks aligned to MEL v0.3.3 |
+| Validate | Scope, typing, and semantic checks aligned to the current compiler contract |
 | Generate IR | Produce DomainSchema for Core |
 | Lower system values | Optional lowering of $system.* into explicit effects |
 
@@ -33,6 +33,14 @@ MEL source -> Compiler -> DomainSchema -> Core
 | Apply patches | Core |
 | Govern authority or seal history | `@manifesto-ai/governance` + `@manifesto-ai/lineage` |
 | Bind UI or caller integrations | SDK / application layer |
+
+Current MEL/compiler highlights:
+
+- `available when` remains the coarse action gate.
+- `dispatchable when` is the fine bound-intent legality gate.
+- Expression-level collection builtins include `filter`, `map`, `find`, `every`, and `some`.
+- Bounded parser-free sugar includes `absDiff`, `clamp`, `idiv`, `streak`, `match`, `argmax`, and `argmin`.
+- Current schema-position lowering supports `Record<string, T>` and `T | null`.
 
 ---
 
@@ -208,7 +216,7 @@ type CompileOptions = {
 | [MEL Syntax](../../docs/mel/SYNTAX.md) | Grammar and syntax |
 | [MEL Examples](../../docs/mel/EXAMPLES.md) | Example library |
 | [MEL Error Guide](../../docs/mel/ERROR-GUIDE.md) | Error codes and fixes |
-| [Compiler Spec](docs/SPEC-v0.7.0.md) | Full compiler and MEL spec |
+| [Compiler Spec](docs/SPEC-v1.0.0.md) | Current full compiler and MEL spec |
 | [Compiler FDR](docs/FDR-v0.5.0.md) | Design rationale |
 | [Compiler Compliance Suite](docs/compiler-SPEC-compilance-test-suite.md) | CCTS structure, rule modes, and execution guide |
 

--- a/packages/compiler/docs/SPEC-v1.0.0.md
+++ b/packages/compiler/docs/SPEC-v1.0.0.md
@@ -4,8 +4,8 @@
 > **Type:** Full
 > **Status:** Normative
 > **Date:** 2026-04-14
-> **Supersedes:** [SPEC-v0.7.0.md](SPEC-v0.7.0.md), [SPEC-v0.8.0.md](SPEC-v0.8.0.md), [SPEC-v0.9.0.md](SPEC-v0.9.0.md) as the current compiler contract
-> **Compatible with:** Core SPEC v4.2.0, SDK living spec v3.5.0
+> **Replaces:** Earlier compiler baselines and addenda as the current compiler contract
+> **Compatible with:** Core SPEC v4.2.0, current SDK activation-first contract
 
 ---
 
@@ -13,11 +13,11 @@
 
 This document is the **current full MEL compiler contract**.
 
-It rolls up the last active baseline plus addenda into one current surface:
+It consolidates the landed compiler surface into one current contract, including:
 
-- v0.7.0 full baseline
-- v0.8.0 `SchemaGraph` addendum
-- v0.9.0 `dispatchable when` addendum
+- the active full MEL/compiler baseline
+- `SchemaGraph` extraction
+- `dispatchable when`
 - current landed compiler/runtime alignment for `Record<string, T>` and `T | null` in schema positions
 - current landed support for pure collection builtins in expression contexts
 - current clarification that additive MEL surface forms must preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary

--- a/packages/compiler/docs/compiler-SPEC-compilance-test-suite.md
+++ b/packages/compiler/docs/compiler-SPEC-compilance-test-suite.md
@@ -1,6 +1,6 @@
 # Compiler SPEC Compilance Test Suite (CCTS)
 
-> **Purpose:** Define the compliance harness for `@manifesto-ai/compiler` against MEL Compiler SPEC v0.7.0.
+> **Purpose:** Define the compliance harness for `@manifesto-ai/compiler` against the current MEL compiler contract in SPEC-v1.0.0.
 > **Audience:** Compiler maintainers and contributors extending MEL semantics.
 > **Status:** Operational
 
@@ -47,7 +47,7 @@ packages/compiler/src/__tests__/compliance/
 
 The suite mirrors the Host HCTS shape, but adds explicit inventory and coverage layers:
 
-- spec inventory (`SPEC-v0.7.0.md` rule surface)
+- spec inventory (`SPEC-v1.0.0.md` rule surface)
 - shared rule registry
 - case/rule coverage map
 - test adapter wrapping exported APIs
@@ -143,7 +143,7 @@ Those are valid follow-up steps once the registry and suite skeleton are stable.
 
 As of the current Phase 4 baseline:
 
-- `blocking`: concrete v0.7.0 feature families already enforced in compiler + CCTS
+- `blocking`: concrete current-contract feature families already enforced in compiler + CCTS
 - `pending`: none
 - `informational`: `A16`, `COMPILER-MEL-2a`
 

--- a/packages/core/docs/core-SPEC.md
+++ b/packages/core/docs/core-SPEC.md
@@ -204,7 +204,7 @@ type DomainSchema = {
   /** Content hash for integrity verification */
   readonly hash: string;
 
-  /** Named type declarations (compiler v0.3.3) */
+  /** Named type declarations supplied by the current compiler contract */
   readonly types: Record<string, TypeSpec>;
 
   /** State structure definition */
@@ -236,7 +236,7 @@ type DomainSchema = {
   Any effective/runtime hash is an internal artifact and MUST NOT be exposed as part of DomainSchema.
 - `state`, `computed`, and `actions` MUST NOT be empty.
 
-### 4.3 Types (Compiler v0.3.3)
+### 4.3 Types
 
 `types` carries **named type declarations** produced by the compiler.
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -4,7 +4,7 @@
 
 `@manifesto-ai/sdk` is the default package for applications that start with `createManifesto()`.
 
-> **Current Contract Note:** The current SDK contract is the living v3.6.0 activation-first model documented in [docs/sdk-SPEC.md](docs/sdk-SPEC.md). It includes typed `createIntent()` object binding, intent explanation reads, `@manifesto-ai/sdk/extensions`, and `createSimulationSession(instance)`.
+> **Current Contract Note:** The current SDK contract is the activation-first model documented in [docs/sdk-SPEC.md](docs/sdk-SPEC.md). It includes typed `createIntent()` object binding, intent explanation reads, `@manifesto-ai/sdk/extensions`, and `createSimulationSession(instance)`.
 
 ## When to Use It
 

--- a/packages/sdk/docs/sdk-SPEC.md
+++ b/packages/sdk/docs/sdk-SPEC.md
@@ -3,18 +3,18 @@
 > **Status:** Normative (Living Document)
 > **Scope:** Manifesto SDK Layer - Public Developer API
 > **Compatible with:** Core SPEC v4.2.0, Host Contract v4.0.0, Compiler SPEC v1.0.0, Lineage SPEC v3.0.0, Governance SPEC v3.0.0
-> **Supersedes:** SDK SPEC v2.0.0
-> **Implements:** ADR-017 v3.1, ADR-019 v1.1, ADR-020 v1
+> **Replaces:** Earlier SDK spec baselines as the current SDK contract
+> **Implements:** ADR-017, ADR-019, ADR-020
 
 > **Historical Note:** Pre-ADR-017 SDK surfaces live in Git history. They are no longer kept as active package docs in the working tree.
 >
-> **Current v3.x Status:** The projected introspection additions, the intent-level dispatchability additions, refined single-parameter object binding in `createIntent()`, the `@manifesto-ai/sdk/extensions` Extension Kernel, the first-party `createSimulationSession()` helper on that seam, additive intent explanation reads via `explainIntentFor()`, `explainIntent()`, `why()`, and `whyNot()`, and the additive base write-report companion `dispatchAsyncWithReport()` are now part of the current living SDK contract. The compiler-side extraction contract now lives in [SPEC-v1.0.0](../../compiler/docs/SPEC-v1.0.0.md).
+> **Current Contract Status:** Projected introspection, intent-level dispatchability, refined single-parameter object binding in `createIntent()`, the `@manifesto-ai/sdk/extensions` Extension Kernel, the first-party `createSimulationSession()` helper on that seam, additive intent explanation reads via `explainIntentFor()`, `explainIntent()`, `why()`, and `whyNot()`, and the additive base write-report companion `dispatchAsyncWithReport()` are all part of the current SDK contract. The compiler-side extraction contract now lives in [SPEC-v1.0.0](../../compiler/docs/SPEC-v1.0.0.md).
 
 ## 1. Purpose
 
-This document defines the current SDK v3.x public contract.
+This document defines the current SDK public contract.
 
-The SDK still owns exactly one concept, `createManifesto()`, but that concept is no longer a ready-to-run runtime factory. In v3, `createManifesto()` returns a **composable manifesto**. Runtime verbs appear only after `activate()`.
+The SDK owns exactly one concept, `createManifesto()`, but that concept is no longer a ready-to-run runtime factory. In the current contract, `createManifesto()` returns a **composable manifesto**. Runtime verbs appear only after `activate()`.
 
 The SDK no longer presents top-level `@manifesto-ai/world` as part of its public story. Governed composition is expressed by decorating the composable manifesto with `withLineage()` and `withGovernance()` from their owning packages.
 


### PR DESCRIPTION
## Summary
- align current-facing docs and maintained hubs to the current SDK/compiler contract
- remove stale version-era framing from maintained current docs without rewriting historical archives
- make current authority routing explicit across API docs, ADR indexes, and FDR hubs

## What changed
- updated current-facing API and package docs for the activation-first SDK/runtime story
- refreshed `current-contract`, compiler/core/sdk maintained specs, and compiler compliance docs to point at the current contract surfaces
- marked `ADR-020` as implemented and updated active ADR/index routing away from old canonical references
- fixed maintained internal hubs so compiler rationale points at `FDR-v0.5.0.md` and current package docs are the clear source of truth

## Validation
- `git diff --check`
- `node scripts/export-canonical-docs.mjs`
- verified regenerated canonical bundles include the updated current-contract, API, and ADR routing content
