### PR TITLE
feat(compiler): add @meta structural annotation support

### DIFF
--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -23,6 +23,26 @@ const app = manifesto.activate();
 
 `createManifesto()` returns a composable object. Runtime verbs such as `dispatchAsync()` and `dispatchAsyncWithReport()`, plus reads such as `getSnapshot()`, exist only after `activate()`.
 
+Compiler tooling artifacts such as `DomainModule` are outside this seam. If you compile through `compileMelModule()`, pass `module.schema` to `createManifesto()`, not the whole module.
+
+## Tooling vs Runtime
+
+```typescript
+import { compileMelModule } from "@manifesto-ai/compiler";
+import { createManifesto } from "@manifesto-ai/sdk";
+
+const result = compileMelModule(melSource, { mode: "module" });
+const module = result.module!;
+
+const manifesto = createManifesto(module.schema, {});
+const annotations = module.annotations;
+```
+
+- `createManifesto()` accepts MEL source or `DomainSchema`.
+- `createManifesto()` does not accept `DomainModule`.
+- tooling may read `module.annotations` and `module.graph`, but runtime remains annotation-blind.
+- importing a `.mel` file through the default loader/bundler path still yields schema-only output, even when the MEL source uses `@meta`.
+
 ## Activation Boundary
 
 ```typescript

--- a/docs/api/compiler.md
+++ b/docs/api/compiler.md
@@ -1,40 +1,69 @@
 # @manifesto-ai/compiler
 
-> MEL compiler package (MEL text -> DomainSchema / patch IR / module code)
+> MEL compiler package (MEL text -> `DomainSchema` / tooling sidecars / patch IR / schema-only module code)
 
 ---
 
 ## Overview
 
-`@manifesto-ai/compiler` provides MEL compilation and lowering adapters.
+`@manifesto-ai/compiler` provides the MEL compilation seams used by runtime creation, tooling, and bundler integration.
 
-ADR-009 alignment points:
-- Conditional patch ops use `IRPatchPath`
-- Runtime evaluation resolves IR path segments to concrete `PatchPath`
-- Invalid segment resolution is skipped with warnings (TOTAL behavior)
+The current canonical compiler contract is [SPEC-v1.0.0](../../packages/compiler/docs/SPEC-v1.0.0.md).
 
-The current full compiler contract is [SPEC-v1.0.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md).
-
-Current compiler responsibilities also include:
+Current compiler responsibilities include:
+- schema-only compilation through `compileMelDomain()`
+- tooling-only module compilation through `compileMelModule()`
 - projected `SchemaGraph` extraction
+- structural annotations via `@meta` as an out-of-schema `AnnotationIndex` sidecar
 - intent-level dispatchability via `dispatchable when`
-- rich schema-position lowering through `state.fieldTypes`, `action.inputType`, and `action.params`
-- pure collection builtins such as `filter`, `map`, `find`, `every`, and `some` in expression contexts
-- bounded lowering-only MEL sugar such as `absDiff`, `clamp`, `idiv`, `streak`, `match`, `argmax`, and `argmin`
-
----
+- MEL patch lowering through `compileMelPatch()`
 
 ## Main Entry Points
 
-### compileMelDomain()
+### `compileMelDomain()`
+
+Use `compileMelDomain()` when you need the semantic runtime artifact only.
 
 ```typescript
 import { compileMelDomain } from "@manifesto-ai/compiler";
 
 const result = compileMelDomain(melSource, { mode: "domain" });
+
+if (result.schema) {
+  // Runtime-facing seam
+  const schema = result.schema;
+}
 ```
 
-### compileMelPatch()
+`compileMelDomain()` returns `DomainSchema` only. Structural annotations never appear inside that schema.
+
+### `compileMelModule()`
+
+Use `compileMelModule()` when tooling needs compiler-owned helper artifacts in addition to the schema.
+
+```typescript
+import { compileMelModule } from "@manifesto-ai/compiler";
+
+const result = compileMelModule(melSource, { mode: "module" });
+
+if (result.module) {
+  const { schema, graph, annotations } = result.module;
+}
+```
+
+`compileMelModule()` returns a tooling-only `DomainModule`:
+
+```typescript
+type DomainModule = {
+  readonly schema: DomainSchema;
+  readonly graph: SchemaGraph;
+  readonly annotations: AnnotationIndex;
+};
+```
+
+`annotations` is the compiler-owned sidecar for `@meta`. It remains outside both `DomainSchema` and `SchemaGraph`.
+
+### `compileMelPatch()`
 
 ```typescript
 import { compileMelPatch } from "@manifesto-ai/compiler";
@@ -47,7 +76,42 @@ const result = compileMelPatch(patchText, {
 
 `compileMelPatch()` returns unresolved conditional ops. Runtime MUST evaluate them before applying to Core.
 
----
+## Tooling vs Runtime
+
+- Runtime seams consume `DomainSchema`, not `DomainModule`.
+- Tooling can use `compileMelModule()` to read `graph` and `annotations`.
+- If you compile through `compileMelModule()`, pass `module.schema` to runtime creation and keep `module.annotations` external.
+- `.mel` loader and bundler integrations still default-export compiled `DomainSchema`, even when the source uses `@meta`.
+
+```typescript
+import { compileMelModule } from "@manifesto-ai/compiler";
+import { createManifesto } from "@manifesto-ai/sdk";
+
+const result = compileMelModule(melSource, { mode: "module" });
+const module = result.module!;
+
+const app = createManifesto(module.schema, {}).activate();
+const annotations = module.annotations;
+```
+
+## Annotation Sidecar Types
+
+```typescript
+type Annotation = {
+  readonly tag: string;
+  readonly payload?: JsonLiteral;
+};
+
+type AnnotationIndex = {
+  readonly schemaHash: string;
+  readonly entries: Record<LocalTargetKey, readonly Annotation[]>;
+};
+```
+
+- `schemaHash` matches the emitted `DomainSchema.hash`.
+- `entries` includes annotated targets only.
+- stacked annotations preserve source order.
+- repeated tags are preserved and not deduplicated.
 
 ## Patch IR Types
 
@@ -66,8 +130,6 @@ type ConditionalPatchOp = {
 };
 ```
 
----
-
 ## Evaluation Contract
 
 ```typescript
@@ -81,14 +143,13 @@ function evaluateConditionalPatchOps(
 - `expr` segment evaluates to:
   - string -> `{ kind: "prop", name }`
   - non-negative integer -> `{ kind: "index", index }`
-- Any other value => skip op + emit warning (never throw due to runtime data).
-
----
+- Any other value => skip op + emit warning.
 
 ## Related Packages
 
 | Package | Relationship |
 |---------|--------------|
 | [@manifesto-ai/core](./core) | Executes compiled `DomainSchema` semantics |
-| [@manifesto-ai/sdk](./sdk) | Uses compiler results at runtime creation |
+| [@manifesto-ai/sdk](./sdk) | Accepts `DomainSchema` or MEL source at runtime creation, not `DomainModule` |
+| [Application](./application) | Runtime-facing `createManifesto()` entrypoint |
 | [MEL Docs](/mel/) | Language reference and examples |

--- a/docs/api/compiler.md
+++ b/docs/api/compiler.md
@@ -8,7 +8,7 @@
 
 `@manifesto-ai/compiler` provides the MEL compilation seams used by runtime creation, tooling, and bundler integration.
 
-The current canonical compiler contract is [SPEC-v1.0.0](../../packages/compiler/docs/SPEC-v1.0.0.md).
+The current canonical compiler contract lives in `packages/compiler/docs/SPEC-v1.0.0.md`.
 
 Current compiler responsibilities include:
 - schema-only compilation through `compileMelDomain()`

--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -53,10 +53,12 @@ _Source: `packages/compiler/src/index.ts`_
 
 - `analyzeScope`
 - `applyPatchToWorkingSnapshot`
+- `buildAnnotationIndex`
 - `check`
 - `classifyCondition`
 - `compile`
 - `compileMelDomain`
+- `compileMelModule`
 - `compileMelPatch`
 - `createError`
 - `createEvaluationContext`
@@ -147,6 +149,10 @@ _Source: `packages/compiler/src/index.ts`_
 - `AddFieldOp`
 - `AddTypeOp`
 - `AllowedSysPrefix`
+- `Annotation`
+- `AnnotationExtractionResult`
+- `AnnotationIndex`
+- `AnnotationNode`
 - `ArrayLiteralExprNode`
 - `ArrayTypeNode`
 - `ASTNode`
@@ -155,6 +161,8 @@ _Source: `packages/compiler/src/index.ts`_
 - `CanonicalDomainSchema`
 - `CompileMelDomainOptions`
 - `CompileMelDomainResult`
+- `CompileMelModuleOptions`
+- `CompileMelModuleResult`
 - `CompileMelPatchOptions`
 - `CompileMelPatchResult`
 - `CompileOptions`
@@ -205,9 +213,11 @@ _Source: `packages/compiler/src/index.ts`_
 - `IRPatchPath`
 - `IRPathSegment`
 - `IterationVarExprNode`
+- `JsonLiteral`
 - `LexResult`
 - `LiteralExprNode`
 - `LiteralTypeNode`
+- `LocalTargetKey`
 - `LoweredPatchOp`
 - `LoweredTypeExpr`
 - `LoweredTypeField`

--- a/docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md
+++ b/docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md
@@ -1,0 +1,467 @@
+# ADR-021: MEL Structural Annotation System — `@meta` Sidecar
+
+> **Status:** Accepted
+> **Date:** 2026-04-15
+> **Deciders:** 정성우 (Architect), Manifesto Architecture Team
+> **Scope:** Compiler (MEL language surface + output contract)
+> **Related ADRs:** ADR-001 (Layer Separation), ADR-006 (PUB/CHAN/CAN — schema hash identity), ADR-018 (Public Snapshot Boundary), ADR-020 (Intent-Level Dispatchability)
+> **Related SPECs:** Compiler SPEC v1.0.0, Core SPEC v4.2.0, SDK SPEC v3.x
+> **Breaking:** No — additive MEL syntax; Core/Host/SDK runtime layers unchanged
+
+> **Current Contract Status:** Accepted. The current compiler spec and maintained MEL docs now define the v1 annotation-sidecar contract. `action_param` remains deferred pending a separate grammar decision.
+
+---
+
+## 1. Context
+
+### 1.1 The Problem
+
+MEL describes pure domain semantics: state, computed, actions, guards. This is sufficient for Core to compute and Host to execute. However, external consumers — UI renderers, test harnesses, documentation generators, analytics SDKs, accessibility tools — need supplementary metadata that MEL's semantic layer does not and should not express.
+
+Examples of consumer needs:
+
+- A UI renderer needs to know "this action should surface as a drag-drop interaction"
+- A test runner needs to know "skip this action in smoke tests"
+- A documentation generator needs to know "this computed is the primary metric"
+
+Currently there is no standard mechanism for attaching this metadata. Consumers either hardcode knowledge about specific MEL structures or rely on ad-hoc conventions that are invisible to the compiler.
+
+### 1.2 The Constraint
+
+Manifesto's architecture enforces strict boundaries:
+
+- `DomainSchema` hash is semantic identity (ADR-006 CAN-3, CAN-4)
+- Core computes purely over `DomainSchema` — no IO, no UI knowledge, no external concerns
+- `compute()`, `available`, `dispatchable`, and schema hash must be impervious to non-semantic changes
+- The harness engineering principle: safety through structural impossibility, not behavioral prohibition
+
+Any metadata system must respect these boundaries absolutely.
+
+### 1.3 What This Is
+
+This is not a UI annotation system. It is a **generic, namespace-blind structural annotation infrastructure** for MEL. `ui:*` is one consumer convention that may be built on top of it, alongside `test:*`, `analytics:*`, `doc:*`, or any future namespace. The annotation system itself is agnostic to all of them.
+
+---
+
+## 2. Decision
+
+### 2.1 MEL Syntax
+
+Annotations use the `@meta` keyword with a string-literal tag and optional literal payload:
+
+```mel
+@meta("namespace:kind")
+@meta("namespace:kind", { key: "value", size: 42, enabled: true })
+```
+
+Annotations attach to the MEL construct that immediately follows them:
+
+```mel
+@meta("ui:drag-drop")
+@meta("ui:context-menu")
+action moveTask(taskId: string, newStatus: Status)
+  available when gt(taskCount, 0) {
+  ...
+}
+
+@meta("ui:current-tasks")
+computed currentVisibleTasks = cond(...)
+
+@meta("test:skip")
+action dangerousReset() { ... }
+```
+
+The tag is an opaque string to the compiler. The `namespace:kind` convention is a consumer-level pattern, not a compiler-enforced structure. The compiler does not parse, validate, or interpret the tag contents.
+
+### 2.2 Attachable Targets
+
+Annotations may attach to:
+
+| MEL Construct | Example |
+|---------------|---------|
+| `domain` | `@meta("doc:description", { summary: "Task management" })` |
+| `type` | `@meta("doc:entity")` on a named type |
+| type field | `@meta("ui:hidden")` on a field within a type |
+| `state` field | `@meta("analytics:track")` on a state field |
+| `computed` | `@meta("ui:primary-metric")` on a computed |
+| `action` | `@meta("ui:button")` on an action |
+| action parameter | `@meta("ui:date-picker")` on an action param |
+
+The compiler validates that `@meta` appears only in these positions. Floating annotations (not attached to a construct) are a syntax error.
+
+### 2.3 Compiler Output — Out-of-Schema Sidecar
+
+The compiler emits annotations as a **separate sidecar**, never inside `DomainSchema`:
+
+```typescript
+type DomainModule = {
+  schema: DomainSchema;          // Core/SDK — zero annotation traces
+  graph: SchemaGraph;            // Studio — zero annotation traces
+  annotations: AnnotationIndex;  // External consumers only
+};
+```
+
+```typescript
+type AnnotationIndex = {
+  schemaHash: string;
+  entries: Record<LocalTargetKey, Annotation[]>;
+};
+
+// LocalTargetKey = "{kind}:{name}"
+// kind ∈ { "domain", "type", "type_field", "state_field",
+//          "computed", "action", "action_param" }
+type LocalTargetKey = string;
+
+type Annotation = {
+  tag: string;                   // opaque — e.g. "ui:button", "test:skip"
+  payload?: JsonLiteral;         // optional, JSON-like literal only
+};
+
+type JsonLiteral =
+  | string | number | boolean | null
+  | JsonLiteral[]
+  | { [key: string]: JsonLiteral };
+```
+
+### 2.4 Local Target Key Grammar
+
+Target keys follow this grammar:
+
+```
+LocalTargetKey ::= Kind ":" Name
+                 | Kind ":" ParentName "." ChildName
+
+Kind ::= "domain" | "type" | "type_field" | "state_field"
+       | "computed" | "action" | "action_param"
+```
+
+Examples:
+
+```
+domain:TaskBoard
+type:Task
+type_field:Task.title
+type_field:Task.status
+state_field:tasks
+state_field:filter
+computed:currentVisibleTasks
+action:createTask
+action_param:createTask.title
+```
+
+`Kind` is a closed set matching MEL's structural constructs. `Name` mirrors `DomainSchema` key structure. Dotted names are used only for child constructs (type fields, action parameters) — nesting beyond one level is not permitted in v1.
+
+The compiler validates that every emitted `LocalTargetKey` corresponds to an existing construct in the emitted `DomainSchema`. A dangling target key (referencing a renamed or removed construct) is a compile error.
+
+### 2.5 Payload Constraints
+
+**v1 payload is JSON-like literal only.**
+
+Permitted: strings, numbers, booleans, null, arrays of literals, objects of literals. Maximum nesting depth: 2 levels.
+
+```mel
+// Permitted
+@meta("ui:button", { variant: "primary", size: "lg" })
+@meta("ui:column", { order: 3 })
+
+// Forbidden — MEL expression
+@meta("ui:button", { disabled: eq(len(items), 0) })
+
+// Forbidden — MEL path reference
+@meta("ui:button", { labelFrom: computed.taskCount })
+
+// Forbidden — depth > 2
+@meta("ui:card", { config: { pricing: { free: "$0" } } })
+```
+
+**Permanent prohibition:** MEL expressions, runtime predicates, guard references, and any construct requiring semantic evaluation.
+
+**v1 prohibition, future extension reserved:** Structured target references (payload values that point to other MEL constructs by `LocalTargetKey`). If consumer evidence demonstrates a need, this may be opened in a future ADR without violating the permanent prohibitions above.
+
+---
+
+## 3. Normative Rules
+
+| ID | Rule | Scope |
+|----|------|-------|
+| META-1 | **Namespace-blind compiler.** The compiler does not parse, validate, or interpret annotation tag contents. All tags are opaque strings. | Permanent |
+| META-2 | **Out-of-schema sidecar.** Annotations exist only in `AnnotationIndex`, never in `DomainSchema` or `SchemaGraph`. | Permanent |
+| META-3 | **Zero semantic influence.** Annotation presence or absence does not affect `DomainSchema`, schema hash, `SchemaGraph`, `compute()`, `available`, `dispatchable`, or any runtime behavior. | Permanent |
+| META-4 | **Tooling-only artifact.** `DomainModule` is a tooling artifact. Runtime entry points (`createManifesto()`, Core, SDK) accept `DomainSchema` only. `DomainModule` must never become a runtime input. | Permanent |
+| META-5 | **Schema-structural target.** `LocalTargetKey` uses `{kind}:{name}` format. `schemaHash` scopes the entire `AnnotationIndex`. Compiler validates target existence. | v1 (opaque stable id reserved for future evaluation) |
+| META-6 | **Literal-only payload.** Payload is JSON-like literal only. MEL expressions and semantic references are permanently forbidden. Structured target references are reserved for future extension. | v1 payload constraint; permanent expression prohibition |
+| META-7 | **Consumer-owned semantic validation.** Namespace/kind/payload semantic correctness is the responsibility of consumers, LSP plugins, or external validators. | Permanent |
+
+---
+
+## 4. Invariants (CI-Enforced)
+
+These invariants must be tested in CI. Failure of any invariant is a release blocker.
+
+| ID | Invariant |
+|----|-----------|
+| INV-META-1 | `DomainSchema` emitted with annotations present is byte-identical to `DomainSchema` emitted after stripping all `@meta` from MEL source. |
+| INV-META-2 | `SchemaGraph` emitted with annotations present is identical to `SchemaGraph` emitted after stripping all `@meta`. |
+| INV-META-3 | For any snapshot and intent, `compute()` results are identical regardless of annotation presence. |
+| INV-META-4 | For any snapshot, `getAvailableActions()` returns identical results regardless of annotation presence. |
+| INV-META-5 | For any snapshot and intent, `isIntentDispatchable()` returns identical results regardless of annotation presence. |
+| INV-META-6 | `DomainModule` is not accepted by `createManifesto()` or any runtime entry point. Only `DomainSchema` is accepted. |
+
+---
+
+## 5. Consumer Binding Model
+
+Annotations serve as **binding points** — when a consumer sees `@meta("ui:button")` on an action, it can look up that action's full semantic context directly from `DomainSchema`:
+
+- `action.available` — a legality signal that consumers may use for visibility/reachability decisions
+- `action.dispatchable` — a legality signal that consumers may use for interactability decisions
+- `action.input` / `action.inputType` — parameter structure for form generation
+- `computed` type information — data shape for rendering strategy
+
+**Critical distinction:** `available` and `dispatchable` are **legality signals**, not UI policies. Whether `available = false` means "hide the button" or "show it grayed out" is a consumer rendering decision, not a MEL-level truth. The current contract defines availability as coarse action-family legality and dispatchability as fine intent-level legality (ADR-020). Consumers interpret these signals according to their own policies.
+
+**Loading state:** How a consumer determines whether an action is currently executing depends on the consumer's runtime surface. The generic annotation system does not prescribe or assume access to any specific canonical substrate field (e.g., `system.currentAction`). Consumers using projected `getSnapshot()` and consumers with canonical access may use different strategies. This is consumer implementation territory.
+
+This binding model means annotations do not need to carry cross-references like `disabledFrom`, `labelFrom`, or `loadingFrom`. The annotation declares the binding point; the `DomainSchema` already holds the semantic facts at that point.
+
+---
+
+## 6. Non-Goals
+
+This ADR does **not:**
+
+- Define any namespace vocabulary (`ui:*`, `test:*`, etc.). These are consumer conventions.
+- Prescribe UI rendering behavior or policy.
+- Change Core, Host, SDK, Lineage, or Governance contracts.
+- Change `DomainSchema` structure or schema hash computation.
+- Change `SchemaGraph` structure or content.
+- Introduce a Consumer Projection Spec or assembly layer. Consumer assembly of multiple semantic constructs into composite widgets is consumer implementation responsibility. This ADR does not prohibit future consumer-side assembly contracts but does not include them.
+- Introduce namespace registry or schema validation infrastructure (future LSP/plugin scope).
+
+---
+
+## 7. Consequences
+
+### 7.1 Positive
+
+1. MEL gains a standard mechanism for external metadata without polluting semantic identity.
+2. Erasability is structurally guaranteed — not a policy, but an architectural impossibility of contamination.
+3. Any tooling ecosystem can build conventions on top of the same infrastructure.
+4. Computed chains + `available when` + `dispatchable when` remain the sole source of semantic facts. Annotations cannot create shadow semantics.
+5. The `DomainModule` boundary prevents annotation from becoming a runtime dependency path.
+
+### 7.2 Trade-offs
+
+1. Consumer assembly (composing multiple semantic constructs into one widget) has no compiler-enforced contract. This is intentional — consumers own their interpretation — but means assembly errors are caught at consumer level, not compile time.
+2. `LocalTargetKey` is name-based; renames require annotation updates. LSP rename integration mitigates this but does not eliminate it for external artifacts.
+3. Namespace-blind compiler means annotation tag typos pass silently. Consumer-side or LSP-plugin validation is required for strictness.
+
+### 7.3 Deferred Decisions
+
+| Item | Precondition | Timing |
+|------|-------------|--------|
+| Structured target references in payload | Consumer evidence of need | Future ADR |
+| Namespace schema registry | Multiple consumers with validated vocabularies | Future LSP/plugin work |
+| Opaque stable target id | External annotation bundles requiring rename resilience | Future ADR if evidence warrants |
+| Consumer Projection Spec | Assembly errors demonstrably unacceptable at consumer level | Future ADR if evidence warrants |
+| Nested dotted target keys beyond one level | Deeply nested type structures in practice | Future extension |
+
+---
+
+## 8. Worked Example
+
+```mel
+domain TaskBoard {
+  type Task = {
+    id: string,
+    title: string,
+    status: "todo" | "doing" | "done",
+    deletedAt: number | null
+  }
+
+  state {
+    tasks: Task[] = []
+    viewMode: "board" | "list" | "calendar" = "board"
+    selectedTaskId: string | null = null
+    clock: ClockStamp | null = null
+  }
+
+  computed activeTasks = filter(tasks, isNull($item.deletedAt))
+  computed deletedTasks = filter(tasks, isNotNull($item.deletedAt))
+  computed deletedCount = len(deletedTasks)
+  computed todoTasks = filter(activeTasks, eq($item.status, "todo"))
+  computed doneTasks = filter(activeTasks, eq($item.status, "done"))
+  computed overdueTasks = cond(
+    isNull(clock), [],
+    filter(activeTasks, lt($item.dueDateTimestamp, clock.todayStartTs))
+  )
+
+  @meta("ui:current-tasks")
+  computed currentVisibleTasks = cond(
+    eq(viewMode, "board"), activeTasks,
+    eq(viewMode, "list"), activeTasks,
+    []
+  )
+
+  @meta("ui:selected-task")
+  computed selectedTask = findById(tasks, selectedTaskId)
+
+  @meta("ui:button")
+  action createTask(task: Task, stamp: ClockStamp)
+    available when true {
+    onceIntent {
+      patch tasks = append(tasks, task)
+      patch clock = stamp
+    }
+  }
+
+  @meta("ui:drag-drop")
+  @meta("ui:context-menu")
+  action moveTask(taskId: string, newStatus: "todo" | "doing" | "done")
+    available when gt(len(activeTasks), 0) {
+    when isNull(findById(tasks, taskId)) {
+      fail "NOT_FOUND"
+    }
+    onceIntent when isNotNull(findById(tasks, taskId)) {
+      patch tasks = updateById(tasks, taskId, { status: newStatus })
+    }
+  }
+
+  @meta("ui:confirm", { variant: "destructive" })
+  action deleteTask(taskId: string, stamp: ClockStamp)
+    available when gt(len(activeTasks), 0) {
+    when isNull(findById(tasks, taskId)) {
+      fail "NOT_FOUND"
+    }
+    onceIntent when isNotNull(findById(tasks, taskId)) {
+      patch tasks = updateById(tasks, taskId, { deletedAt: stamp.now })
+      patch clock = stamp
+    }
+  }
+
+  @meta("ui:button")
+  action emptyTrash(stamp: ClockStamp)
+    available when gt(deletedCount, 0) {
+    onceIntent {
+      patch tasks = filter(tasks, isNull($item.deletedAt))
+      patch clock = stamp
+    }
+  }
+
+  @meta("ui:button", { role: "view-change" })
+  action changeView(mode: "board" | "list" | "calendar", stamp: ClockStamp) {
+    onceIntent {
+      patch viewMode = mode
+      patch clock = stamp
+    }
+  }
+}
+```
+
+**What a UI consumer sees:**
+
+1. `@meta("ui:button")` on `emptyTrash` → render a button. Check `action.available` (`gt(deletedCount, 0)`) as legality signal. Action has `available when`, so consumer knows when to disable/hide based on its own policy.
+2. `@meta("ui:drag-drop")` + `@meta("ui:context-menu")` on `moveTask` → two interaction paths for the same action. Both use the same `action.available` and `action.input`.
+3. `@meta("ui:current-tasks")` on `currentVisibleTasks` → this computed is the main data source. Consumer reads its type (`Task[]`) from `DomainSchema` and renders accordingly.
+4. `@meta("ui:confirm", { variant: "destructive" })` on `deleteTask` → render with confirmation dialog, destructive styling. The semantic guard (`available when`) is still the source of truth for when the action is reachable.
+5. Actions and computed without `@meta` → consumer decides whether to render based on its own defaults and conventions.
+
+**What the compiler emits as `AnnotationIndex`:**
+
+```json
+{
+  "schemaHash": "a7f3c2",
+  "entries": {
+    "computed:currentVisibleTasks": [
+      { "tag": "ui:current-tasks" }
+    ],
+    "computed:selectedTask": [
+      { "tag": "ui:selected-task" }
+    ],
+    "action:createTask": [
+      { "tag": "ui:button" }
+    ],
+    "action:moveTask": [
+      { "tag": "ui:drag-drop" },
+      { "tag": "ui:context-menu" }
+    ],
+    "action:deleteTask": [
+      { "tag": "ui:confirm", "payload": { "variant": "destructive" } }
+    ],
+    "action:emptyTrash": [
+      { "tag": "ui:button" }
+    ],
+    "action:changeView": [
+      { "tag": "ui:button", "payload": { "role": "view-change" } }
+    ]
+  }
+}
+```
+
+`DomainSchema` and `SchemaGraph` contain zero traces of these annotations.
+
+---
+
+## 9. Implementation Scope
+
+### 9.1 Compiler API Surface
+
+`DomainModule` exposure MUST be additive to the existing compiler API. `compile()` / `compileMelDomain()` continue to return `DomainSchema` as before. A new entry point (e.g., `compileMelModule()`) or an additive field on the existing result provides access to `AnnotationIndex`. Existing consumers that only read `schema` are unaffected.
+
+### 9.2 Compiler Changes
+
+| Component | Change |
+|-----------|--------|
+| Parser | Recognize `@meta(...)` preceding attachable constructs |
+| Analyzer | Validate attachment position, payload literal-only, depth ≤ 2 |
+| Emitter | Emit `AnnotationIndex` as sidecar in `DomainModule` |
+| Target validation | Verify every `LocalTargetKey` maps to an existing `DomainSchema` entry |
+
+### 9.3 Pre-Implementation Grammar Decision
+
+`action_param` is listed as an attachable target (§2.2), but inline parameter annotation grammar is not yet finalized. Before implementation begins, the following must be decided:
+
+- Whether parameter annotations use inline syntax (e.g., `action create(@meta("ui:date-picker") dueDate: ClockStamp)`)
+- Or whether `action_param` attachment is deferred to a future version
+
+This is a grammar decision, not an architectural one. The sidecar model supports `action_param` targets regardless of syntax choice.
+
+### 9.4 No Changes Required
+
+| Component | Reason |
+|-----------|--------|
+| Core | Does not receive `AnnotationIndex` |
+| Host | Does not receive `AnnotationIndex` |
+| SDK | Runtime entry accepts `DomainSchema` only |
+| Lineage | Schema hash computation unchanged |
+| Governance | Proposal/approval unchanged |
+
+### 9.5 Downstream Enablement (Not This ADR)
+
+| Consumer | What they build on top |
+|----------|----------------------|
+| `json-render` | `ui:*` vocabulary and rendering conventions |
+| `mel-lsp` | Namespace-specific completion, hover, validation plugins |
+| `studio-core` | Annotation-aware domain visualization |
+| Test harnesses | `test:*` vocabulary for selective execution |
+
+---
+
+## 10. Relationship to Existing Concepts
+
+### 10.1 Effect vs Annotation
+
+| | Effect | Annotation |
+|---|---|---|
+| Core awareness | Yes — semantic loop participant | No — structurally invisible to Core |
+| Runtime impact | Yes — generates requirements, Host executes | Zero |
+| Erasability | Not erasable — alters state transitions | Fully erasable — zero semantic impact |
+| Analogy | Opaque declaration within the world | Structured preserved comment about the world |
+
+### 10.2 `available when` / `dispatchable when` vs Annotation
+
+`available when` and `dispatchable when` are semantic legality gates — they determine what is possible in the world. Annotations are consumer hints — they suggest how to surface what is possible. The two layers must never be conflated. Annotations cannot create, modify, or override legality.
+
+---
+
+*End of ADR-021 v1*

--- a/docs/internals/adr/index.md
+++ b/docs/internals/adr/index.md
@@ -51,6 +51,7 @@ These ADRs affect multiple packages across the monorepo:
 | [ADR-018](./018-public-snapshot-boundary) | Public Snapshot Boundary — User-Facing Snapshot Projection and CanonicalSnapshot Separation | Implemented | 2026-04-03 | SDK, Core (docs), Docs, Lineage, Governance |
 | [ADR-019](./019-post-activation-extension-kernel) | Post-Activation Extension Kernel — Safe Public Seam for Arbitrary-Snapshot Operations | Implemented | 2026-04-07 | SDK |
 | [ADR-020](./020-intent-level-dispatchability) | Intent-Level Dispatchability — `dispatchable when` Clause | Implemented | 2026-04-07 | Compiler, Core, SDK, Studio/Introspection, Docs |
+| [ADR-021](./021-mel-structural-annotation-system-meta-sidecar) | MEL Structural Annotation System — `@meta` Sidecar | Accepted | 2026-04-15 | Compiler, Tooling, Docs |
 
 ### ADR-006 Companion Evidence (Non-Normative)
 
@@ -128,6 +129,12 @@ These ADRs affect multiple packages across the monorepo:
 - ADR-020 is implemented in the current compiler, core, and SDK contracts.
 - The current behavior now lives in [SPEC-v1.0.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md), [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), and the maintained MEL docs.
 - This ADR remains the architectural rationale for `dispatchable when`; the owning package specs define the current runtime and compiler behavior.
+
+### ADR-021 Companion Notes
+
+- ADR-021 is accepted and reflected in the current compiler contract and maintained MEL docs for the current v1 surface.
+- The current landed/documented subset excludes `action_param`; that grammar decision remains deferred.
+- Core, Host, and SDK runtime entrypoints remain annotation-blind.
 
 ### ADR-017 Version Notes
 

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -162,7 +162,12 @@
 
 ### DomainModule
 
-**Definition:** The output of MEL compilation. At minimum it carries compiled `DomainSchema`; some compiler surfaces may also attach helper artifacts or generated facades around that schema.
+**Definition:** A compiler tooling artifact returned by additive seams such as `compileMelModule()`. It carries the compiled `DomainSchema` plus compiler-owned helper artifacts such as `SchemaGraph` and `AnnotationIndex`.
+
+**Key properties:**
+- Contains `schema`, `graph`, and `annotations`
+- Exists for tooling, inspection, and external consumers
+- Is not accepted by runtime seams such as `createManifesto()`; runtime consumes `DomainSchema` only
 
 **See also:** [Compiler](#compiler), [DomainSchema](#domainschema)
 

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -56,6 +56,7 @@ Records of significant architectural decisions:
 | [ADR-018](./adr/018-public-snapshot-boundary) | Public Snapshot Boundary — User-Facing Snapshot Projection and CanonicalSnapshot Separation | Implemented |
 | [ADR-019](./adr/019-post-activation-extension-kernel) | Post-Activation Extension Kernel — Safe Public Seam for Arbitrary-Snapshot Operations | Implemented |
 | [ADR-020](./adr/020-intent-level-dispatchability) | Intent-Level Dispatchability — `dispatchable when` Clause | Implemented |
+| [ADR-021](./adr/021-mel-structural-annotation-system-meta-sidecar) | MEL Structural Annotation System — `@meta` Sidecar | Accepted |
 
 Status meanings (Proposed, Accepted, Implemented, Withdrawn, etc.) are defined in [ADR Status Definitions](./adr/#adr-status-definitions).
 

--- a/docs/mel/ERROR-GUIDE.md
+++ b/docs/mel/ERROR-GUIDE.md
@@ -14,7 +14,8 @@
 4. [Guard Errors](#guard-errors)
 5. [Type Errors](#type-errors)
 6. [Identifier Errors](#identifier-errors)
-7. [Semantic Errors](#semantic-errors)
+7. [Annotation Errors](#annotation-errors)
+8. [Semantic Errors](#semantic-errors)
 
 ---
 
@@ -568,6 +569,113 @@ action initialize() {
     patch init = $meta.intentId
     patch id = $system.uuid
     patch createdAt = $system.timestamp
+  }
+}
+```
+
+---
+
+## Annotation Errors
+
+### Error: @meta inside an action body (`E053`)
+
+```mel
+// ❌ BROKEN
+action archive(id: string) {
+  @meta("ui:button")
+  when true {
+    patch lastArchivedId = id
+  }
+}
+```
+
+**Error:** `E053 SyntaxError: @meta can attach only to domain, type, type field, state field, computed, or action declarations.`
+
+**Rule violated:** `@meta` attaches to the immediately following declaration or field, not to control-flow statements inside an action body.
+
+```mel
+// ✅ FIXED: Move @meta to the action declaration
+@meta("ui:button")
+action archive(id: string) {
+  when true {
+    patch lastArchivedId = id
+  }
+}
+```
+
+---
+
+### Error: Non-literal annotation payload (`E055`)
+
+```mel
+// ❌ BROKEN
+@meta("ui:button", { disabled: eq(len(items), 0) })
+action archive() {
+  when true {
+    patch lastArchivedId = "done"
+  }
+}
+```
+
+**Error:** `E055 SemanticError: Annotation payloads must be JSON-like literals. MEL expressions are not allowed in @meta payloads.`
+
+**Rule violated:** `@meta` payloads are tooling data, not semantic expressions.
+
+```mel
+// ✅ FIXED: Use literal metadata only
+@meta("ui:button", { variant: "secondary", disabledByDefault: false })
+action archive() {
+  when true {
+    patch lastArchivedId = "done"
+  }
+}
+```
+
+---
+
+### Error: Annotation payload nesting too deep (`E056`)
+
+```mel
+// ❌ BROKEN
+@meta("ui:card", { config: { pricing: { free: "$0" } } })
+computed cardVariant = "free"
+```
+
+**Error:** `E056 SemanticError: Annotation payload nesting exceeds the current MEL limit of 2 levels.`
+
+**Rule violated:** Current `@meta` payloads may use JSON-like literals only, with nesting depth capped at 2.
+
+```mel
+// ✅ FIXED: Flatten the payload
+@meta("ui:card", { tier: "free", priceLabel: "$0" })
+computed cardVariant = "free"
+```
+
+---
+
+### Error: Annotation on action parameter (`E054`)
+
+```mel
+// ❌ BROKEN
+action create(
+  @meta("ui:date-picker") dueDate: string
+) {
+  when true {
+    patch nextDueDate = dueDate
+  }
+}
+```
+
+**Error:** `E054 SyntaxError: Action-parameter annotations are not part of the current MEL syntax.`
+
+**Rule violated:** `action_param` annotations are deferred from the current v1 MEL contract.
+
+```mel
+// ✅ FIXED: Move metadata to the action for now
+@meta("ui:date-picker-form")
+action create(dueDate: string) {
+  when true {
+    patch nextDueDate = dueDate
   }
 }
 ```

--- a/docs/mel/REFERENCE.md
+++ b/docs/mel/REFERENCE.md
@@ -148,6 +148,49 @@ domain DomainName {
 - Multiple `computed` and `action` declarations are allowed
 - Named `type` declarations must appear before their first use
 
+### Structural Annotations (`@meta`)
+
+`@meta` attaches tooling-only structural metadata to the next declaration or field.
+
+```mel
+@meta("doc:summary", { area: "tasks" })
+domain TaskBoard {
+  @meta("doc:entity")
+  type Task = {
+    id: string,
+    @meta("ui:hidden")
+    internalNote: string | null
+  }
+
+  state {
+    @meta("analytics:track")
+    lastArchivedId: string | null = null
+  }
+
+  @meta("ui:status")
+  computed hasArchivedTask = isNotNull(lastArchivedId)
+
+  @meta("ui:button", { variant: "secondary" })
+  action archive(id: string) {
+    when true {
+      patch lastArchivedId = id
+    }
+  }
+}
+```
+
+Current rules:
+- `@meta` uses prefix syntax and attaches to the immediately following construct.
+- Current attachable targets are `domain`, `type`, `type field`, `state field`, `computed`, and `action`.
+- Payload is optional, but when present it must be JSON-like literal data only.
+- Payload nesting depth is capped at 2 levels.
+- Multiple annotations may stack on the same target.
+- Stacked annotations preserve source order.
+- Repeated tags on the same target are preserved and are not deduplicated by the compiler.
+- `action_param` annotations are not part of the current MEL surface.
+
+Annotations are preserved in a tooling-only compiler sidecar. They do not become part of `DomainSchema`, they do not alter `SchemaGraph`, and they do not change runtime legality or execution behavior.
+
 ---
 
 ## 3. State and Types

--- a/docs/mel/SYNTAX.md
+++ b/docs/mel/SYNTAX.md
@@ -38,6 +38,48 @@ domain Counter {
 }
 ```
 
+### Structural Annotations (`@meta`)
+
+Use `@meta` to attach tooling-only metadata to the next declaration or field.
+
+```mel
+@meta("doc:summary", { area: "tasks" })
+domain TaskBoard {
+  @meta("doc:entity")
+  type Task = {
+    id: string,
+    @meta("ui:hidden")
+    internalNote: string | null
+  }
+
+  state {
+    @meta("analytics:track")
+    lastArchivedId: string | null = null
+  }
+
+  @meta("ui:primary-list")
+  computed hasArchivedTask = isNotNull(lastArchivedId)
+
+  @meta("ui:button", { variant: "secondary" })
+  action archive(id: string) {
+    when true {
+      patch lastArchivedId = id
+    }
+  }
+}
+```
+
+Rules:
+- `@meta` attaches to the immediately following construct.
+- Current targets are `domain`, `type`, `type field`, `state field`, `computed`, and `action`.
+- Multiple annotations may stack on the same target, and their source order is preserved.
+- Repeated tags on the same target are preserved; the compiler does not deduplicate them.
+- Payload must be JSON-like literal data only.
+- Payload nesting depth is capped at 2 levels.
+- Annotations do not change `compute()`, `available when`, or `dispatchable when`.
+- Unsupported attachment sites emit `E053`.
+- `action_param` annotations are not part of current MEL syntax.
+
 ---
 
 ## State
@@ -458,6 +500,29 @@ action bad() {
 action bad() {
   when true {
     count = 5        // Error: Use 'patch count = 5'
+  }
+}
+
+// ❌ COMPILE ERROR: @meta payload cannot contain MEL expressions
+@meta("ui:button", { disabled: eq(len(items), 0) })
+action archive() {
+  when true {
+    patch lastArchivedId = "done"
+  }
+}
+
+// ❌ COMPILE ERROR: @meta cannot annotate action parameters in current MEL
+action create(
+  @meta("ui:date-picker") dueDate: string
+) {
+  when true { }
+}
+
+// ❌ COMPILE ERROR: @meta cannot appear inside an action body
+action archive() {
+  @meta("ui:button")
+  when true {
+    patch lastArchivedId = "done"
   }
 }
 ```

--- a/packages/compiler/docs/SPEC-v1.0.0.md
+++ b/packages/compiler/docs/SPEC-v1.0.0.md
@@ -3,7 +3,7 @@
 > **Version:** 1.0.0
 > **Type:** Full
 > **Status:** Normative
-> **Date:** 2026-04-14
+> **Date:** 2026-04-15
 > **Replaces:** Earlier compiler baselines and addenda as the current compiler contract
 > **Compatible with:** Core SPEC v4.2.0, current SDK activation-first contract
 
@@ -17,6 +17,7 @@ It consolidates the landed compiler surface into one current contract, including
 
 - the active full MEL/compiler baseline
 - `SchemaGraph` extraction
+- structural annotations via `@meta` with a tooling-only sidecar
 - `dispatchable when`
 - current landed compiler/runtime alignment for `Record<string, T>` and `T | null` in schema positions
 - current landed support for pure collection builtins in expression contexts
@@ -28,7 +29,23 @@ Historical compiler docs remain useful for archaeology, but **this file is the c
 
 ## 2. Current Output Contract
 
-The compiler emits three distinct type-carrying seams in `DomainSchema`:
+The current compiler contract defines three distinct artifacts:
+
+- `DomainSchema` as the semantic runtime artifact returned by existing schema-only compile entrypoints
+- `SchemaGraph` as the projected static dependency artifact
+- `AnnotationIndex` as the tooling-only structural sidecar
+
+Additive compiler/tooling entrypoints MAY expose those artifacts together through a module envelope:
+
+```typescript
+type DomainModule = {
+  readonly schema: DomainSchema;
+  readonly graph: SchemaGraph;
+  readonly annotations: AnnotationIndex;
+};
+```
+
+Within `DomainSchema`, the compiler emits three distinct type-carrying seams:
 
 ```typescript
 type DomainSchema = {
@@ -56,6 +73,10 @@ type ActionSpec = {
 
 Normative meaning:
 
+- `schema` is the semantic runtime artifact. Core, Host, and SDK runtime entrypoints remain `DomainSchema`-only.
+- `graph` is the projected static dependency artifact extracted from `schema` alone.
+- `annotations` is a tooling-only structural sidecar and MUST remain out-of-schema.
+- schema-only compiler entrypoints MAY continue to expose `DomainSchema` without wrapping it in `DomainModule`.
 - `types` preserves named MEL type declarations losslessly.
 - `state.fields` and `action.input` are the **compatibility / coarse introspection seam**.
 - `state.fieldTypes` and `action.inputType` are the **normative runtime typing seam** when present.
@@ -308,16 +329,195 @@ The compiler MUST continue to extract the projected static graph with:
 
 `dispatchable when` is input-bound and MUST NOT be projected into `SchemaGraph`.
 `unlocks` remains derived from `available when` only.
+Structural annotations MUST NOT alter graph nodes, graph edges, or graph derivation.
 
 ---
 
-## 8. Diagnostics
+## 8. Structural Annotations
+
+### 8.1 Surface and Target Model
+
+`@meta` is part of the current MEL surface as a structural annotation form.
+
+Source form:
+
+```mel
+@meta("namespace:kind")
+@meta("namespace:kind", { key: "value", enabled: true })
+```
+
+Normative rules:
+
+- `@meta` uses prefix syntax and attaches to the immediately following construct.
+- Multiple annotations MAY stack on the same target.
+- The compiler MUST treat the tag string as opaque. Namespace or kind semantics are consumer-owned.
+- Current v1 attachable targets are:
+  - `domain`
+  - `type`
+  - `type_field`
+  - `state_field`
+  - `computed`
+  - `action`
+- For `type_field` and `state_field`, the same prefix form appears immediately above the field declaration inside the enclosing block.
+- `action_param` annotations are deferred from the current v1 contract and are NOT part of current MEL syntax.
+
+Examples:
+
+```mel
+@meta("doc:summary", { area: "tasks" })
+domain TaskBoard {
+  @meta("doc:entity")
+  type Task = {
+    id: string,
+    @meta("ui:hidden")
+    internalNote: string | null
+  }
+
+  state {
+    @meta("analytics:track")
+    lastArchivedId: string | null = null
+  }
+
+  @meta("ui:primary-list")
+  computed hasArchivedTask = isNotNull(lastArchivedId)
+
+  @meta("ui:button", { variant: "secondary" })
+  action archive(id: string) {
+    when true {
+      patch lastArchivedId = id
+    }
+  }
+}
+```
+
+### 8.2 Sidecar Types and Boundaries
+
+Annotations compile into a tooling-only sidecar. They MUST NOT appear inside `DomainSchema` or `SchemaGraph`.
+
+```typescript
+type AnnotationIndex = {
+  readonly schemaHash: string;
+  readonly entries: Record<LocalTargetKey, readonly Annotation[]>;
+};
+
+type LocalTargetKey = string;
+
+type Annotation = {
+  readonly tag: string;
+  readonly payload?: JsonLiteral;
+};
+
+type JsonLiteral =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonLiteral[]
+  | { readonly [key: string]: JsonLiteral };
+```
+
+Current v1 `LocalTargetKey` forms are:
+
+```text
+domain:<DomainName>
+type:<TypeName>
+type_field:<TypeName>.<FieldName>
+state_field:<FieldName>
+computed:<ComputedName>
+action:<ActionName>
+```
+
+Current v1 emission rules:
+
+- `schemaHash` MUST equal `hash` on the emitted `DomainSchema`.
+- `entries` MUST include only targets that carry at least one annotation.
+- `entries` MUST NOT contain empty annotation arrays.
+- stacked annotations on the same target MUST preserve source order.
+- repeated tags on the same target MUST NOT be deduplicated by the compiler.
+- sidecar emission order MUST be deterministic for a fixed source input.
+
+Normative rules:
+
+- `schemaHash` scopes the entire annotation sidecar to one emitted semantic schema.
+- Every emitted `LocalTargetKey` MUST map to an existing construct in the emitted `DomainSchema`.
+- Child targets use exactly one dotted segment (`Parent.Child`) in the current contract.
+- The sidecar MAY be exposed only by additive compiler/tooling entrypoints. It MUST NOT become a runtime input artifact.
+
+### 8.3 Payload Model
+
+Payloads are JSON-like literals only.
+
+Permitted payload values:
+
+- strings
+- numbers
+- booleans
+- `null`
+- arrays of JSON-like literals
+- objects whose values are JSON-like literals
+
+Current v1 payload restrictions:
+
+- payload is optional
+- maximum nesting depth is 2
+- MEL expressions are forbidden
+- semantic references are forbidden
+- guard references or runtime predicates are forbidden
+
+Examples:
+
+```mel
+// valid
+@meta("ui:button", { variant: "primary", size: "lg" })
+@meta("doc:priority", 3)
+
+// invalid: MEL expression in payload
+@meta("ui:button", { disabled: eq(len(items), 0) })
+
+// invalid: depth > 2
+@meta("ui:card", { config: { pricing: { free: "$0" } } })
+```
+
+### 8.4 Annotation Rules and Invariants
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| META-1 | MUST | The compiler MUST remain namespace-blind for annotation tags and payload meaning |
+| META-2 | MUST | Annotations MUST exist only in `AnnotationIndex`, never in `DomainSchema` or `SchemaGraph` |
+| META-3 | MUST | Annotation presence or absence MUST NOT affect schema hash, `compute()`, availability, dispatchability, or other runtime semantics |
+| META-4 | MUST | Runtime entrypoints MUST continue to accept `DomainSchema` only, not `DomainModule` |
+| META-5 | MUST | The compiler MUST validate emitted annotation targets against the emitted `DomainSchema` structure |
+| META-6 | MUST | Payloads MUST be JSON-like literals only, with current v1 nesting depth capped at 2 |
+| META-7 | MUST | Semantic validation of namespace-specific annotation meaning MUST remain consumer-owned |
+| META-8 | MUST | Stacked annotations on the same target MUST preserve source order and repeated tags MUST NOT be deduplicated |
+| META-9 | MUST | `AnnotationIndex.schemaHash` MUST equal `hash` on the emitted `DomainSchema` |
+| META-10 | MUST | `AnnotationIndex.entries` MUST omit unannotated targets and empty arrays, and emission order MUST be deterministic |
+
+Current invariants:
+
+| Invariant | Meaning |
+|-----------|---------|
+| INV-META-1 | Removing all `@meta` from MEL source MUST leave emitted `DomainSchema` byte-identical |
+| INV-META-2 | Removing all `@meta` from MEL source MUST leave emitted `SchemaGraph` identical |
+| INV-META-3 | For any snapshot and intent, `compute()` results MUST remain identical regardless of annotation presence |
+| INV-META-4 | For any snapshot, `getAvailableActions()` MUST remain identical regardless of annotation presence |
+| INV-META-5 | For any snapshot and intent, `isIntentDispatchable()` MUST remain identical regardless of annotation presence |
+| INV-META-6 | Tooling-only `DomainModule` artifacts MUST remain outside runtime schema-input seams |
+
+---
+
+## 9. Diagnostics
 
 The following diagnostics remain active in this area:
 
 - `E043` for unsupported non-trivial schema-position unions
 - `E044` for recursive schema-position refs that cannot be soundly lowered
 - `E047` / `E048` for `dispatchable when` scope violations
+- `E053` for misplaced or floating `@meta`, including unsupported attachment sites
+- `E054` for unsupported `action_param` annotation syntax in the current contract
+- `E055` for annotation payload values that are not JSON-like literals, including MEL expressions and semantic references
+- `E056` for annotation payload nesting depth overflow
+- `E057` for emitted annotation targets that do not map to the emitted `DomainSchema`
 
 The following historical diagnostics are superseded in the current contract:
 
@@ -328,7 +528,7 @@ They remain historical references only and are no longer part of the current com
 
 ---
 
-## 9. Summary
+## 10. Summary
 
 The current compiler contract is:
 
@@ -337,6 +537,8 @@ The current compiler contract is:
 - nullable and record schema-position types are supported
 - pure collection builtins are supported in expressions
 - additive MEL surface expansions MUST preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary
+- structural annotations via `@meta` compile into a tooling-only `AnnotationIndex` sidecar
+- `action_param` annotations remain outside the current v1 surface
 - `dispatchable when` is part of the full action contract
 - `SchemaGraph` remains availability-only and input-independent
 

--- a/packages/compiler/docs/VERSION-INDEX.md
+++ b/packages/compiler/docs/VERSION-INDEX.md
@@ -1,7 +1,7 @@
 # MEL Compiler Documentation Index
 
 > **Package:** `@manifesto-ai/compiler`
-> **Last Updated:** 2026-04-14
+> **Last Updated:** 2026-04-15
 
 ---
 
@@ -10,7 +10,9 @@
 - **Current Full SPEC:** [v1.0.0](SPEC-v1.0.0.md) (Full)
 - **FDR:** [v0.5.0](FDR-v0.5.0.md) (Full)
 
-**Note:** [v1.0.0](SPEC-v1.0.0.md) is the current integrated compiler contract. It rolls up the old v0.7.0 baseline plus the v0.8.0 `SchemaGraph` and v0.9.0 `dispatchable when` addenda, reflects the landed `TypeDefinition`-backed support for nullable and record schema-position types, clarifies that any future additive MEL surface forms must preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary, and records the admitted bounded sugar function forms in parser-free function-call shape.
+**Note:** [v1.0.0](SPEC-v1.0.0.md) is the current integrated compiler contract. It rolls up the old v0.7.0 baseline plus the v0.8.0 `SchemaGraph` and v0.9.0 `dispatchable when` addenda, reflects the landed `TypeDefinition`-backed support for nullable and record schema-position types, clarifies that any future additive MEL surface forms must preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary, records the admitted bounded sugar function forms in parser-free function-call shape, and now includes tooling-only structural annotations via `@meta` with `action_param` explicitly deferred from the current v1 surface.
+
+**ADR Source:** [ADR-021](../../../docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md) is the architectural source for the current structural-annotation contract.
 
 ---
 
@@ -41,6 +43,7 @@
 1. Read [SPEC-v1.0.0.md](SPEC-v1.0.0.md) for the current full compiler contract.
 2. Use [SPEC-v0.8.0.md](SPEC-v0.8.0.md) and [SPEC-v0.9.0.md](SPEC-v0.9.0.md) only for historical addendum context.
 3. For rationale history, use [FDR-v0.5.0.md](FDR-v0.5.0.md).
+4. If you are working on structural annotations, read [SPEC-v1.0.0.md](SPEC-v1.0.0.md) for the current v1 contract, then [ADR-021](../../../docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md) for the architectural rationale and deferred `action_param` decision.
 
 ### For v0.4.0 (Historical Patch)
 

--- a/packages/compiler/docs/compiler-SPEC-compilance-test-suite.md
+++ b/packages/compiler/docs/compiler-SPEC-compilance-test-suite.md
@@ -36,6 +36,7 @@ packages/compiler/src/__tests__/compliance/
   ccts-matrix.spec.ts
   suite/
     grammar.spec.ts
+    annotations.spec.ts
     context.spec.ts
     state-and-computed.spec.ts
     actions-and-control.spec.ts
@@ -100,6 +101,7 @@ Blocking rules reflect currently implemented compiler behavior:
 - `flow` / `include` composition and diagnostics (ADR-013a, `FLOW-*`, `E013`-`E024`)
 - entity primitives and placement/type diagnostics (ADR-013b, `ENTITY-*`, `TRANSFORM-*`, `E030`-`E035`)
 - schema-position lowering hardening (`A26`, `A28`, `A33`, `TYPE-LOWER-6`-`TYPE-LOWER-9`, `E040`-`E044`; `E045`/`E046` retained only as superseded inventory items)
+- structural annotations via `@meta`, including valid v1 target placement, literal-only payload enforcement, payload-depth enforcement, deterministic sidecar emission, semantic erasure invariants, and the runtime-boundary guard between `DomainSchema` and tooling-only `DomainModule`
 - deterministic compile/lower output
 
 ### Pending

--- a/packages/compiler/src/__tests__/annotations.test.ts
+++ b/packages/compiler/src/__tests__/annotations.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAnnotationIndex } from "../annotations.js";
+import { compileMelDomain, compileMelModule } from "../api/index.js";
+import { parse } from "../parser/index.js";
+import { tokenize } from "../lexer/index.js";
+import { extractSchemaGraph } from "../schema-graph.js";
+
+const ANNOTATED_SOURCE = `
+  @meta("doc:summary", { area: "tasks" })
+  domain TaskBoard {
+    @meta("doc:entity")
+    type Task = {
+      id: string,
+      @meta("ui:hidden")
+      internalNote: string | null
+    }
+
+    state {
+      @meta("analytics:track")
+      lastArchivedId: string | null = null
+    }
+
+    @meta("ui:panel")
+    @meta("ui:panel")
+    @meta("ui:status", { variant: "compact" })
+    computed hasArchivedTask = isNotNull(lastArchivedId)
+
+    @meta("ui:button", { variant: "secondary" })
+    action archive(id: string)
+      dispatchable when isNull(lastArchivedId) {
+      when true {
+        patch lastArchivedId = id
+      }
+    }
+  }
+`;
+
+const STRIPPED_SOURCE = `
+  domain TaskBoard {
+    type Task = {
+      id: string,
+      internalNote: string | null
+    }
+
+    state {
+      lastArchivedId: string | null = null
+    }
+
+    computed hasArchivedTask = isNotNull(lastArchivedId)
+
+    action archive(id: string)
+      dispatchable when isNull(lastArchivedId) {
+      when true {
+        patch lastArchivedId = id
+      }
+    }
+  }
+`;
+
+const FLOATING_ANNOTATION_SOURCE = `
+  @meta("doc:summary")
+`;
+
+describe("structural annotations", () => {
+  it("keeps compileMelDomain schema output byte-identical when annotations are present", () => {
+    const annotated = compileMelDomain(ANNOTATED_SOURCE, { mode: "domain" });
+    const stripped = compileMelDomain(STRIPPED_SOURCE, { mode: "domain" });
+
+    expect(annotated.errors).toEqual([]);
+    expect(stripped.errors).toEqual([]);
+    expect(JSON.stringify(annotated.schema)).toBe(JSON.stringify(stripped.schema));
+  });
+
+  it("emits deterministic AnnotationIndex sidecars through compileMelModule", () => {
+    const first = compileMelModule(ANNOTATED_SOURCE, { mode: "module" });
+    const second = compileMelModule(ANNOTATED_SOURCE, { mode: "module" });
+
+    expect(first.errors).toEqual([]);
+    expect(second.errors).toEqual([]);
+    expect(first.module).not.toBeNull();
+    expect(second.module).not.toBeNull();
+
+    const firstModule = first.module!;
+    const secondModule = second.module!;
+
+    expect(firstModule.annotations.schemaHash).toBe(firstModule.schema.hash);
+    expect(firstModule.graph).toEqual(extractSchemaGraph(firstModule.schema));
+    expect(firstModule.graph).toEqual(extractSchemaGraph(compileMelDomain(STRIPPED_SOURCE, { mode: "domain" }).schema!));
+    expect(JSON.stringify(firstModule.annotations)).toBe(JSON.stringify(secondModule.annotations));
+    expect(Object.keys(firstModule.annotations.entries)).toEqual([
+      "action:archive",
+      "computed:hasArchivedTask",
+      "domain:TaskBoard",
+      "state_field:lastArchivedId",
+      "type:Task",
+      "type_field:Task.internalNote",
+    ]);
+    expect(firstModule.annotations.entries["computed:hasArchivedTask"]).toEqual([
+      { tag: "ui:panel" },
+      { tag: "ui:panel" },
+      { tag: "ui:status", payload: { variant: "compact" } },
+    ]);
+    expect(Object.isFrozen(firstModule)).toBe(true);
+    expect(Object.isFrozen(firstModule.graph)).toBe(true);
+    expect(Object.isFrozen(firstModule.annotations)).toBe(true);
+    expect(Object.isFrozen(firstModule.annotations.entries)).toBe(true);
+    expect(Object.isFrozen(firstModule.annotations.entries["computed:hasArchivedTask"])).toBe(true);
+    expect(Object.isFrozen(firstModule.annotations.entries["computed:hasArchivedTask"]?.[2]?.payload)).toBe(true);
+  });
+
+  it("remains namespace-blind and accepts unknown annotation vocabularies", () => {
+    const result = compileMelModule(`
+      @meta("totally:custom", { enabled: true })
+      domain Demo {
+        state { count: number = 0 }
+        @meta("acme:button")
+        action increment() {
+          when true { patch count = add(count, 1) }
+        }
+      }
+    `, { mode: "module" });
+
+    expect(result.errors).toEqual([]);
+    expect(result.module?.annotations.entries).toEqual({
+      "action:increment": [{ tag: "acme:button" }],
+      "domain:Demo": [{ tag: "totally:custom", payload: { enabled: true } }],
+    });
+  });
+
+  it("reports E053 for unsupported annotation placement", () => {
+    const statementResult = compileMelDomain(`
+      domain Demo {
+        state { count: number = 0 }
+        action increment() {
+          @meta("ui:button")
+          when true { patch count = add(count, 1) }
+        }
+      }
+    `, { mode: "domain" });
+
+    const nestedFieldResult = compileMelDomain(`
+      domain Demo {
+        state {
+          config: {
+            @meta("ui:hidden")
+            nested: string
+          } = { nested: "x" }
+        }
+      }
+    `, { mode: "domain" });
+    const trailingMemberResult = compileMelDomain(`
+      domain Demo {
+        @meta("ui:button")
+      }
+    `, { mode: "domain" });
+    const floatingTopLevelResult = compileMelDomain(FLOATING_ANNOTATION_SOURCE, { mode: "domain" });
+
+    expect(statementResult.errors.some((error) => error.code === "E053")).toBe(true);
+    expect(nestedFieldResult.errors.some((error) => error.code === "E053")).toBe(true);
+    expect(trailingMemberResult.errors.some((error) => error.code === "E053")).toBe(true);
+    expect(floatingTopLevelResult.errors.some((error) => error.code === "E053")).toBe(true);
+  });
+
+  it("reports E054 for action-parameter annotations", () => {
+    const result = compileMelDomain(`
+      domain Demo {
+        state { nextDueDate: string = "" }
+        action create(@meta("ui:date-picker") dueDate: string) {
+          when true { patch nextDueDate = dueDate }
+        }
+      }
+    `, { mode: "domain" });
+
+    expect(result.errors.some((error) => error.code === "E054")).toBe(true);
+  });
+
+  it("reports E055 for non-literal annotation payloads", () => {
+    const result = compileMelDomain(`
+      domain Demo {
+        state {
+          items: Array<string> = []
+          lastArchivedId: string | null = null
+        }
+
+        @meta("ui:button", { disabled: eq(len(items), 0) })
+        action archive() {
+          when true { patch lastArchivedId = "done" }
+        }
+      }
+    `, { mode: "domain" });
+
+    expect(result.errors.some((error) => error.code === "E055")).toBe(true);
+  });
+
+  it("reports E056 for payloads that exceed the v1 nesting limit", () => {
+    const result = compileMelDomain(`
+      domain Demo {
+        state { cardVariant: string = "free" }
+
+        @meta("ui:card", { config: { pricing: { free: "$0" } } })
+        computed cardVariantView = cardVariant
+      }
+    `, { mode: "domain" });
+
+    expect(result.errors.some((error) => error.code === "E056")).toBe(true);
+  });
+
+  it("reports E057 when extracted targets do not match the emitted schema", () => {
+    const lexed = tokenize(ANNOTATED_SOURCE);
+    const parsed = parse(lexed.tokens);
+    const compiled = compileMelDomain(ANNOTATED_SOURCE, { mode: "domain" });
+
+    expect(parsed.diagnostics).toEqual([]);
+    expect(compiled.errors).toEqual([]);
+    expect(parsed.program).not.toBeNull();
+    expect(compiled.schema).not.toBeNull();
+
+    const { archive: _archive, ...actions } = compiled.schema!.actions;
+    const tamperedSchema = {
+      ...compiled.schema!,
+      actions,
+    };
+    const result = buildAnnotationIndex(parsed.program!, tamperedSchema);
+
+    expect(result.diagnostics.some((diagnostic) => diagnostic.code === "E057")).toBe(true);
+  });
+});

--- a/packages/compiler/src/__tests__/compliance/ccts-coverage.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-coverage.ts
@@ -22,6 +22,12 @@ export const CCTS_CASES = {
   GRAMMAR_INVALID_SYSTEM_REF: "CCTS-GRAM-003",
   GRAMMAR_ONCE_INTENT_CONTEXTUAL: "CCTS-GRAM-004",
 
+  ANNOTATIONS_SURFACE: "CCTS-ANN-001",
+  ANNOTATIONS_PAYLOAD: "CCTS-ANN-002",
+  ANNOTATIONS_INVARIANTS: "CCTS-ANN-003",
+  ANNOTATIONS_RUNTIME_BOUNDARY: "CCTS-ANN-004",
+  ANNOTATIONS_DIAGNOSTICS: "CCTS-ANN-005",
+
   CONTEXT_COMPUTED_SYSTEM: "CCTS-CTX-001",
   CONTEXT_STATE_INIT_SYSTEM: "CCTS-CTX-002",
   CONTEXT_AVAILABLE_PURITY: "CCTS-CTX-003",
@@ -77,6 +83,12 @@ export const COMPILER_COMPLIANCE_CASES: readonly CompilerComplianceCase[] = [
   complianceCase(CCTS_CASES.GRAMMAR_INVALID_SYSTEM_REF, "grammar", "Invalid system references are diagnosed."),
   complianceCase(CCTS_CASES.GRAMMAR_ONCE_INTENT_CONTEXTUAL, "grammar", "onceIntent is parsed contextually."),
 
+  complianceCase(CCTS_CASES.ANNOTATIONS_SURFACE, "annotations", "@meta target placement, target-key shape, and sidecar emission determinism are staged."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_PAYLOAD, "annotations", "@meta payload literal-only and depth constraints are staged."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_INVARIANTS, "annotations", "@meta semantic erasure invariants are staged."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_RUNTIME_BOUNDARY, "annotations", "Tooling-only DomainModule runtime-boundary guards are staged."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_DIAGNOSTICS, "annotations", "@meta diagnostic families are staged."),
+
   complianceCase(CCTS_CASES.CONTEXT_COMPUTED_SYSTEM, "context", "$system is rejected in computed expressions."),
   complianceCase(CCTS_CASES.CONTEXT_STATE_INIT_SYSTEM, "context", "$system is rejected in state initializers."),
   complianceCase(CCTS_CASES.CONTEXT_AVAILABLE_PURITY, "context", "available when stays schema-pure."),
@@ -118,7 +130,7 @@ export const COMPILER_COMPLIANCE_CASES: readonly CompilerComplianceCase[] = [
   complianceCase(CCTS_CASES.ENTITY_TYPING, "entity-primitives", "Entity typing and uniqueness rules are tracked."),
 
   complianceCase(CCTS_CASES.INTROSPECTION_GRAPH_SURFACE, "introspection", "SchemaGraph emits projected nodes with kind-prefixed ids and deterministic ordering."),
-  complianceCase(CCTS_CASES.INTROSPECTION_FEEDS_UNLOCKS, "introspection", "SchemaGraph extracts feeds and unlocks relations from computed deps and availability." ),
+  complianceCase(CCTS_CASES.INTROSPECTION_FEEDS_UNLOCKS, "introspection", "SchemaGraph extracts feeds and unlocks relations from computed deps and availability."),
   complianceCase(CCTS_CASES.INTROSPECTION_MUTATIONS, "introspection", "SchemaGraph extracts mutates relations from patches and effect into roots."),
   complianceCase(CCTS_CASES.INTROSPECTION_PROJECTION, "introspection", "SchemaGraph excludes $*-owned substrate and tainted computed nodes."),
 
@@ -172,6 +184,12 @@ export const COMPILER_RULE_COVERAGE: readonly CompilerComplianceCoverageEntry[] 
   ...coverMany(["SGRAPH-5", "SGRAPH-6", "SGRAPH-10", "SGRAPH-11"], [CCTS_CASES.INTROSPECTION_FEEDS_UNLOCKS]),
   ...coverMany(["SGRAPH-7", "SGRAPH-8", "SGRAPH-9"], [CCTS_CASES.INTROSPECTION_MUTATIONS]),
   ...coverMany(["SGRAPH-12", "SGRAPH-13"], [CCTS_CASES.INTROSPECTION_PROJECTION]),
+
+  ...coverMany(["META-1", "META-2", "META-5", "META-7", "META-8", "META-9", "META-10"], [CCTS_CASES.ANNOTATIONS_SURFACE]),
+  ...coverMany(["META-6"], [CCTS_CASES.ANNOTATIONS_PAYLOAD]),
+  ...coverMany(["META-3", "INV-META-1", "INV-META-2", "INV-META-3", "INV-META-4", "INV-META-5"], [CCTS_CASES.ANNOTATIONS_INVARIANTS]),
+  ...coverMany(["META-4", "INV-META-6"], [CCTS_CASES.ANNOTATIONS_RUNTIME_BOUNDARY]),
+  ...coverMany(["E053", "E054", "E055", "E056", "E057"], [CCTS_CASES.ANNOTATIONS_DIAGNOSTICS]),
 
   ...coverMany(["E003"], [CCTS_CASES.GRAMMAR_INVALID_SYSTEM_REF]),
   ...coverMany(["E006", "E007", "E008"], [CCTS_CASES.ACTIONS_FAIL_STOP_DIAGNOSTICS]),

--- a/packages/compiler/src/__tests__/compliance/ccts-rules.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-rules.ts
@@ -52,6 +52,9 @@ export const COMPILER_COMPLIANCE_RULES: readonly CompilerComplianceRule[] = [
   registry("COMPILER-MEL-4", "blocking"),
   ...registryMany(["MEL-SUGAR-1", "MEL-SUGAR-2", "MEL-SUGAR-3", "MEL-SUGAR-4"], "blocking"),
 
+  ...registryMany(["META-1", "META-2", "META-3", "META-4", "META-5", "META-6", "META-7", "META-8", "META-9", "META-10"], "blocking"),
+  ...registryMany(["INV-META-1", "INV-META-2", "INV-META-3", "INV-META-4", "INV-META-5", "INV-META-6"], "blocking"),
+
   registry("AD-COMP-LOW-001", "blocking"),
   registry("AD-COMP-LOW-002", "blocking"),
   registry("AD-COMP-LOW-003", "blocking"),
@@ -60,6 +63,7 @@ export const COMPILER_COMPLIANCE_RULES: readonly CompilerComplianceRule[] = [
   ...registryMany(["E001", "E002", "E003", "E004", "E005", "E009", "E010", "E011"], "blocking"),
   ...registryMany(["E006", "E007", "E008"], "blocking"),
   ...registryMany(["E012", "E013", "E014", "E015", "E016", "E017", "E018", "E019", "E020", "E021", "E022", "E023", "E024", "E030", "E030a", "E030b", "E031", "E032", "E033", "E034", "E035", "E041", "E042", "E043", "E044", "E049", "E050", "E051", "E052"], "blocking"),
+  ...registryMany(["E053", "E054", "E055", "E056", "E057"], "blocking"),
   registry("E045", "informational"),
   registry("E046", "informational"),
   registry("E040", "blocking"),

--- a/packages/compiler/src/__tests__/compliance/ccts-spec-inventory.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-spec-inventory.ts
@@ -92,6 +92,9 @@ export const COMPILER_SPEC_INVENTORY: readonly CompilerComplianceInventoryItem[]
 
   ...inventoryMany(["MEL-SUGAR-1", "MEL-SUGAR-2", "MEL-SUGAR-3", "MEL-SUGAR-4"], "§5.1", "MUST", "lowering-and-ir"),
 
+  ...inventoryMany(["META-1", "META-2", "META-3", "META-4", "META-5", "META-6", "META-7", "META-8", "META-9", "META-10"], "§8.2-§8.4", "MUST", "annotations"),
+  ...inventoryMany(["INV-META-1", "INV-META-2", "INV-META-3", "INV-META-4", "INV-META-5", "INV-META-6"], "§8.4", "CRITICAL", "annotations"),
+
   ...inventoryMany(["AD-COMP-LOW-001", "AD-COMP-LOW-002", "AD-COMP-LOW-003"], "§16", "MUST", "lowering-and-ir"),
   inventory("SCHEMA-RESERVED-1", "§17.4 / §21", "MUST", "lowering-and-ir"),
 
@@ -104,6 +107,7 @@ export const COMPILER_SPEC_INVENTORY: readonly CompilerComplianceInventoryItem[]
   ...inventoryMany(["E030", "E030a", "E030b", "E031", "E032", "E033", "E034", "E035"], "§13.6", "MUST", "entity-primitives"),
   ...inventoryMany(["E040", "E041", "E042", "E043", "E044"], "§13.6", "MUST", "state-and-computed"),
   ...inventoryMany(["E049", "E050", "E051", "E052"], "§13.6", "MUST", "lowering-and-ir"),
+  ...inventoryMany(["E053", "E054", "E055", "E056", "E057"], "§9", "MUST", "annotations"),
   inventory("E045", "§13.6", "MUST", "state-and-computed", {
     lifecycle: "superseded",
     notes: "Superseded when nullable schema-position types became supported through TypeDefinition-backed runtime validation.",

--- a/packages/compiler/src/__tests__/compliance/ccts-types.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-types.ts
@@ -6,6 +6,7 @@ import type { CanonicalDomainSchema, DomainSchema } from "../../generator/ir.js"
 
 export const CCTS_SUITES = [
   "grammar",
+  "annotations",
   "context",
   "state-and-computed",
   "actions-and-control",

--- a/packages/compiler/src/__tests__/compliance/suite/annotations.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/annotations.spec.ts
@@ -1,0 +1,395 @@
+import { describe, it } from "vitest";
+import { createManifesto } from "../../../../../sdk/src/index.js";
+import { buildAnnotationIndex } from "../../../annotations.js";
+import { compileMelDomain, compileMelModule } from "../../../api/index.js";
+import {
+  diagnosticEvidence,
+  evaluateRule,
+  expectAllCompliance,
+  hasDiagnosticCode,
+  noteEvidence,
+} from "../ccts-assertions.js";
+import { CCTS_CASES, caseTitle } from "../ccts-coverage.js";
+import { getRuleOrThrow } from "../ccts-rules.js";
+import { parse } from "../../../parser/index.js";
+import { tokenize } from "../../../lexer/index.js";
+import { extractSchemaGraph } from "../../../schema-graph.js";
+
+type AnnotationInvariantDomain = {
+  actions: {
+    archive: (limit: number) => Promise<void>;
+  };
+  state: {
+    count: number;
+  };
+  computed: {
+    canArchive: boolean;
+  };
+};
+
+const ANNOTATED_SOURCE = `
+  @meta("doc:summary", { area: "tasks" })
+  domain TaskBoard {
+    @meta("doc:entity")
+    type Task = {
+      id: string,
+      @meta("ui:hidden")
+      internalNote: string | null
+    }
+
+    state {
+      @meta("analytics:track")
+      count: number = 0
+    }
+
+    @meta("ui:panel")
+    @meta("ui:panel")
+    @meta("ui:status", { variant: "compact" })
+    computed canArchive = lt(count, 2)
+
+    @meta("ui:button", { variant: "secondary" })
+    action archive(limit: number)
+      available when canArchive
+      dispatchable when lt(count, limit) {
+      when true { patch count = add(count, 1) }
+    }
+  }
+`;
+
+const STRIPPED_SOURCE = `
+  domain TaskBoard {
+    type Task = {
+      id: string,
+      internalNote: string | null
+    }
+
+    state {
+      count: number = 0
+    }
+
+    computed canArchive = lt(count, 2)
+
+    action archive(limit: number)
+      available when canArchive
+      dispatchable when lt(count, limit) {
+      when true { patch count = add(count, 1) }
+    }
+  }
+`;
+
+describe("CCTS Annotation Suite", () => {
+  it(caseTitle(CCTS_CASES.ANNOTATIONS_SURFACE, "(META-1/META-2/META-5/META-7/META-8/META-9/META-10) annotation sidecar surface is enforced"), () => {
+    const first = compileMelModule(ANNOTATED_SOURCE, { mode: "module" });
+    const second = compileMelModule(ANNOTATED_SOURCE, { mode: "module" });
+    const namespaceBlind = compileMelModule(`
+      @meta("acme:unknown", { enabled: true })
+      domain Demo {
+        state { count: number = 0 }
+        @meta("vendor:action")
+        action increment() {
+          when true { patch count = add(count, 1) }
+        }
+      }
+    `, { mode: "module" });
+
+    const parsed = parse(tokenize(ANNOTATED_SOURCE).tokens);
+    const tamperedIndex = first.module && parsed.program
+      ? buildAnnotationIndex(parsed.program, {
+        ...first.module.schema,
+        actions: {},
+      })
+      : null;
+
+    const firstModule = first.module;
+    const secondModule = second.module;
+    const sortedKeys = firstModule ? Object.keys(firstModule.annotations.entries) : [];
+    const noEmptyArrays = firstModule
+      ? Object.values(firstModule.annotations.entries).every((entry) => entry.length > 0)
+      : false;
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("META-1"), namespaceBlind.errors.length === 0, {
+        passMessage: "Unknown annotation namespaces compile without compiler-owned semantic interpretation.",
+        failMessage: "Compiler no longer treats annotation tags as opaque strings.",
+        evidence: diagnosticEvidence(namespaceBlind.errors),
+      }),
+      evaluateRule(getRuleOrThrow("META-2"), Boolean(firstModule)
+        && !("annotations" in firstModule.schema)
+        && JSON.stringify(firstModule.graph) === JSON.stringify(extractSchemaGraph(firstModule.schema)), {
+        passMessage: "Annotations stay outside DomainSchema and SchemaGraph.",
+        failMessage: "Annotations leaked into semantic compiler artifacts.",
+        evidence: firstModule ? [
+          noteEvidence("Annotation entry keys", sortedKeys),
+        ] : diagnosticEvidence(first.errors),
+      }),
+      evaluateRule(getRuleOrThrow("META-5"), Boolean(tamperedIndex)
+        && hasDiagnosticCode(tamperedIndex!.diagnostics, "E057"), {
+        passMessage: "Annotation targets are validated against emitted DomainSchema structure.",
+        failMessage: "Target validation no longer reports dangling annotation targets.",
+        evidence: tamperedIndex ? diagnosticEvidence(tamperedIndex.diagnostics) : diagnosticEvidence(first.errors),
+      }),
+      evaluateRule(getRuleOrThrow("META-7"), namespaceBlind.errors.length === 0, {
+        passMessage: "Namespace-specific semantics remain consumer-owned.",
+        failMessage: "Compiler started rejecting unknown annotation vocabularies.",
+        evidence: diagnosticEvidence(namespaceBlind.errors),
+      }),
+      evaluateRule(getRuleOrThrow("META-8"), Boolean(firstModule)
+        && JSON.stringify(firstModule.annotations.entries["computed:canArchive"]) === JSON.stringify([
+          { tag: "ui:panel" },
+          { tag: "ui:panel" },
+          { tag: "ui:status", payload: { variant: "compact" } },
+        ]), {
+        passMessage: "Stacked annotations preserve source order and repeated tags.",
+        failMessage: "Same-target annotation ordering or duplicate preservation regressed.",
+        evidence: firstModule ? [
+          noteEvidence("Computed annotations", firstModule.annotations.entries["computed:canArchive"]),
+        ] : diagnosticEvidence(first.errors),
+      }),
+      evaluateRule(getRuleOrThrow("META-9"), Boolean(firstModule)
+        && firstModule.annotations.schemaHash === firstModule.schema.hash, {
+        passMessage: "AnnotationIndex.schemaHash matches DomainSchema.hash.",
+        failMessage: "AnnotationIndex.schemaHash no longer aligns with the emitted DomainSchema hash.",
+        evidence: firstModule ? [
+          noteEvidence("Annotation schema hash", firstModule.annotations.schemaHash),
+          noteEvidence("Schema hash", firstModule.schema.hash),
+        ] : diagnosticEvidence(first.errors),
+      }),
+      evaluateRule(getRuleOrThrow("META-10"), Boolean(firstModule && secondModule)
+        && JSON.stringify(firstModule.annotations) === JSON.stringify(secondModule.annotations)
+        && noEmptyArrays, {
+        passMessage: "Annotation sidecar emission is deterministic and omits empty targets.",
+        failMessage: "Annotation sidecar emission is unstable or includes empty target entries.",
+        evidence: firstModule ? [
+          noteEvidence("Annotation entry keys", sortedKeys),
+        ] : diagnosticEvidence(first.errors),
+      }),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.ANNOTATIONS_PAYLOAD, "(META-6) annotation payload constraints are enforced"), () => {
+    const valid = compileMelModule(ANNOTATED_SOURCE, { mode: "module" });
+    const invalidExpr = compileMelDomain(`
+      domain Demo {
+        state {
+          items: Array<string> = []
+          count: number = 0
+        }
+
+        @meta("ui:button", { disabled: eq(len(items), 0) })
+        action archive() {
+          when true { patch count = add(count, 1) }
+        }
+      }
+    `, { mode: "domain" });
+    const invalidDepth = compileMelDomain(`
+      domain Demo {
+        state { count: number = 0 }
+
+        @meta("ui:card", { config: { pricing: { free: "$0" } } })
+        computed cardVariant = count
+      }
+    `, { mode: "domain" });
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("META-6"), valid.errors.length === 0
+        && hasDiagnosticCode(invalidExpr.errors, "E055")
+        && hasDiagnosticCode(invalidDepth.errors, "E056"), {
+        passMessage: "Annotation payloads remain literal-only with the current depth cap.",
+        failMessage: "Annotation payload validation no longer enforces literal-only payloads and depth bounds.",
+        evidence: [
+          ...diagnosticEvidence(invalidExpr.errors),
+          ...diagnosticEvidence(invalidDepth.errors),
+        ],
+      }),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.ANNOTATIONS_INVARIANTS, "(META-3/INV-META-1..5) annotation erasure invariants are enforced"), async () => {
+    const annotatedSchema = compileMelDomain(ANNOTATED_SOURCE, { mode: "domain" });
+    const strippedSchema = compileMelDomain(STRIPPED_SOURCE, { mode: "domain" });
+    const annotated = createManifesto<AnnotationInvariantDomain>(annotatedSchema.schema!, {}).activate();
+    const stripped = createManifesto<AnnotationInvariantDomain>(strippedSchema.schema!, {}).activate();
+    const annotatedIntent = annotated.createIntent(annotated.MEL.actions.archive, 2);
+    const strippedIntent = stripped.createIntent(stripped.MEL.actions.archive, 2);
+
+    const sameSchema = JSON.stringify(annotatedSchema.schema) === JSON.stringify(strippedSchema.schema);
+    const sameGraph = JSON.stringify(extractSchemaGraph(annotatedSchema.schema!)) === JSON.stringify(extractSchemaGraph(strippedSchema.schema!));
+    const sameDispatchability = annotated.isIntentDispatchable(annotated.MEL.actions.archive, 2) === stripped.isIntentDispatchable(stripped.MEL.actions.archive, 2);
+    const sameAvailability = JSON.stringify(annotated.getAvailableActions()) === JSON.stringify(stripped.getAvailableActions());
+    const sameBlockers = JSON.stringify(annotated.getIntentBlockers(annotated.MEL.actions.archive, 2)) === JSON.stringify(stripped.getIntentBlockers(stripped.MEL.actions.archive, 2));
+
+    await annotated.dispatchAsync(annotatedIntent);
+    await stripped.dispatchAsync(strippedIntent);
+
+    const annotatedAvailableActions = annotated.getAvailableActions();
+    const strippedAvailableActions = stripped.getAvailableActions();
+    const annotatedBlockers = annotated.getIntentBlockers(annotated.MEL.actions.archive, 2);
+    const strippedBlockers = stripped.getIntentBlockers(stripped.MEL.actions.archive, 2);
+    const annotatedSnapshot = annotated.getSnapshot();
+    const strippedSnapshot = stripped.getSnapshot();
+    const sameSnapshots = JSON.stringify(annotatedSnapshot) === JSON.stringify(strippedSnapshot);
+
+    annotated.dispose();
+    stripped.dispose();
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("META-3"), sameSchema && sameGraph && sameDispatchability && sameAvailability && sameSnapshots, {
+        passMessage: "Structural annotations have zero semantic influence on runtime behavior.",
+        failMessage: "Structural annotations changed runtime semantics or emitted semantic artifacts.",
+        evidence: [
+          noteEvidence("Same schema", sameSchema),
+          noteEvidence("Same graph", sameGraph),
+          noteEvidence("Same availability", sameAvailability),
+          noteEvidence("Same dispatchability", sameDispatchability),
+          noteEvidence("Same blockers", sameBlockers),
+          noteEvidence("Same snapshots after dispatch", sameSnapshots),
+        ],
+      }),
+      evaluateRule(getRuleOrThrow("INV-META-1"), sameSchema, {
+        passMessage: "Removing @meta leaves DomainSchema byte-identical.",
+        failMessage: "Removing @meta changed the emitted DomainSchema.",
+        evidence: [
+          noteEvidence("Annotated schema hash", annotatedSchema.schema?.hash ?? null),
+          noteEvidence("Stripped schema hash", strippedSchema.schema?.hash ?? null),
+        ],
+      }),
+      evaluateRule(getRuleOrThrow("INV-META-2"), sameGraph, {
+        passMessage: "Removing @meta leaves SchemaGraph identical.",
+        failMessage: "Removing @meta changed SchemaGraph projection.",
+        evidence: [
+          noteEvidence("Annotated graph node count", extractSchemaGraph(annotatedSchema.schema!).nodes.length),
+          noteEvidence("Stripped graph node count", extractSchemaGraph(strippedSchema.schema!).nodes.length),
+        ],
+      }),
+      evaluateRule(getRuleOrThrow("INV-META-3"), sameSnapshots, {
+        passMessage: "compute()/dispatch results remain identical with or without annotations.",
+        failMessage: "compute()/dispatch results changed when annotations were present.",
+        evidence: [
+          noteEvidence("Annotated snapshot", annotatedSnapshot),
+          noteEvidence("Stripped snapshot", strippedSnapshot),
+        ],
+      }),
+      evaluateRule(getRuleOrThrow("INV-META-4"), sameAvailability, {
+        passMessage: "getAvailableActions() remains identical with or without annotations.",
+        failMessage: "getAvailableActions() changed when annotations were present.",
+        evidence: [
+          noteEvidence("Annotated available actions", annotatedAvailableActions),
+          noteEvidence("Stripped available actions", strippedAvailableActions),
+        ],
+      }),
+      evaluateRule(getRuleOrThrow("INV-META-5"), sameDispatchability && sameBlockers, {
+        passMessage: "Intent dispatchability remains identical with or without annotations.",
+        failMessage: "Intent dispatchability changed when annotations were present.",
+        evidence: [
+          noteEvidence("Annotated blockers", annotatedBlockers),
+          noteEvidence("Stripped blockers", strippedBlockers),
+        ],
+      }),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.ANNOTATIONS_RUNTIME_BOUNDARY, "(META-4/INV-META-6) DomainModule runtime-boundary guards are enforced"), () => {
+    const result = compileMelModule(ANNOTATED_SOURCE, { mode: "module" });
+
+    let rejected = false;
+    let message = "";
+    try {
+      createManifesto(
+        result.module as never,
+        {},
+      );
+    } catch (error) {
+      rejected = true;
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("META-4"), rejected, {
+        passMessage: "Runtime entrypoints reject DomainModule tooling artifacts.",
+        failMessage: "Runtime entrypoints accepted a tooling-only DomainModule artifact.",
+        evidence: [noteEvidence("Runtime rejection message", message)],
+      }),
+      evaluateRule(getRuleOrThrow("INV-META-6"), rejected, {
+        passMessage: "DomainModule is not accepted by createManifesto().",
+        failMessage: "DomainModule reached createManifesto() without rejection.",
+        evidence: [noteEvidence("Runtime rejection message", message)],
+      }),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.ANNOTATIONS_DIAGNOSTICS, "(E053-E057) annotation diagnostic families are enforced"), () => {
+    const invalidPlacement = compileMelDomain(`
+      domain Demo {
+        state { count: number = 0 }
+        action increment() {
+          @meta("ui:button")
+          when true { patch count = add(count, 1) }
+        }
+      }
+    `, { mode: "domain" });
+    const invalidParam = compileMelDomain(`
+      domain Demo {
+        state { nextDueDate: string = "" }
+        action create(@meta("ui:date-picker") dueDate: string) {
+          when true { patch nextDueDate = dueDate }
+        }
+      }
+    `, { mode: "domain" });
+    const invalidPayload = compileMelDomain(`
+      domain Demo {
+        state {
+          items: Array<string> = []
+          count: number = 0
+        }
+        @meta("ui:button", { disabled: eq(len(items), 0) })
+        action archive() {
+          when true { patch count = add(count, 1) }
+        }
+      }
+    `, { mode: "domain" });
+    const invalidDepth = compileMelDomain(`
+      domain Demo {
+        state { count: number = 0 }
+        @meta("ui:card", { config: { pricing: { free: "$0" } } })
+        computed cardVariant = count
+      }
+    `, { mode: "domain" });
+
+    const parsed = parse(tokenize(ANNOTATED_SOURCE).tokens);
+    const moduleResult = compileMelModule(ANNOTATED_SOURCE, { mode: "module" });
+    const dangling = moduleResult.module && parsed.program
+      ? buildAnnotationIndex(parsed.program, {
+        ...moduleResult.module.schema,
+        actions: {},
+      })
+      : null;
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("E053"), hasDiagnosticCode(invalidPlacement.errors, "E053"), {
+        passMessage: "Unsupported annotation placement emits E053.",
+        failMessage: "Unsupported annotation placement no longer emits E053.",
+        evidence: diagnosticEvidence(invalidPlacement.errors),
+      }),
+      evaluateRule(getRuleOrThrow("E054"), hasDiagnosticCode(invalidParam.errors, "E054"), {
+        passMessage: "Action-parameter annotations emit E054.",
+        failMessage: "Action-parameter annotations no longer emit E054.",
+        evidence: diagnosticEvidence(invalidParam.errors),
+      }),
+      evaluateRule(getRuleOrThrow("E055"), hasDiagnosticCode(invalidPayload.errors, "E055"), {
+        passMessage: "Non-literal annotation payloads emit E055.",
+        failMessage: "Non-literal annotation payloads no longer emit E055.",
+        evidence: diagnosticEvidence(invalidPayload.errors),
+      }),
+      evaluateRule(getRuleOrThrow("E056"), hasDiagnosticCode(invalidDepth.errors, "E056"), {
+        passMessage: "Annotation payload depth overflow emits E056.",
+        failMessage: "Annotation payload depth overflow no longer emits E056.",
+        evidence: diagnosticEvidence(invalidDepth.errors),
+      }),
+      evaluateRule(getRuleOrThrow("E057"), Boolean(dangling) && hasDiagnosticCode(dangling!.diagnostics, "E057"), {
+        passMessage: "Dangling annotation targets emit E057.",
+        failMessage: "Dangling annotation targets no longer emit E057.",
+        evidence: dangling ? diagnosticEvidence(dangling.diagnostics) : diagnosticEvidence(moduleResult.errors),
+      }),
+    ]);
+  });
+});

--- a/packages/compiler/src/__tests__/loader-vite.test.ts
+++ b/packages/compiler/src/__tests__/loader-vite.test.ts
@@ -17,6 +17,18 @@ domain Counter {
 }
 `.trim();
 
+const ANNOTATED_MEL = `
+@meta("doc:summary", { area: "counter" })
+domain Counter {
+  state { count: number = 0 }
+
+  @meta("ui:button", { variant: "primary" })
+  action increment() {
+    onceIntent { patch count = add(count, 1) }
+  }
+}
+`.trim();
+
 async function importFromModuleCode(code: string): Promise<{ default: unknown }> {
   const encoded = Buffer.from(code, "utf8").toString("base64");
   return import(`data:text/javascript;base64,${encoded}`);
@@ -34,6 +46,19 @@ describe("unplugin core", () => {
     const module = await importFromModuleCode(code!);
     const schema = module.default as { actions?: Record<string, unknown> };
     expect(schema.actions).toHaveProperty("increment");
+  });
+
+  it("keeps schema-only bundler output even when MEL uses @meta", async () => {
+    const plugin = unpluginMel.raw({});
+    const result = await plugin.transform(ANNOTATED_MEL, "/tmp/counter.mel");
+    expect(result).toBeDefined();
+
+    const code = typeof result === "string" ? result : result?.code;
+    const module = await importFromModuleCode(code!);
+    const schema = module.default as { actions?: Record<string, unknown>; annotations?: unknown };
+
+    expect(schema.actions).toHaveProperty("increment");
+    expect(schema).not.toHaveProperty("annotations");
   });
 
   it("filters out non-.mel files via transformInclude", () => {
@@ -204,6 +229,32 @@ describe("node-loader resolve/load hooks", () => {
       const module = await importFromModuleCode(result.source as string);
       const schema = module.default as { actions?: Record<string, unknown> };
       expect(schema.actions).toHaveProperty("increment");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads annotated .mel files as schema-only modules", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "manifesto-mel-loader-"));
+
+    try {
+      const melPath = join(tempDir, "counter.mel");
+      await writeFile(melPath, ANNOTATED_MEL, "utf8");
+
+      const nextLoad = vi.fn(async () => ({
+        format: "module",
+        source: "",
+      }));
+
+      const result = await load(pathToFileURL(melPath).href, {}, nextLoad);
+      expect(nextLoad).not.toHaveBeenCalled();
+      expect(result.format).toBe("module");
+      expect(result.shortCircuit).toBe(true);
+
+      const module = await importFromModuleCode(result.source as string);
+      const schema = module.default as { annotations?: unknown; actions?: Record<string, unknown> };
+      expect(schema.actions).toHaveProperty("increment");
+      expect(schema).not.toHaveProperty("annotations");
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }

--- a/packages/compiler/src/annotations.ts
+++ b/packages/compiler/src/annotations.ts
@@ -1,0 +1,468 @@
+import { createError, type Diagnostic } from "./diagnostics/types.js";
+import type { DomainSchema } from "./generator/ir.js";
+import type {
+  ActionNode,
+  AnnotationNode,
+  ExprNode,
+  ParamNode,
+  ProgramNode,
+  TypeExprNode,
+} from "./parser/ast.js";
+import type { SchemaGraph } from "./schema-graph.js";
+
+export type JsonLiteral =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonLiteral[]
+  | { readonly [key: string]: JsonLiteral };
+
+export interface Annotation {
+  readonly tag: string;
+  readonly payload?: JsonLiteral;
+}
+
+export type LocalTargetKey =
+  | `domain:${string}`
+  | `type:${string}`
+  | `type_field:${string}.${string}`
+  | `state_field:${string}`
+  | `computed:${string}`
+  | `action:${string}`;
+
+export interface AnnotationIndex {
+  readonly schemaHash: string;
+  readonly entries: Record<LocalTargetKey, readonly Annotation[]>;
+}
+
+export interface DomainModule {
+  readonly schema: DomainSchema;
+  readonly graph: SchemaGraph;
+  readonly annotations: AnnotationIndex;
+}
+
+export interface AnnotationExtractionResult {
+  annotations: AnnotationIndex;
+  diagnostics: Diagnostic[];
+}
+
+const INVALID_ATTACHMENT_MESSAGE =
+  "@meta can attach only to domain, type, type field, state field, computed, or action declarations.";
+const INVALID_PARAM_MESSAGE =
+  "Action-parameter annotations are not part of the current MEL syntax.";
+const INVALID_PAYLOAD_MESSAGE =
+  "Annotation payloads must be JSON-like literals. MEL expressions are not allowed in @meta payloads.";
+const PAYLOAD_DEPTH_MESSAGE =
+  "Annotation payload nesting exceeds the current MEL limit of 2 levels.";
+const DANGLING_TARGET_MESSAGE =
+  "Annotation target does not map to the emitted DomainSchema.";
+const MAX_PAYLOAD_DEPTH = 2;
+
+type EntryMap = Map<LocalTargetKey, Annotation[]>;
+
+export function buildAnnotationIndex(
+  program: ProgramNode,
+  schema: DomainSchema,
+): AnnotationExtractionResult {
+  const diagnostics: Diagnostic[] = [];
+  const entries: EntryMap = new Map();
+  const domain = program.domain;
+
+  collectAnnotationsForTarget(domain.annotations, `domain:${domain.name}`, diagnostics, entries);
+
+  for (const typeDecl of domain.types) {
+    collectAnnotationsForTarget(typeDecl.annotations, `type:${typeDecl.name}`, diagnostics, entries);
+    collectTypeFieldAnnotations(typeDecl.typeExpr, typeDecl.name, 0, diagnostics, entries);
+  }
+
+  for (const member of domain.members) {
+    switch (member.kind) {
+      case "state":
+        for (const field of member.fields) {
+          collectAnnotationsForTarget(field.annotations, `state_field:${field.name}`, diagnostics, entries);
+          collectUnsupportedTypeFieldAnnotations(field.typeExpr, diagnostics);
+        }
+        break;
+
+      case "computed":
+        collectAnnotationsForTarget(member.annotations, `computed:${member.name}`, diagnostics, entries);
+        break;
+
+      case "action":
+        collectAnnotationsForTarget(member.annotations, `action:${member.name}`, diagnostics, entries);
+        collectActionParamAnnotationDiagnostics(member, diagnostics);
+        for (const param of member.params) {
+          collectUnsupportedTypeFieldAnnotations(param.typeExpr, diagnostics);
+        }
+        break;
+
+      case "flow":
+        break;
+    }
+  }
+
+  const sortedEntries = {} as Record<LocalTargetKey, readonly Annotation[]>;
+  for (const key of [...entries.keys()].sort()) {
+    if (!hasSchemaTarget(schema, key)) {
+      diagnostics.push(createError("E057", DANGLING_TARGET_MESSAGE, inferTargetLocation(program, key) ?? domain.location));
+      continue;
+    }
+    const targetAnnotations = entries.get(key);
+    if (targetAnnotations && targetAnnotations.length > 0) {
+      sortedEntries[key] = Object.freeze(
+        targetAnnotations.map((annotation) => freezeAnnotation(annotation)),
+      );
+    }
+  }
+
+  return {
+    annotations: Object.freeze({
+      schemaHash: schema.hash,
+      entries: Object.freeze(sortedEntries),
+    }),
+    diagnostics,
+  };
+}
+
+function collectAnnotationsForTarget(
+  annotations: readonly AnnotationNode[] | undefined,
+  targetKey: LocalTargetKey,
+  diagnostics: Diagnostic[],
+  entries: EntryMap,
+): void {
+  if (!annotations || annotations.length === 0) {
+    return;
+  }
+
+  const emitted: Annotation[] = [];
+  for (const annotation of annotations) {
+    const payloadResult = annotation.payload === undefined
+      ? { ok: true as const, value: undefined }
+      : exprToJsonLiteral(annotation.payload, 0, diagnostics);
+
+    if (!payloadResult.ok) {
+      continue;
+    }
+
+    emitted.push({
+      tag: annotation.tag,
+      ...(payloadResult.value === undefined ? {} : { payload: payloadResult.value }),
+    });
+  }
+
+  if (emitted.length === 0) {
+    return;
+  }
+
+  const existing = entries.get(targetKey);
+  if (existing) {
+    existing.push(...emitted);
+    return;
+  }
+
+  entries.set(targetKey, emitted);
+}
+
+function collectTypeFieldAnnotations(
+  typeExpr: TypeExprNode,
+  typeName: string,
+  depth: number,
+  diagnostics: Diagnostic[],
+  entries: EntryMap,
+): void {
+  switch (typeExpr.kind) {
+    case "objectType":
+      for (const field of typeExpr.fields) {
+        if (field.annotations?.length) {
+          if (depth === 0) {
+            collectAnnotationsForTarget(
+              field.annotations,
+              `type_field:${typeName}.${field.name}`,
+              diagnostics,
+              entries,
+            );
+          } else {
+            pushInvalidAttachmentDiagnostics(field.annotations, diagnostics);
+          }
+        }
+        collectTypeFieldAnnotations(field.typeExpr, typeName, depth + 1, diagnostics, entries);
+      }
+      return;
+
+    case "arrayType":
+      collectTypeFieldAnnotations(typeExpr.elementType, typeName, depth, diagnostics, entries);
+      return;
+
+    case "recordType":
+      collectTypeFieldAnnotations(typeExpr.keyType, typeName, depth, diagnostics, entries);
+      collectTypeFieldAnnotations(typeExpr.valueType, typeName, depth, diagnostics, entries);
+      return;
+
+    case "unionType":
+      for (const member of typeExpr.types) {
+        collectTypeFieldAnnotations(member, typeName, depth, diagnostics, entries);
+      }
+      return;
+
+    case "simpleType":
+    case "literalType":
+      return;
+  }
+}
+
+function collectUnsupportedTypeFieldAnnotations(
+  typeExpr: TypeExprNode,
+  diagnostics: Diagnostic[],
+): void {
+  switch (typeExpr.kind) {
+    case "objectType":
+      for (const field of typeExpr.fields) {
+        pushInvalidAttachmentDiagnostics(field.annotations, diagnostics);
+        collectUnsupportedTypeFieldAnnotations(field.typeExpr, diagnostics);
+      }
+      return;
+
+    case "arrayType":
+      collectUnsupportedTypeFieldAnnotations(typeExpr.elementType, diagnostics);
+      return;
+
+    case "recordType":
+      collectUnsupportedTypeFieldAnnotations(typeExpr.keyType, diagnostics);
+      collectUnsupportedTypeFieldAnnotations(typeExpr.valueType, diagnostics);
+      return;
+
+    case "unionType":
+      for (const member of typeExpr.types) {
+        collectUnsupportedTypeFieldAnnotations(member, diagnostics);
+      }
+      return;
+
+    case "simpleType":
+    case "literalType":
+      return;
+  }
+}
+
+function collectActionParamAnnotationDiagnostics(
+  action: ActionNode,
+  diagnostics: Diagnostic[],
+): void {
+  for (const param of action.params) {
+    pushActionParamDiagnostics(param, diagnostics);
+  }
+}
+
+function pushActionParamDiagnostics(
+  param: ParamNode,
+  diagnostics: Diagnostic[],
+): void {
+  if (!param.annotations) {
+    return;
+  }
+
+  for (const annotation of param.annotations) {
+    diagnostics.push(createError("E054", INVALID_PARAM_MESSAGE, annotation.location));
+  }
+}
+
+function pushInvalidAttachmentDiagnostics(
+  annotations: readonly AnnotationNode[] | undefined,
+  diagnostics: Diagnostic[],
+): void {
+  if (!annotations) {
+    return;
+  }
+
+  for (const annotation of annotations) {
+    diagnostics.push(createError("E053", INVALID_ATTACHMENT_MESSAGE, annotation.location));
+  }
+}
+
+function exprToJsonLiteral(
+  expr: ExprNode,
+  depth: number,
+  diagnostics: Diagnostic[],
+): { ok: true; value: JsonLiteral } | { ok: false } {
+  switch (expr.kind) {
+    case "literal":
+      if (
+        expr.literalType === "string"
+        || expr.literalType === "number"
+        || expr.literalType === "boolean"
+        || expr.literalType === "null"
+      ) {
+        return { ok: true, value: expr.value as JsonLiteral };
+      }
+      diagnostics.push(createError("E055", INVALID_PAYLOAD_MESSAGE, expr.location));
+      return { ok: false };
+
+    case "arrayLiteral": {
+      if (depth + 1 > MAX_PAYLOAD_DEPTH) {
+        diagnostics.push(createError("E056", PAYLOAD_DEPTH_MESSAGE, expr.location));
+        return { ok: false };
+      }
+
+      const elements: JsonLiteral[] = [];
+      for (const element of expr.elements) {
+        const result = exprToJsonLiteral(element, depth + 1, diagnostics);
+        if (!result.ok) {
+          return { ok: false };
+        }
+        elements.push(result.value);
+      }
+
+      return { ok: true, value: elements };
+    }
+
+    case "objectLiteral": {
+      if (depth + 1 > MAX_PAYLOAD_DEPTH) {
+        diagnostics.push(createError("E056", PAYLOAD_DEPTH_MESSAGE, expr.location));
+        return { ok: false };
+      }
+
+      const objectValue: Record<string, JsonLiteral> = {};
+      for (const property of expr.properties) {
+        const result = exprToJsonLiteral(property.value, depth + 1, diagnostics);
+        if (!result.ok) {
+          return { ok: false };
+        }
+        objectValue[property.key] = result.value;
+      }
+
+      return { ok: true, value: objectValue };
+    }
+
+    default:
+      diagnostics.push(createError("E055", INVALID_PAYLOAD_MESSAGE, expr.location));
+      return { ok: false };
+  }
+}
+
+function freezeAnnotation(annotation: Annotation): Annotation {
+  if (annotation.payload === undefined) {
+    return Object.freeze({ tag: annotation.tag });
+  }
+
+  return Object.freeze({
+    tag: annotation.tag,
+    payload: freezeJsonLiteral(annotation.payload),
+  });
+}
+
+function freezeJsonLiteral(value: JsonLiteral): JsonLiteral {
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map((entry) => freezeJsonLiteral(entry)));
+  }
+
+  if (value !== null && typeof value === "object") {
+    const frozenObject: Record<string, JsonLiteral> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      frozenObject[key] = freezeJsonLiteral(entry);
+    }
+    return Object.freeze(frozenObject);
+  }
+
+  return value;
+}
+
+function hasSchemaTarget(schema: DomainSchema, targetKey: LocalTargetKey): boolean {
+  const separator = targetKey.indexOf(":");
+  if (separator < 0) {
+    return false;
+  }
+
+  const kind = targetKey.slice(0, separator);
+  const name = targetKey.slice(separator + 1);
+
+  switch (kind) {
+    case "domain":
+      return schema.meta?.name === name || schema.id === `mel:${name.toLowerCase()}`;
+
+    case "type":
+      return Object.hasOwn(schema.types, name);
+
+    case "type_field": {
+      const dotIndex = name.indexOf(".");
+      if (dotIndex <= 0 || dotIndex !== name.lastIndexOf(".")) {
+        return false;
+      }
+
+      const typeName = name.slice(0, dotIndex);
+      const fieldName = name.slice(dotIndex + 1);
+      const typeSpec = schema.types[typeName];
+      if (!typeSpec || typeSpec.definition.kind !== "object") {
+        return false;
+      }
+
+      return Object.hasOwn(typeSpec.definition.fields, fieldName);
+    }
+
+    case "state_field":
+      return Object.hasOwn(schema.state.fields, name);
+
+    case "computed":
+      return Object.hasOwn(schema.computed.fields, name);
+
+    case "action":
+      return Object.hasOwn(schema.actions, name);
+
+    default:
+      return false;
+  }
+}
+
+function inferTargetLocation(
+  program: ProgramNode,
+  targetKey: LocalTargetKey,
+): ProgramNode["location"] | null {
+  const separator = targetKey.indexOf(":");
+  if (separator < 0) {
+    return null;
+  }
+
+  const kind = targetKey.slice(0, separator);
+  const name = targetKey.slice(separator + 1);
+  const domain = program.domain;
+
+  if (kind === "domain" && domain.name === name) {
+    return domain.location;
+  }
+
+  if (kind === "type") {
+    return domain.types.find((typeDecl) => typeDecl.name === name)?.location ?? null;
+  }
+
+  if (kind === "type_field") {
+    const dotIndex = name.indexOf(".");
+    if (dotIndex <= 0) {
+      return null;
+    }
+    const typeName = name.slice(0, dotIndex);
+    const fieldName = name.slice(dotIndex + 1);
+    const typeDecl = domain.types.find((candidate) => candidate.name === typeName);
+    if (!typeDecl || typeDecl.typeExpr.kind !== "objectType") {
+      return typeDecl?.location ?? null;
+    }
+    return typeDecl.typeExpr.fields.find((field) => field.name === fieldName)?.location ?? typeDecl.location;
+  }
+
+  if (kind === "state_field") {
+    for (const member of domain.members) {
+      if (member.kind !== "state") continue;
+      const field = member.fields.find((candidate) => candidate.name === name);
+      if (field) return field.location;
+    }
+    return null;
+  }
+
+  if (kind === "computed") {
+    return domain.members.find((member) => member.kind === "computed" && member.name === name)?.location ?? null;
+  }
+
+  if (kind === "action") {
+    return domain.members.find((member) => member.kind === "action" && member.name === name)?.location ?? null;
+  }
+
+  return null;
+}

--- a/packages/compiler/src/api/compile-mel.ts
+++ b/packages/compiler/src/api/compile-mel.ts
@@ -9,13 +9,22 @@
 import type { Diagnostic } from "../diagnostics/types.js";
 import type { DomainSchema } from "../generator/ir.js";
 import type { RuntimeConditionalPatchOp } from "../lowering/lower-runtime-patch.js";
+import type {
+  Annotation,
+  AnnotationIndex,
+  DomainModule,
+  JsonLiteral,
+  LocalTargetKey,
+} from "../annotations.js";
 
+import { buildAnnotationIndex } from "../annotations.js";
 import { tokenize, type Token } from "../lexer/index.js";
 import { parse, type ProgramNode } from "../parser/index.js";
 import { generate } from "../generator/ir.js";
 import { analyzeScope } from "../analyzer/scope.js";
 import { validateSemantics } from "../analyzer/validator.js";
 import { validateAndExpandFlows } from "../analyzer/flow-composition.js";
+import { extractSchemaGraph } from "../schema-graph.js";
 import { compileMelPatchText } from "./compile-mel-patch.js";
 
 // ============ Types ============
@@ -34,6 +43,11 @@ export interface CompileTrace {
  */
 export interface CompileMelDomainOptions {
   mode: "domain";
+  fnTableVersion?: string;
+}
+
+export interface CompileMelModuleOptions {
+  mode: "module";
   fnTableVersion?: string;
 }
 
@@ -63,6 +77,36 @@ export interface CompileMelDomainResult {
    */
   errors: Diagnostic[];
 }
+
+export interface CompileMelModuleResult {
+  /**
+   * Tooling-only compiled module, or null if errors occurred.
+   */
+  module: DomainModule | null;
+
+  /**
+   * Compilation trace.
+   */
+  trace: CompileTrace[];
+
+  /**
+   * Warning diagnostics.
+   */
+  warnings: Diagnostic[];
+
+  /**
+   * Error diagnostics.
+   */
+  errors: Diagnostic[];
+}
+
+export type {
+  Annotation,
+  AnnotationIndex,
+  DomainModule,
+  JsonLiteral,
+  LocalTargetKey,
+} from "../annotations.js";
 
 /**
  * Patch compilation options.
@@ -133,6 +177,51 @@ export function compileMelDomain(
   melText: string,
   options?: CompileMelDomainOptions
 ): CompileMelDomainResult {
+  const result = compileMelArtifacts(melText, options);
+  return {
+    schema: result.schema,
+    trace: result.trace,
+    warnings: result.warnings,
+    errors: result.errors,
+  };
+}
+
+export function compileMelModule(
+  melText: string,
+  options?: CompileMelModuleOptions,
+): CompileMelModuleResult {
+  const result = compileMelArtifacts(melText, options);
+
+  if (result.errors.length > 0 || !result.schema || !result.annotations) {
+    return {
+      module: null,
+      trace: result.trace,
+      warnings: result.warnings,
+      errors: result.errors,
+    };
+  }
+
+  return {
+    module: createDomainModule(result.schema, result.annotations),
+    trace: result.trace,
+    warnings: result.warnings,
+    errors: result.errors,
+  };
+}
+
+interface CompileMelArtifactsResult {
+  program: ProgramNode | null;
+  schema: DomainSchema | null;
+  annotations: AnnotationIndex | null;
+  trace: CompileTrace[];
+  warnings: Diagnostic[];
+  errors: Diagnostic[];
+}
+
+function compileMelArtifacts(
+  melText: string,
+  _options?: CompileMelDomainOptions | CompileMelModuleOptions,
+): CompileMelArtifactsResult {
   const trace: CompileTrace[] = [];
   const warnings: Diagnostic[] = [];
   const errors: Diagnostic[] = [];
@@ -149,7 +238,7 @@ export function compileMelDomain(
     if (lexErrors.length > 0) {
       errors.push(...lexErrors);
       trace.push({ phase: "lex", durationMs: performance.now() - lexStart, details: { tokenCount: tokens.length } });
-      return { schema: null, trace, warnings, errors };
+      return { program: null, schema: null, annotations: null, trace, warnings, errors };
     }
     const lexWarnings = lexResult.diagnostics.filter(d => d.severity === "warning");
     warnings.push(...lexWarnings);
@@ -162,7 +251,7 @@ export function compileMelDomain(
       location: { start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 1, offset: 0 } },
     });
     trace.push({ phase: "lex", durationMs: performance.now() - lexStart });
-    return { schema: null, trace, warnings, errors };
+    return { program: null, schema: null, annotations: null, trace, warnings, errors };
   }
   trace.push({ phase: "lex", durationMs: performance.now() - lexStart, details: { tokenCount: tokens.length } });
 
@@ -175,7 +264,7 @@ export function compileMelDomain(
     if (parseErrors.length > 0) {
       errors.push(...parseErrors);
       trace.push({ phase: "parse", durationMs: performance.now() - parseStart });
-      return { schema: null, trace, warnings, errors: capDiagnostics(errors) };
+      return { program: null, schema: null, annotations: null, trace, warnings, errors: capDiagnostics(errors) };
     }
     ast = parseResult.program as ProgramNode;
   } catch (e) {
@@ -187,7 +276,7 @@ export function compileMelDomain(
       location: { start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 1, offset: 0 } },
     });
     trace.push({ phase: "parse", durationMs: performance.now() - parseStart });
-    return { schema: null, trace, warnings, errors };
+    return { program: null, schema: null, annotations: null, trace, warnings, errors };
   }
   trace.push({ phase: "parse", durationMs: performance.now() - parseStart });
 
@@ -214,7 +303,14 @@ export function compileMelDomain(
 
   if (analyzeErrors.length > 0) {
     errors.push(...analyzeErrors);
-    return { schema: null, trace, warnings, errors };
+    return {
+      program: flowResult.program,
+      schema: null,
+      annotations: null,
+      trace,
+      warnings,
+      errors: capDiagnostics(errors),
+    };
   }
 
   // Phase 3: Generate IR
@@ -231,12 +327,72 @@ export function compileMelDomain(
     }
   }
 
+  if (genResult.schema) {
+    const annotationResult = buildAnnotationIndex(flowResult.program, genResult.schema);
+    const annotationWarnings = annotationResult.diagnostics.filter((d) => d.severity === "warning");
+    const annotationErrors = annotationResult.diagnostics.filter((d) => d.severity === "error");
+    warnings.push(...annotationWarnings);
+    errors.push(...annotationErrors);
+
+    if (annotationErrors.length > 0) {
+      return {
+        program: flowResult.program,
+        schema: null,
+        annotations: null,
+        trace,
+        warnings,
+        errors: capDiagnostics(errors),
+      };
+    }
+
+    return {
+      program: flowResult.program,
+      schema: genResult.schema,
+      annotations: annotationResult.annotations,
+      trace,
+      warnings,
+      errors: capDiagnostics(errors),
+    };
+  }
+
   return {
-    schema: genResult.schema,
+    program: flowResult.program,
+    schema: null,
+    annotations: null,
     trace,
     warnings,
     errors: capDiagnostics(errors),
   };
+}
+
+function createDomainModule(
+  schema: DomainSchema,
+  annotations: AnnotationIndex,
+): DomainModule {
+  return Object.freeze({
+    schema,
+    graph: deepFreeze(extractSchemaGraph(schema)),
+    annotations,
+  });
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      deepFreeze(entry);
+    }
+    return Object.freeze(value);
+  }
+
+  for (const entry of Object.values(value)) {
+    deepFreeze(entry);
+  }
+
+  return Object.freeze(value);
 }
 
 /** Cap diagnostics to prevent error flooding in output. */

--- a/packages/compiler/src/api/index.ts
+++ b/packages/compiler/src/api/index.ts
@@ -7,11 +7,18 @@
  */
 
 export type {
+  Annotation,
+  AnnotationIndex,
   CompileTrace,
   CompileMelDomainOptions,
   CompileMelDomainResult,
+  CompileMelModuleOptions,
+  CompileMelModuleResult,
   CompileMelPatchOptions,
   CompileMelPatchResult,
+  DomainModule,
+  JsonLiteral,
+  LocalTargetKey,
 } from "./compile-mel.js";
 
-export { compileMelDomain, compileMelPatch } from "./compile-mel.js";
+export { compileMelDomain, compileMelModule, compileMelPatch } from "./compile-mel.js";

--- a/packages/compiler/src/diagnostics/codes.ts
+++ b/packages/compiler/src/diagnostics/codes.ts
@@ -239,6 +239,31 @@ export const DIAGNOSTIC_CODES: Record<string, DiagnosticCode> = {
     message: "Invalid argmax()/argmin() form",
     category: "semantic",
   },
+  E053: {
+    code: "E053",
+    message: "@meta can attach only to domain, type, type field, state field, computed, or action declarations",
+    category: "syntax",
+  },
+  E054: {
+    code: "E054",
+    message: "Action-parameter annotations are not part of the current MEL syntax",
+    category: "syntax",
+  },
+  E055: {
+    code: "E055",
+    message: "Annotation payloads must be JSON-like literals",
+    category: "semantic",
+  },
+  E056: {
+    code: "E056",
+    message: "Annotation payload nesting exceeds the current MEL limit of 2 levels",
+    category: "semantic",
+  },
+  E057: {
+    code: "E057",
+    message: "Annotation target does not map to the emitted DomainSchema",
+    category: "semantic",
+  },
 
   // ============ Scope Errors (E1xx) ============
   E_UNDEFINED: {

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -84,10 +84,8 @@ export * from "./evaluation/index.js";
 // ════════════════════════════════════════════════════════════════════════════
 
 export * from "./api/index.js";
+export * from "./annotations.js";
 export * from "./schema-graph.js";
-
-// Compatibility type used in docs for `.mel` module declarations
-export type { DomainSchema as DomainModule } from "./generator/ir.js";
 
 // ===========================================================================
 // Legacy compatibility API
@@ -96,6 +94,7 @@ export type { DomainSchema as DomainModule } from "./generator/ir.js";
 import type { ParseResult } from "./parser/index.js";
 import { analyzeScope, validateSemantics } from "./analyzer/index.js";
 import { validateAndExpandFlows } from "./analyzer/flow-composition.js";
+import { buildAnnotationIndex } from "./annotations.js";
 import { generate, type GenerateResult } from "./generator/ir.js";
 import { lowerSystemValues, type DomainSchema } from "./generator/index.js";
 import type { CompileTrace } from "./api/index.js";
@@ -190,6 +189,11 @@ export function compile(source: string, options: CompileOptions = {}): CompileRe
   const genResult: GenerateResult = generate(flowResult.program);
   diagnostics.push(...genResult.diagnostics);
   trace.push({ phase: "generate", durationMs: performance.now() - generateStart });
+
+  if (!options.skipSemanticAnalysis && genResult.schema) {
+    const annotationResult = buildAnnotationIndex(flowResult.program, genResult.schema);
+    diagnostics.push(...annotationResult.diagnostics);
+  }
 
   if (options.skipSemanticAnalysis) {
     diagnostics.push(...parseResult.diagnostics);

--- a/packages/compiler/src/lexer/lexer.ts
+++ b/packages/compiler/src/lexer/lexer.ts
@@ -81,6 +81,7 @@ export class Lexer {
       case "*": this.addToken("STAR"); break;
       case "%": this.addToken("PERCENT"); break;
       case ":": this.addToken("COLON"); break;
+      case "@": this.addToken("AT"); break;
 
       // Two-character tokens
       case "=":

--- a/packages/compiler/src/lexer/tokens.ts
+++ b/packages/compiler/src/lexer/tokens.ts
@@ -52,6 +52,7 @@ export type TokenKind =
   | "QUESTION" // ?
   | "COLON" // :
   | "EQ" // =
+  | "AT" // @
   // Delimiters
   | "LPAREN" // (
   | "RPAREN" // )

--- a/packages/compiler/src/mel-module.ts
+++ b/packages/compiler/src/mel-module.ts
@@ -18,6 +18,11 @@ export function formatDiagnostic(diagnostic: Diagnostic): string {
   return `[${diagnostic.code}] ${diagnostic.message} (${line}:${column})`;
 }
 
+export function renderSchemaModuleCode(schema: unknown): string {
+  const serializedSchema = JSON.stringify(schema, null, 2);
+  return `export default ${serializedSchema};\n`;
+}
+
 /**
  * Compile MEL source and emit ESM source that exports the compiled schema.
  *
@@ -36,7 +41,5 @@ export function compileMelToModuleCode(melSource: string, sourceId: string): str
     throw new Error(`MEL compilation produced no schema for ${sourceId}`);
   }
 
-  const serializedSchema = JSON.stringify(result.schema, null, 2);
-  return `export default ${serializedSchema};\n`;
+  return renderSchemaModuleCode(result.schema);
 }
-

--- a/packages/compiler/src/parser/ast.ts
+++ b/packages/compiler/src/parser/ast.ts
@@ -40,9 +40,19 @@ export interface ImportNode extends ASTNode {
 export interface DomainNode extends ASTNode {
   kind: "domain";
   name: string;
+  annotations?: AnnotationNode[];
   /** v0.3.3: Named type declarations */
   types: TypeDeclNode[];
   members: DomainMember[];
+}
+
+/**
+ * Structural annotation declaration.
+ */
+export interface AnnotationNode extends ASTNode {
+  kind: "annotation";
+  tag: string;
+  payload?: ExprNode;
 }
 
 /**
@@ -57,6 +67,7 @@ export type DomainMember = StateNode | ComputedNode | ActionNode | FlowDeclNode;
 export interface TypeDeclNode extends ASTNode {
   kind: "typeDecl";
   name: string;
+  annotations?: AnnotationNode[];
   typeExpr: TypeExprNode;
 }
 
@@ -76,6 +87,7 @@ export interface StateNode extends ASTNode {
 export interface StateFieldNode extends ASTNode {
   kind: "stateField";
   name: string;
+  annotations?: AnnotationNode[];
   typeExpr: TypeExprNode;
   initializer?: ExprNode;
 }
@@ -88,6 +100,7 @@ export interface StateFieldNode extends ASTNode {
 export interface ComputedNode extends ASTNode {
   kind: "computed";
   name: string;
+  annotations?: AnnotationNode[];
   expression: ExprNode;
 }
 
@@ -99,6 +112,7 @@ export interface ComputedNode extends ASTNode {
 export interface ActionNode extends ASTNode {
   kind: "action";
   name: string;
+  annotations?: AnnotationNode[];
   params: ParamNode[];
   /** v0.3.2: Optional availability condition */
   available?: ExprNode;
@@ -124,6 +138,7 @@ export interface FlowDeclNode extends ASTNode {
 export interface ParamNode extends ASTNode {
   kind: "param";
   name: string;
+  annotations?: AnnotationNode[];
   typeExpr: TypeExprNode;
 }
 
@@ -306,6 +321,7 @@ export interface ObjectTypeNode extends ASTNode {
 export interface TypeFieldNode extends ASTNode {
   kind: "typeField";
   name: string;
+  annotations?: AnnotationNode[];
   typeExpr: TypeExprNode;
   optional: boolean;
 }

--- a/packages/compiler/src/parser/parser.ts
+++ b/packages/compiler/src/parser/parser.ts
@@ -11,6 +11,7 @@ import {
   type ProgramNode,
   type DomainNode,
   type DomainMember,
+  type AnnotationNode,
   type TypeDeclNode,    // v0.3.3
   type StateNode,
   type StateFieldNode,
@@ -90,7 +91,11 @@ export class Parser {
     }
 
     // Parse domain
-    const domain = this.parseDomain();
+    const domainAnnotations = this.parseAnnotationList();
+    if (domainAnnotations.length > 0 && !this.check("DOMAIN")) {
+      this.reportUnsupportedAnnotations(domainAnnotations);
+    }
+    const domain = this.parseDomain(domainAnnotations);
 
     return {
       kind: "program",
@@ -121,24 +126,23 @@ export class Parser {
     };
   }
 
-  private parseDomain(): DomainNode {
+  private parseDomain(annotations: AnnotationNode[] = []): DomainNode {
     const start = this.consume("DOMAIN", "Expected 'domain'").location;
     const name = this.consume("IDENTIFIER", "Expected domain name").lexeme;
     this.consume("LBRACE", "Expected '{' after domain name");
 
-    // v0.3.3: Parse type declarations first
     const types: TypeDeclNode[] = [];
-    while (this.check("TYPE") && !this.isAtEnd()) {
-      types.push(this.parseTypeDecl());
-    }
-
     const members: DomainMember[] = [];
     while (!this.check("RBRACE") && !this.isAtEnd()) {
-      // v0.3.3: type declarations can appear anywhere in domain
+      const memberAnnotations = this.parseAnnotationList();
+      if (memberAnnotations.length > 0 && (this.check("RBRACE") || this.isAtEnd())) {
+        this.reportUnsupportedAnnotations(memberAnnotations);
+        continue;
+      }
       if (this.check("TYPE")) {
-        types.push(this.parseTypeDecl());
+        types.push(this.parseTypeDecl(memberAnnotations));
       } else {
-        const member = this.parseDomainMember();
+        const member = this.parseDomainMember(memberAnnotations);
         if (member) members.push(member);
       }
     }
@@ -148,6 +152,7 @@ export class Parser {
     return {
       kind: "domain",
       name,
+      annotations: annotations.length > 0 ? annotations : undefined,
       types,
       members,
       location: mergeLocations(start, end),
@@ -158,7 +163,7 @@ export class Parser {
    * v0.3.3: Parse type declaration
    * Syntax: type Name = TypeExpr
    */
-  private parseTypeDecl(): TypeDeclNode {
+  private parseTypeDecl(annotations: AnnotationNode[] = []): TypeDeclNode {
     const start = this.consume("TYPE", "Expected 'type'").location;
     const name = this.consume("IDENTIFIER", "Expected type name").lexeme;
     this.consume("EQ", "Expected '=' after type name");
@@ -167,17 +172,25 @@ export class Parser {
     return {
       kind: "typeDecl",
       name,
+      annotations: annotations.length > 0 ? annotations : undefined,
       typeExpr,
       location: mergeLocations(start, typeExpr.location),
     };
   }
 
-  private parseDomainMember(): DomainMember | null {
-    if (this.check("STATE")) return this.parseState();
-    if (this.check("COMPUTED")) return this.parseComputed();
-    if (this.check("ACTION")) return this.parseAction();
-    if (this.isFlowDeclContext()) return this.parseFlowDecl();
+  private parseDomainMember(annotations: AnnotationNode[] = []): DomainMember | null {
+    if (this.check("STATE")) {
+      this.reportUnsupportedAnnotations(annotations);
+      return this.parseState();
+    }
+    if (this.check("COMPUTED")) return this.parseComputed(annotations);
+    if (this.check("ACTION")) return this.parseAction(annotations);
+    if (this.isFlowDeclContext()) {
+      this.reportUnsupportedAnnotations(annotations);
+      return this.parseFlowDecl();
+    }
 
+    this.reportUnsupportedAnnotations(annotations);
     this.error(`Unexpected token '${this.peek().lexeme}'. Expected 'state', 'computed', 'action', or 'flow'.`);
     this.advance(); // Skip the bad token
     return null;
@@ -191,7 +204,12 @@ export class Parser {
 
     const fields: StateFieldNode[] = [];
     while (!this.check("RBRACE") && !this.isAtEnd()) {
-      fields.push(this.parseStateField());
+      const fieldAnnotations = this.parseAnnotationList();
+      if (fieldAnnotations.length > 0 && (this.check("RBRACE") || this.isAtEnd())) {
+        this.reportUnsupportedAnnotations(fieldAnnotations);
+        continue;
+      }
+      fields.push(this.parseStateField(fieldAnnotations));
     }
 
     const end = this.consume("RBRACE", "Expected '}' to close state block").location;
@@ -203,7 +221,7 @@ export class Parser {
     };
   }
 
-  private parseStateField(): StateFieldNode {
+  private parseStateField(annotations: AnnotationNode[] = []): StateFieldNode {
     const nameToken = this.consume("IDENTIFIER", "Expected field name");
     this.consume("COLON", "Expected ':' after field name");
     const typeExpr = this.parseTypeExpr();
@@ -216,6 +234,7 @@ export class Parser {
     return {
       kind: "stateField",
       name: nameToken.lexeme,
+      annotations: annotations.length > 0 ? annotations : undefined,
       typeExpr,
       initializer,
       location: mergeLocations(
@@ -227,7 +246,7 @@ export class Parser {
 
   // ============ Computed ============
 
-  private parseComputed(): ComputedNode {
+  private parseComputed(annotations: AnnotationNode[] = []): ComputedNode {
     const start = this.consume("COMPUTED", "Expected 'computed'").location;
     const name = this.consume("IDENTIFIER", "Expected computed name").lexeme;
     this.consume("EQ", "Expected '=' after computed name");
@@ -236,6 +255,7 @@ export class Parser {
     return {
       kind: "computed",
       name,
+      annotations: annotations.length > 0 ? annotations : undefined,
       expression,
       location: mergeLocations(start, expression.location),
     };
@@ -243,7 +263,7 @@ export class Parser {
 
   // ============ Action ============
 
-  private parseAction(): ActionNode {
+  private parseAction(annotations: AnnotationNode[] = []): ActionNode {
     const start = this.consume("ACTION", "Expected 'action'").location;
     const name = this.consume("IDENTIFIER", "Expected action name").lexeme;
     this.consume("LPAREN", "Expected '(' after action name");
@@ -251,7 +271,12 @@ export class Parser {
     const params: ParamNode[] = [];
     if (!this.check("RPAREN")) {
       do {
-        params.push(this.parseParam());
+        const paramAnnotations = this.parseAnnotationList();
+        if (paramAnnotations.length > 0 && (this.check("RPAREN") || this.isAtEnd())) {
+          this.reportUnsupportedAnnotations(paramAnnotations);
+          break;
+        }
+        params.push(this.parseParam(paramAnnotations));
       } while (this.match("COMMA"));
     }
 
@@ -291,6 +316,7 @@ export class Parser {
     return {
       kind: "action",
       name,
+      annotations: annotations.length > 0 ? annotations : undefined,
       params,
       available,
       dispatchable,
@@ -307,7 +333,12 @@ export class Parser {
     const params: ParamNode[] = [];
     if (!this.check("RPAREN")) {
       do {
-        params.push(this.parseParam());
+        const paramAnnotations = this.parseAnnotationList();
+        this.reportUnsupportedAnnotations(paramAnnotations);
+        if (paramAnnotations.length > 0 && (this.check("RPAREN") || this.isAtEnd())) {
+          break;
+        }
+        params.push(this.parseParam(paramAnnotations));
       } while (this.match("COMMA"));
     }
 
@@ -331,7 +362,7 @@ export class Parser {
     };
   }
 
-  private parseParam(): ParamNode {
+  private parseParam(annotations: AnnotationNode[] = []): ParamNode {
     const nameToken = this.consume("IDENTIFIER", "Expected parameter name");
     this.consume("COLON", "Expected ':' after parameter name");
     const typeExpr = this.parseTypeExpr();
@@ -339,6 +370,7 @@ export class Parser {
     return {
       kind: "param",
       name: nameToken.lexeme,
+      annotations: annotations.length > 0 ? annotations : undefined,
       typeExpr,
       location: mergeLocations(nameToken.location, typeExpr.location),
     };
@@ -347,6 +379,9 @@ export class Parser {
   // ============ Statements ============
 
   private parseGuardedStmt(): GuardedStmtNode | null {
+    const annotations = this.parseAnnotationList();
+    this.reportUnsupportedAnnotations(annotations);
+
     if (this.check("WHEN")) return this.parseWhenStmt();
     if (this.check("ONCE")) return this.parseOnceStmt();
     if (this.isOnceIntentContext()) return this.parseOnceIntentStmt();
@@ -373,6 +408,9 @@ export class Parser {
   }
 
   private parseFlowStmt(): FlowStmtNode | null {
+    const annotations = this.parseAnnotationList();
+    this.reportUnsupportedAnnotations(annotations);
+
     if (this.check("WHEN")) return this.parseWhenStmt();
     if (this.isIncludeContext()) return this.parseIncludeStmt();
     if (this.check("ONCE")) return this.parseOnceStmt();
@@ -495,6 +533,9 @@ export class Parser {
   }
 
   private parseInnerStmt(): InnerStmtNode | null {
+    const annotations = this.parseAnnotationList();
+    this.reportUnsupportedAnnotations(annotations);
+
     if (this.check("PATCH")) return this.parsePatchStmt();
     if (this.check("EFFECT")) return this.parseEffectStmt();
     if (this.check("WHEN")) return this.parseWhenStmt();
@@ -760,6 +801,11 @@ export class Parser {
     const fields: TypeFieldNode[] = [];
 
     while (!this.check("RBRACE") && !this.isAtEnd()) {
+      const annotations = this.parseAnnotationList();
+      if (annotations.length > 0 && (this.check("RBRACE") || this.isAtEnd())) {
+        this.reportUnsupportedAnnotations(annotations);
+        continue;
+      }
       const nameToken = this.consume("IDENTIFIER", "Expected field name");
       const optional = this.match("QUESTION");
       this.consume("COLON", "Expected ':' after field name");
@@ -768,6 +814,7 @@ export class Parser {
       fields.push({
         kind: "typeField",
         name: nameToken.lexeme,
+        annotations: annotations.length > 0 ? annotations : undefined,
         typeExpr,
         optional,
         location: mergeLocations(nameToken.location, typeExpr.location),
@@ -1110,7 +1157,7 @@ export class Parser {
     const prev = this.previous();
     const unaryPrecedingTokens: TokenKind[] = [
       "LPAREN", "LBRACKET", "LBRACE", "COMMA", "COLON", "EQ",
-      "PLUS", "MINUS", "STAR", "SLASH", "PERCENT",
+      "PLUS", "MINUS", "STAR", "SLASH", "PERCENT", "AT",
       "EQ_EQ", "BANG_EQ", "LT", "LT_EQ", "GT", "GT_EQ",
       "AMP_AMP", "PIPE_PIPE", "BANG", "QUESTION", "QUESTION_QUESTION",
     ];
@@ -1187,6 +1234,52 @@ export class Parser {
     throw this.errorAtCurrent(message);
   }
 
+  private parseAnnotationList(): AnnotationNode[] {
+    const annotations: AnnotationNode[] = [];
+
+    while (this.check("AT")) {
+      annotations.push(this.parseAnnotation());
+    }
+
+    return annotations;
+  }
+
+  private parseAnnotation(): AnnotationNode {
+    const start = this.consume("AT", "Expected '@'").location;
+    const nameToken = this.consume("IDENTIFIER", "Expected annotation name after '@'");
+    if (nameToken.lexeme !== "meta") {
+      throw this.errorAtToken(nameToken, "Expected 'meta' after '@'");
+    }
+
+    this.consume("LPAREN", "Expected '(' after '@meta'");
+    const tagToken = this.consume("STRING", "Expected string tag as first @meta argument");
+
+    let payload: ExprNode | undefined;
+    if (this.match("COMMA")) {
+      payload = this.parseExpression();
+    }
+
+    const end = this.consume("RPAREN", "Expected ')' after @meta arguments").location;
+
+    return {
+      kind: "annotation",
+      tag: tagToken.value as string,
+      payload,
+      location: mergeLocations(start, end),
+    };
+  }
+
+  private reportUnsupportedAnnotations(annotations: readonly AnnotationNode[]): void {
+    for (const annotation of annotations) {
+      this.diagnostics.push({
+        severity: "error",
+        code: "E053",
+        message: "@meta can attach only to domain, type, type field, state field, computed, or action declarations.",
+        location: annotation.location,
+      });
+    }
+  }
+
   private error(message: string): void {
     this.diagnostics.push({
       severity: "error",
@@ -1202,6 +1295,16 @@ export class Parser {
       code: "MEL_PARSER",
       message,
       location: this.peek().location,
+    });
+    return new Error(message);
+  }
+
+  private errorAtToken(token: Token, message: string): Error {
+    this.diagnostics.push({
+      severity: "error",
+      code: "MEL_PARSER",
+      message,
+      location: token.location,
     });
     return new Error(message);
   }

--- a/packages/compiler/src/unplugin.ts
+++ b/packages/compiler/src/unplugin.ts
@@ -9,7 +9,7 @@ import * as nodePath from "node:path";
 import { createUnplugin } from "unplugin";
 import type { DomainSchema } from "@manifesto-ai/core";
 import { compileMelDomain } from "./api/index.js";
-import { formatDiagnostic } from "./mel-module.js";
+import { formatDiagnostic, renderSchemaModuleCode } from "./mel-module.js";
 
 export type MelCodegenArtifact = {
   readonly schema: DomainSchema;
@@ -143,8 +143,7 @@ export const unpluginMel = createUnplugin((options: MelPluginOptions = {}) => {
         }
       }
 
-      const serializedSchema = JSON.stringify(result.schema, null, 2);
-      return `export default ${serializedSchema};\n`;
+      return renderSchemaModuleCode(result.schema);
     },
 
     async buildEnd() {

--- a/packages/sdk/docs/sdk-SPEC.md
+++ b/packages/sdk/docs/sdk-SPEC.md
@@ -8,7 +8,7 @@
 
 > **Historical Note:** Pre-ADR-017 SDK surfaces live in Git history. They are no longer kept as active package docs in the working tree.
 >
-> **Current Contract Status:** Projected introspection, intent-level dispatchability, refined single-parameter object binding in `createIntent()`, the `@manifesto-ai/sdk/extensions` Extension Kernel, the first-party `createSimulationSession()` helper on that seam, additive intent explanation reads via `explainIntentFor()`, `explainIntent()`, `why()`, and `whyNot()`, and the additive base write-report companion `dispatchAsyncWithReport()` are all part of the current SDK contract. The compiler-side extraction contract now lives in [SPEC-v1.0.0](../../compiler/docs/SPEC-v1.0.0.md).
+> **Current Contract Status:** Projected introspection, intent-level dispatchability, refined single-parameter object binding in `createIntent()`, the `@manifesto-ai/sdk/extensions` Extension Kernel, the first-party `createSimulationSession()` helper on that seam, additive intent explanation reads via `explainIntentFor()`, `explainIntent()`, `why()`, and `whyNot()`, and the additive base write-report companion `dispatchAsyncWithReport()` are all part of the current SDK contract. The compiler-side extraction contract now lives in [SPEC-v1.0.0](../../compiler/docs/SPEC-v1.0.0.md), including tooling-only structural annotations via `@meta`.
 
 ## 1. Purpose
 
@@ -527,6 +527,8 @@ If `schema` is a string, SDK MUST compile it as MEL domain source before exposin
 
 If `schema` is a compiled `DomainSchema`, SDK MUST still normalize it before exposing `ComposableManifesto.schema`.
 
+Compiler tooling artifacts that bundle schema-side metadata, such as `DomainModule`, are outside this runtime seam. Callers MUST pass `DomainSchema` only.
+
 Normalization includes:
 
 - platform namespace injection for `$host`
@@ -563,6 +565,7 @@ The `snapshot` in `EffectContext` MUST reflect the current projected snapshot vi
 | SDK-CREATE-8 | MUST | SDK MUST reject user effects that override reserved effect types with `ReservedEffectError` |
 | SDK-CREATE-9 | MUST | SDK MUST reject action names using reserved namespace prefixes with `ManifestoError` code `RESERVED_NAMESPACE` |
 | SDK-CREATE-10 | MUST | SDK MUST inject platform namespaces needed by compiler/host coordination before activation |
+| SDK-CREATE-11 | MUST NOT | SDK MUST NOT accept compiler tooling artifacts such as `DomainModule` in place of `DomainSchema` |
 
 ## 7. Activated Base Surface
 
@@ -894,6 +897,7 @@ Admitted results MUST expose the canonical simulated snapshot, the projected pub
 `getSchemaGraph()` returns the current instance's projected static dependency graph.
 
 The graph MUST be derived from the activated `DomainSchema` alone. It MUST NOT depend on the current snapshot or dispatch history.
+Compiler-side annotation sidecars or other tooling-only metadata MUST NOT participate in graph derivation.
 
 The SDK SHOULD compute the graph once at activation time and cache it for the lifetime of the instance.
 
@@ -1412,6 +1416,7 @@ Required stable codes:
 - SDK v3 is a super hard cut, not a migration layer.
 - Re-activating the same composable manifesto is a programmer error.
 - The visible snapshot is always mutation-safe from the caller side.
+- Runtime schema input remains `DomainSchema | string`; tooling-only compiler artifacts such as `DomainModule` are not accepted by `createManifesto()`.
 
 ## 12. Compliance Checklist
 
@@ -1426,6 +1431,7 @@ An SDK v3.x implementation complies with this living contract only if all of the
 - `createIntent()` is keyed by `MEL.actions.*`, not raw string action names.
 - `dispatchAsync()` is FIFO per instance and evaluates availability, then input validation, then dispatchability at dequeue time.
 - `dispatchAsyncWithReport()` is additive, reuses the same legality ordering and projected diff semantics, and does not change `dispatchAsync()` publication behavior.
+- `createManifesto()` accepts MEL source or `DomainSchema`, but not tooling-only compiler artifacts such as `DomainModule`.
 - `getSchemaGraph()` exposes the projected static graph only and accepts refs as the canonical lookup surface.
 - `simulate()` is a pure dry-run that applies both `apply()` and `applySystemDelta()` and treats `changedPaths` as inspection/debug-only.
 - `@manifesto-ai/sdk/extensions` exposes `getExtensionKernel()` with pure canonical-input arbitrary-snapshot helpers, including `explainIntentFor()`, and no runtime-control methods.

--- a/packages/sdk/src/__tests__/create-manifesto.test.ts
+++ b/packages/sdk/src/__tests__/create-manifesto.test.ts
@@ -20,6 +20,30 @@ import {
 } from "./helpers/schema.js";
 
 describe("createManifesto()", () => {
+  it("rejects compiler DomainModule artifacts at the runtime schema seam", () => {
+    const schema = createCounterSchema();
+    const moduleArtifact = {
+      schema,
+      graph: { nodes: [], edges: [] },
+      annotations: {
+        schemaHash: schema.hash,
+        entries: {},
+      },
+    };
+
+    expect(() =>
+      createManifesto(
+        moduleArtifact as unknown as DomainSchema,
+        {},
+      ),
+    ).toThrowError(
+      expect.objectContaining<Partial<ManifestoError>>({
+        code: "SCHEMA_ERROR",
+        message: expect.stringContaining("DomainModule"),
+      }),
+    );
+  });
+
   it("returns a composable manifesto with normalized schema and no runtime verbs", () => {
     const manifesto = createManifesto<CounterDomain>(createCounterSchema(), {});
 

--- a/packages/sdk/src/__tests__/create-manifesto.test.ts
+++ b/packages/sdk/src/__tests__/create-manifesto.test.ts
@@ -44,6 +44,23 @@ describe("createManifesto()", () => {
     );
   });
 
+  it("does not reject a DomainSchema when DomainModule-shaped keys only exist on the prototype", () => {
+    const schema = createCounterSchema();
+    const inheritedDomainModuleShape = {
+      schema: "prototype-only",
+      graph: { nodes: [], edges: [] },
+      annotations: { schemaHash: schema.hash, entries: {} },
+    };
+    const schemaWithInheritedKeys = Object.assign(
+      Object.create(inheritedDomainModuleShape) as DomainSchema,
+      schema,
+    );
+
+    expect(() =>
+      createManifesto<CounterDomain>(schemaWithInheritedKeys, {}),
+    ).not.toThrow();
+  });
+
   it("returns a composable manifesto with normalized schema and no runtime verbs", () => {
     const manifesto = createManifesto<CounterDomain>(createCounterSchema(), {});
 

--- a/packages/sdk/src/manifest/resolve-schema.ts
+++ b/packages/sdk/src/manifest/resolve-schema.ts
@@ -23,6 +23,13 @@ import {
 } from "./shared.js";
 
 export function resolveSchema(schema: DomainSchema | string): ResolvedSchema {
+  if (typeof schema !== "string" && isDomainModuleArtifact(schema)) {
+    throw new ManifestoError(
+      "SCHEMA_ERROR",
+      "DomainModule is a compiler tooling artifact. Pass module.schema or MEL source to createManifesto().",
+    );
+  }
+
   const resolved: CompiledSchema = typeof schema === "string"
     ? compileSchema(schema)
     : {
@@ -40,6 +47,20 @@ export function resolveSchema(schema: DomainSchema | string): ResolvedSchema {
     actionSingleParamObjectValueMetadata: resolved.actionSingleParamObjectValueMetadata,
     projectionPlan: buildSnapshotProjectionPlan(normalizedSchema),
   };
+}
+
+function isDomainModuleArtifact(
+  schema: DomainSchema,
+): schema is DomainSchema & {
+  schema: unknown;
+  graph: unknown;
+  annotations: unknown;
+} {
+  return typeof schema === "object"
+    && schema !== null
+    && "schema" in schema
+    && "graph" in schema
+    && "annotations" in schema;
 }
 
 function withPlatformNamespaces(schema: DomainSchema): DomainSchema {

--- a/packages/sdk/src/manifest/resolve-schema.ts
+++ b/packages/sdk/src/manifest/resolve-schema.ts
@@ -58,9 +58,9 @@ function isDomainModuleArtifact(
 } {
   return typeof schema === "object"
     && schema !== null
-    && "schema" in schema
-    && "graph" in schema
-    && "annotations" in schema;
+    && Object.hasOwn(schema, "schema")
+    && Object.hasOwn(schema, "graph")
+    && Object.hasOwn(schema, "annotations");
 }
 
 function withPlatformNamespaces(schema: DomainSchema): DomainSchema {


### PR DESCRIPTION
## What changed
- add compiler support for `@meta(...)` structural annotations with a tooling-only `AnnotationIndex` sidecar and `compileMelModule()`
- keep runtime seams schema-only while documenting and enforcing `DomainModule` rejection at the SDK boundary
- land the associated compiler/spec/doc updates and compliance coverage for annotation syntax, diagnostics, and semantic erasure invariants

## Why
- MEL needed a first-class structural annotation surface for tooling and downstream consumers without changing `DomainSchema`, `SchemaGraph`, or runtime semantics
- the compiler and SDK needed an explicit boundary between schema runtime inputs and compiler-only module artifacts

## Developer impact
- compiler consumers can now compile MEL into `{ schema, graph, annotations }` through the additive module seam
- runtime consumers still pass `DomainSchema` or MEL source to `createManifesto()`; `DomainModule` remains tooling-only
- docs/specs now describe `@meta` as the current compiler-side structural annotation contract

## Validation
- `pnpm --filter @manifesto-ai/compiler exec vitest run src/__tests__/annotations.test.ts src/__tests__/compliance/suite/annotations.spec.ts src/__tests__/loader-vite.test.ts`
- `pnpm exec vitest run packages/sdk/src/__tests__/create-manifesto.test.ts`