### PR TITLE
feat(compiler): add source map sidecar contract

### DIFF
--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -36,11 +36,12 @@ const module = result.module!;
 
 const manifesto = createManifesto(module.schema, {});
 const annotations = module.annotations;
+const sourceMap = module.sourceMap;
 ```
 
 - `createManifesto()` accepts MEL source or `DomainSchema`.
 - `createManifesto()` does not accept `DomainModule`.
-- tooling may read `module.annotations` and `module.graph`, but runtime remains annotation-blind.
+- tooling may read `module.annotations`, `module.sourceMap`, and `module.graph`, but runtime remains sidecar-blind.
 - importing a `.mel` file through the default loader/bundler path still yields schema-only output, even when the MEL source uses `@meta`.
 
 ## Activation Boundary

--- a/docs/api/compiler.md
+++ b/docs/api/compiler.md
@@ -8,13 +8,14 @@
 
 `@manifesto-ai/compiler` provides the MEL compilation seams used by runtime creation, tooling, and bundler integration.
 
-The current canonical compiler contract is [SPEC-v1.0.0](../../packages/compiler/docs/SPEC-v1.0.0.md).
+The current canonical compiler contract is documented in the [current SPEC index](../internals/spec/index.md), with the compiler pinned to `SPEC-v1.1.0`.
 
 Current compiler responsibilities include:
 - schema-only compilation through `compileMelDomain()`
 - tooling-only module compilation through `compileMelModule()`
 - projected `SchemaGraph` extraction
 - structural annotations via `@meta` as an out-of-schema `AnnotationIndex` sidecar
+- declaration-level source locations as an out-of-schema `SourceMapIndex` sidecar
 - intent-level dispatchability via `dispatchable when`
 - MEL patch lowering through `compileMelPatch()`
 
@@ -35,7 +36,7 @@ if (result.schema) {
 }
 ```
 
-`compileMelDomain()` returns `DomainSchema` only. Structural annotations never appear inside that schema.
+`compileMelDomain()` returns `DomainSchema` only. Structural annotations and source maps never appear inside that schema.
 
 ### `compileMelModule()`
 
@@ -47,7 +48,7 @@ import { compileMelModule } from "@manifesto-ai/compiler";
 const result = compileMelModule(melSource, { mode: "module" });
 
 if (result.module) {
-  const { schema, graph, annotations } = result.module;
+  const { schema, graph, annotations, sourceMap } = result.module;
 }
 ```
 
@@ -58,10 +59,11 @@ type DomainModule = {
   readonly schema: DomainSchema;
   readonly graph: SchemaGraph;
   readonly annotations: AnnotationIndex;
+  readonly sourceMap: SourceMapIndex;
 };
 ```
 
-`annotations` is the compiler-owned sidecar for `@meta`. It remains outside both `DomainSchema` and `SchemaGraph`.
+`annotations` is the compiler-owned sidecar for `@meta`. `sourceMap` is the compiler-owned sidecar for declaration-level MEL provenance. Both remain outside `DomainSchema` and `SchemaGraph`.
 
 ### `compileMelPatch()`
 
@@ -79,8 +81,8 @@ const result = compileMelPatch(patchText, {
 ## Tooling vs Runtime
 
 - Runtime seams consume `DomainSchema`, not `DomainModule`.
-- Tooling can use `compileMelModule()` to read `graph` and `annotations`.
-- If you compile through `compileMelModule()`, pass `module.schema` to runtime creation and keep `module.annotations` external.
+- Tooling can use `compileMelModule()` to read `graph`, `annotations`, and `sourceMap`.
+- If you compile through `compileMelModule()`, pass `module.schema` to runtime creation and keep `module.annotations` and `module.sourceMap` external.
 - `.mel` loader and bundler integrations still default-export compiled `DomainSchema`, even when the source uses `@meta`.
 
 ```typescript
@@ -92,9 +94,10 @@ const module = result.module!;
 
 const app = createManifesto(module.schema, {}).activate();
 const annotations = module.annotations;
+const sourceMap = module.sourceMap;
 ```
 
-## Annotation Sidecar Types
+## Tooling Sidecar Types
 
 ```typescript
 type Annotation = {
@@ -106,12 +109,28 @@ type AnnotationIndex = {
   readonly schemaHash: string;
   readonly entries: Record<LocalTargetKey, readonly Annotation[]>;
 };
+
+type SourceMapIndex = {
+  readonly schemaHash: string;
+  readonly sourceHash: string;
+  readonly format: "manifesto/source-map-v1";
+  readonly coordinateUnit: "utf16" | "bytes";
+  readonly emissionFingerprint: string;
+  readonly entries: Record<LocalTargetKey, SourceMapEntry>;
+};
+
+type SourceMapEntry = {
+  readonly target: SourceMapPath;
+  readonly span: SourceSpan;
+};
 ```
 
 - `schemaHash` matches the emitted `DomainSchema.hash`.
 - `entries` includes annotated targets only.
 - stacked annotations preserve source order.
 - repeated tags are preserved and not deduplicated.
+- `sourceMap` is keyed by the same landed declaration target space and carries physical source spans only.
+- `sourceMap` remains tooling-only and does not participate in runtime schema input, schema hash, or `SchemaGraph` derivation.
 
 ## Patch IR Types
 

--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -274,6 +274,12 @@ _Source: `packages/compiler/src/index.ts`_
 - `SimpleTypeNode`
 - `SkippedRuntimePatch`
 - `SourceLocation`
+- `SourceMapEmissionContext`
+- `SourceMapEntry`
+- `SourceMapIndex`
+- `SourceMapPath`
+- `SourcePoint`
+- `SourceSpan`
 - `StateFieldNode`
 - `StateNode`
 - `StateSpec`

--- a/docs/internals/adr/002-dx-improvement-mel-namespace-onceIntent.md
+++ b/docs/internals/adr/002-dx-improvement-mel-namespace-onceIntent.md
@@ -10,7 +10,7 @@
 - **Date:** 2026-01-27
 - **Status:** Implemented
 - **Implemented-by:**
-  - [Compiler current contract (SPEC-v1.0.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md)
+  - [Compiler current contract (SPEC-v1.1.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)
   - historical SDK v1.0.0 contract (removed from the working tree; see Git history)
   - `packages/compiler/src/parser/parser.ts`, `packages/compiler/src/api/compile-mel-patch-collector.ts`, `packages/compiler/src/__tests__/once-intent.test.ts`, `packages/sdk/src/create-manifesto.ts`
 - **Owners:** 정성우

--- a/docs/internals/adr/009-structured-patch-path.md
+++ b/docs/internals/adr/009-structured-patch-path.md
@@ -6,7 +6,7 @@
 > **Scope:** Core, Compiler, Host, Runtime, World
 > **Resolves:** [#108](https://github.com/manifesto-ai/core/issues/108), [#189](https://github.com/manifesto-ai/core/issues/189)
 > **Supersedes:** None
-> **Implemented-by:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler current contract (SPEC-v1.0.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md), [host-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC.md), and concrete code in `packages/core/src/schema/patch.ts`, `packages/core/src/core/apply.ts`, `packages/compiler/src/lowering/lower-runtime-patch.ts`, plus historical pre-split world/store code paths
+> **Implemented-by:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler current contract (SPEC-v1.1.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md), [host-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC.md), and concrete code in `packages/core/src/schema/patch.ts`, `packages/core/src/core/apply.ts`, `packages/compiler/src/lowering/lower-runtime-patch.ts`, plus historical pre-split world/store code paths
 > **Strengthens:** FDR-015 (Static Patch Paths), FDR-MEL-032 (Dynamic Path Segments)
 > **Breaking:** Yes — Major version bump required for Core, Compiler
 

--- a/docs/internals/adr/012-remove-computed-prefix.md
+++ b/docs/internals/adr/012-remove-computed-prefix.md
@@ -5,7 +5,7 @@
 > **Deciders:** Manifesto Core/Compiler Design Group
 > **Scope:** Core, Compiler, Host, SDK, Docs
 > **Breaking:** Yes
-> **Implemented-by:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler current contract (SPEC-v1.0.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md), and concrete code in `packages/core/src/evaluator/expr.ts`, `packages/core/src/core/explain.ts`
+> **Implemented-by:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler current contract (SPEC-v1.1.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md), and concrete code in `packages/core/src/evaluator/expr.ts`, `packages/core/src/core/explain.ts`
 > **Related:** ADR-001 (Layer Separation), ADR-006 (Canonical rules), ADR-009 (Structured PatchPath), ADR-011 (Boundary contract)
 > **Reason for change:** Developer Ergonomics / API consistency
 

--- a/docs/internals/adr/013a-mel-statement-composition-flow-and-include.md
+++ b/docs/internals/adr/013a-mel-statement-composition-flow-and-include.md
@@ -9,7 +9,7 @@
 > **Related:** ADR-013b (Entity Collection Primitives — separate approval gate)
 > **Supersedes:** ADR-013 (Withdrawn — mixed three independent decisions)
 > **Breaking:** No — additive syntax via contextual keywords; runtime layers unchanged
-> **Implemented In:** Compiler current contract ([SPEC-v1.0.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md)), `packages/compiler/src/analyzer/flow-composition.ts`, analyzer/generator/integration/compliance test suites
+> **Implemented In:** Compiler current contract ([SPEC-v1.1.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)), `packages/compiler/src/analyzer/flow-composition.ts`, analyzer/generator/integration/compliance test suites
 
 ---
 

--- a/docs/internals/adr/013b-entity-collection-primitives.md
+++ b/docs/internals/adr/013b-entity-collection-primitives.md
@@ -10,7 +10,7 @@
 > **Supersedes:** ADR-013 (Withdrawn — mixed three independent decisions)
 > **Breaking:** No — additive builtin functions only; existing syntax unaffected; Core IR unchanged; runtime layers unchanged
 > **Internal Structure:** §4 Query Primitives (013b-1) and §5 Transform Primitives (013b-2) have **separate acceptance criteria** and may be approved independently.
-> **Implemented In:** Compiler current contract ([SPEC-v1.0.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md)), entity primitive lowering/analyzer paths, generator/integration/compliance test suites
+> **Implemented In:** Compiler current contract ([SPEC-v1.1.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)), entity primitive lowering/analyzer paths, generator/integration/compliance test suites
 
 ---
 

--- a/docs/internals/adr/020-intent-level-dispatchability.md
+++ b/docs/internals/adr/020-intent-level-dispatchability.md
@@ -5,7 +5,7 @@
 > **Deciders:** 정성우 (Architect), Manifesto Architecture Team
 > **Scope:** Compiler, Core, SDK, Studio/Introspection, Docs
 > **Related ADRs:** ADR-017 (Capability Decorator Pattern), ADR-018 (Public Snapshot Boundary)
-> **Related SPECs:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), [SPEC-v1.0.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md)
+> **Related SPECs:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), [SPEC-v1.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)
 
 > **Current Contract Authority:** This ADR is implemented. The current behavior now lives in the owning package specs and current MEL docs. This document remains the architectural decision record and original design rationale.
 

--- a/docs/internals/adr/022-compiler-owned-source-location-sidecar-source-map-index.md
+++ b/docs/internals/adr/022-compiler-owned-source-location-sidecar-source-map-index.md
@@ -1,0 +1,778 @@
+# ADR-022: Compiler-Owned Source Location Sidecar (`SourceMapIndex`)
+
+> **Status:** Accepted (v11)
+> **Date:** 2026-04-16
+> **Deciders:** 정성우 (Architect), Manifesto Architecture Team
+> **Scope:** Compiler (MEL output contract), Tooling, Docs
+> **Related ADRs:** ADR-001 (Layer Separation), ADR-009 (Structured PatchPath), ADR-021 (`@meta` Structural Annotation Sidecar)
+> **Related SPECs:** Compiler SPEC v1.0.0, Core SPEC v4.2.0, SDK SPEC v3.x
+> **Breaking:** No — additive tooling-only sidecar; Core/Host/SDK runtime layers unchanged
+> **Preserves:** `DomainSchema` hash, `SchemaGraph`, `AnnotationIndex`, runtime entrypoint contract
+> **Current-truth alignment:** This ADR is subordinate to the owning package SPECs and the current-contract page. Where ambiguity exists, owning package SPEC > current-contract page > this ADR.
+
+---
+
+## 0. Revision Note
+
+### v11 (2026-04-16, acceptance + polish)
+
+**Accepted** after nine review cycles (v2 → v10). Status flips from `Proposed` to `Accepted`. Two non-blocking polish items applied per final review:
+
+- **§14 Compiler SPEC list gains `SourceMapEmissionContext`** as a new type introduced by this ADR. Oversight from v8 when the type was added to §10.2 but not back-referenced in the spec-changes summary.
+- **§15 Review Checklist gains a quick-reference cache key table** at the top, compressing the per-artifact scope (§5.2) into a three-row lookup for scan-speed during review.
+
+No normative change. `SourceMapIndex` shape, cache rules, trace scope, extraction contract, and API-surface rules are byte-identical to v10.
+
+Phase 0 consumer evidence annex is a separate deliverable and not part of this ADR file (see `ADR-022-Phase0-Annex.md` for the skeleton).
+
+### v10 (2026-04-16, eighth review)
+
+Resolves one API-surface representation issue: the ADR's §10.1 entrypoint block read as a public API shape change, conflicting with the header's "No — additive tooling-only sidecar" promise and with current compiler wrapper-form API (`result.success / result.errors? / result.schema?` style).
+
+- **§10.1 rewritten in wrapper-form.** New `CompileMelDomainResult` / `CompileMelModuleResult` type sketches make explicit that only `DomainModule` gains `sourceMap` (§3.1), while the rest of the result wrapper — success discriminant, diagnostics, errors, metadata — is unchanged. The type blocks are labeled illustrative and omit fields this ADR does not touch, rather than re-declaring the current compile-result contract.
+- **SMAP-API-1..4 added.** Normative rules pinning down that this ADR introduces exactly one new field on `DomainModule` and no other change to the compile-result surface.
+- **Concrete function names removed from §6 / §7 / §14.** `compileMelDomain()` and `compileMelModule()` references in SMAP-ARCH-2/3, INV-SMAP-3, the §14 Compiler SPEC bullet, and the §14 API Docs example replaced with role-based phrasing ("schema-only compile entrypoint", "module compile entrypoint"). Specific function naming belongs to the compiler SPEC, not to this ADR.
+- **§14 API Docs example corrected** to use wrapper-form access (`if (result.module) { ... }`) instead of chaining on a hypothetical function return.
+
+No type change inside `SourceMapIndex`, no new cache rules, no new invariants. This is an API-surface alignment pass.
+
+### v9 (2026-04-16, seventh review)
+
+Alignment pass only — no normative change. Brings the summary and checklist layers into line with the three-axis identity model that v7 established but v8 had not yet propagated everywhere.
+
+- **§12.1 Positive #4 updated** from `(schemaHash, sourceHash) gives consumers exact cache-invalidation signals` to per-artifact phrasing: `schemaHash` for semantic artifacts, `(schemaHash, sourceHash)` for `AnnotationIndex` under a fixed compiler version, `(schemaHash, sourceHash, emissionFingerprint)` for `SourceMapIndex` and `DomainModule`.
+- **§15 checklist "Per-artifact cache scope" item updated** from `sidecars on tuple` to the explicit per-artifact breakdown that matches §5.2.
+- **§15 checklist "SMAP-HASH-5/7 contradict" item updated** to reference the 5a/5b/5c split landed in v7 and describe the correct per-artifact key for each.
+
+No type changes, no rule changes, no new invariants. Body normative content (§3, §4, §5, §7, §10) is byte-identical to v8.
+
+### v8 (2026-04-16, sixth review)
+
+Resolves one extract-contract contradiction introduced in v7, plus two polish items.
+
+- **`extractSourceMap()` now takes `SourceMapEmissionContext` as an explicit input.** v7 simultaneously required (a) `emissionFingerprint` to be a deterministic function of `coordinateUnit` + compiler version + future emission options (SMAP-EMIT-FP-1), and (b) `extractSourceMap(ast, source, schema)` to depend only on AST, source text, and `DomainSchema` (SMAP-EMIT-1). Those cannot both be true — there is no path from the v7 extract inputs to the v7 fingerprint inputs. v8 introduces `SourceMapEmissionContext = { coordinateUnit, compilerVersion, emissionOptionsFingerprint }` as a fourth explicit input to `extractSourceMap()`. `SMAP-EMIT-1` is amended accordingly, a new SMAP-EMIT-5 requires the compiler to populate the context faithfully, and SMAP-EMIT-FP-1 is rewritten as a deterministic function of the context. `emissionOptionsFingerprint` absorbs future emission options without further signature churn (the same opacity pattern applied to `emissionFingerprint` itself).
+- **Phase 1 identity-model bullet updated** from `(schemaHash, sourceHash)` to the three-axis `(schemaHash, sourceHash, emissionFingerprint)` model that v5/v7 actually established.
+- **§15 checklist cardinality item updated** to reference `SMAP-HASH-1..9` and `SMAP-EMIT-FP-1..5` together, and a new checklist item verifies that `extractSourceMap()` and SMAP-EMIT-FP-1 do not contradict.
+
+### v7 (2026-04-16, fifth review)
+
+Resolves one cache-identity gap introduced in v6.
+
+- **`emissionFingerprint` added as `SourceMapIndex`'s third identity axis.** v6 made `coordinateUnit` an observable field on `SourceMapIndex`, which by design can vary across emissions of the same `(schemaHash, sourceHash)` (e.g., a utf16 build vs a bytes build of the same source on the same compiler version). But v6 SMAP-HASH-5 still keyed sidecar caches on `(schemaHash, sourceHash)` alone, which meant two structurally different `SourceMapIndex` instances could collide on the same cache slot. v7 adds `emissionFingerprint: string` to `SourceMapIndex` — an opaque, deterministic hash composed by the compiler over `coordinateUnit`, compiler version, and any future emission options. Adds SMAP-EMIT-FP-1..5. Splits SMAP-HASH-5 into 5a/5b/5c: `AnnotationIndex` keeps the `(schemaHash, sourceHash)` tuple under a fixed compiler version (its content is emission-option-independent in current contract), `SourceMapIndex` uses `(schemaHash, sourceHash, emissionFingerprint)`, `DomainModule` blob inherits the strictest triple.
+- **Three-axis identity model made explicit in §3.2.2.** semantic (`schemaHash`, observable) / physical source (`sourceHash`, observable) / emission (`emissionFingerprint`, opaque). `format` is a separate literal protocol-version field. `coordinateUnit` remains an observable payload encoding flag. Each axis evolves independently. **Amended by v8 above** — v7 left the extract-contract path from context to fingerprint unwritten.
+
+### v6 (2026-04-16, fourth review)
+
+Resolves one type-level contract contradiction introduced in v5.
+
+- **`format` vs `coordinateUnit` separated into two fields.** v5 `SourceMapIndex` declared `format: "manifesto/source-map-v1"` as a fixed literal, then SMAP-OFFSET-1 said the unit (`utf16`/`bytes`) had to be encoded *inside* `format`, with examples like `"manifesto/source-map-v1+utf16"`. Those two normative statements are type-level incompatible — the same field cannot be both a fixed literal and an extended union in the same contract. v6 splits them: `format` remains the protocol version literal, and a new `coordinateUnit: "utf16" | "bytes"` field carries payload encoding. This preserves independent evolution axes — format can bump to v2 (e.g., for extended `SourceMapPath` kinds under ADR-022c) without constraining coordinate encoding choice, and vice versa. SMAP-OFFSET-1..5 renumbered and restated accordingly. **Amended by v7 above** — v6 still left cache identity incomplete.
+
+### v5 (2026-04-16, third review)
+
+Resolves one internal inconsistency + one polish item flagged in the third architecture review.
+
+- **Hash / cache rule split by artifact class.** v4 §5.1 described `schemaHash` match as sufficient to reuse `SchemaGraph` **and** `AnnotationIndex`, while v4 SMAP-HASH-5 required all consumer caches to key on the `(schemaHash, sourceHash)` tuple. These two normative statements contradict each other. Current contract already settles the underlying question: `@meta` (ADR-021 INV-META-1/2) and `SourceMapIndex` (INV-SMAP-3/4) are invariant to `DomainSchema` / `SchemaGraph`, which means sidecars can vary within a fixed `schemaHash`. v5 separates cache scope by artifact: runtime-semantic products (`DomainSchema`, `SchemaGraph`, activation artifacts) MAY reuse on `schemaHash` alone; sidecars (`AnnotationIndex`, `SourceMapIndex`) and `DomainModule` blobs MUST use the tuple. Rules are renumbered SMAP-HASH-1..9 with explicit per-artifact scope.
+- **`SourcePoint` unit ambiguity made explicit.** v4 described `offset` as byte offset without committing to a column/offset unit convention. Editor tooling (LSP) uses UTF-16 code units; some compiler front-ends use bytes. v5 does not fix the choice but requires the compiler to declare the unit alongside `format`. **Superseded by v6 above** — the v5 approach entangled the unit with `format`, v6 splits them into separate fields.
+
+### v4 (2026-04-16, second review)
+
+One critical correction from the second architecture review:
+
+- **Trace replay scope further reduced to action-level only (via `TraceGraph.intent.type`).** v3 promised "enclosing declaration (action or computed) highlight," but the current Core trace contract exposes `TraceNode.kind`, `TraceNode.sourcePath` (as an opaque schema-navigation string), and `TraceGraph.intent.type`. Only the last is a stable consumer-facing coordinate today. Mapping an arbitrary trace node *up to its enclosing computed declaration* would require `sourcePath` parsing stability, which this ADR explicitly defers to ADR-022c. v1 therefore promises only what `TraceGraph.intent.type` can deliver: `action:<intent.type>` highlighting. Computed-level and sub-declaration highlighting both defer to ADR-022c.
+- Related: §13 Phase 0 evidence annex MUST cite a concrete trace surface path (Core `TraceGraph` via compiler/host integration, or a future tooling path). Current SDK `SimulateResult` does not expose trace, and MUST NOT be cited as the evidence surface for trace-replay highlighting.
+
+### v3 (2026-04-16, first review)
+
+v3 incorporated the first 2026-04-16 architecture review. Four critical corrections and two polish items:
+
+1. **`SourceMapPath.domain` now carries a `name`** — the v2 shape could not round-trip through its own `LocalTargetKey` grammar. Fixed.
+2. **Graph↔source is an explicit mapping, not a direct join** — v2 overstated shared-key-space symmetry. `SchemaGraphNodeId` uses `state:*` while `LocalTargetKey` uses `state_field:*`. A compiler-owned mapping function is now normative (§9.1).
+3. **`action_param` is excluded from v1** — ADR-021's *landed* subset excludes `action_param` pending a separate grammar decision (ADR-021 Companion Notes). Per current-truth rule, this ADR follows the landed subset rather than the ADR-021 grammar text. `SourceMapIndex` Kind set is therefore exactly `AnnotationIndex` landed Kind set, and co-evolves with it.
+4. **Trace replay scoped to enclosing-declaration highlighting** — further narrowed in v4 (see above).
+
+Polish: `SourceLocation` → `SourceSpan` (reflects that it carries start+end). `SMAP-HASH-3` relaxed to hold only within a fixed compiler version and compile options.
+
+---
+
+## 1. Context
+
+### 1.1 The Gap
+
+The compiler already knows where MEL constructs come from in source text — AST nodes carry source locations during parsing. After lowering, however, the current emission envelope preserves only:
+
+- `DomainSchema` — semantic runtime artifact
+- `SchemaGraph` — projected static dependency artifact
+- `AnnotationIndex` — user-authored structural sidecar (ADR-021)
+
+Nothing in the envelope answers the physical question:
+
+> "Which MEL source span produced this declaration?"
+
+That drives three downstream needs — editor navigation, coarse trace highlighting (§9.2), and coverage/inspection tooling. Without a compiler-owned answer, tooling either re-parses MEL or guesses via name matching, duplicating compiler knowledge the compiler already holds.
+
+### 1.2 Why `AnnotationIndex` Does Not Solve This
+
+`@meta` is intentionally user-authored, **partial**, and **semantic**. Per ADR-021 §2.3–2.5, annotations attach only where the author declares them, carry opaque tag strings the compiler does not interpret, and express semantic hints rather than physical coordinates.
+
+A compiler-owned source map has the opposite shape: **compiler-produced**, **total over declarations**, **physical** (line/column, not semantic). Collapsing the two forces either `@meta` to become mandatory and compiler-authored, or source maps to become user-authored and partial. Both are wrong.
+
+The correct pattern is **sibling sidecars under a shared key space**: different payloads, same key. ADR-021 established `AnnotationIndex`; this ADR introduces `SourceMapIndex` as its structural sibling.
+
+### 1.3 Why Declaration-Level Only in v1
+
+The earlier draft proposed mapping source spans down to body-statement resolution. Review concluded:
+
+- No landed consumer currently requires body-statement resolution at the *source map* layer. (Trace *itself* uses sub-declaration `sourcePath`, but that is a runtime artifact, not a sidecar — see §1.5.)
+- `SchemaGraph` operates at declaration level.
+- `AnnotationIndex` operates at declaration + one-level-child.
+
+Extending source-map resolution below declaration level in v1 would require inventing a new coordinate system the compiler does not externalize elsewhere. That violates the Manifesto principle **"separation by evidence, not by speculation."** Body-level resolution is therefore deferred to ADR-022c with explicit entry criteria (§11.3).
+
+### 1.4 Why `OriginIndex` Is Not Part of This ADR
+
+The earlier draft proposed a second sidecar, `OriginIndex`, to express 1:N source→semantic provenance for compiler-introduced expansion.
+
+MEL is declarative and non-Turing-complete. The landed lowering surface (ADR-013a `flow`/`include`, ADR-013b entity collection primitives, `dispatchable when`) does not currently produce 1:N fan-out that consumers cannot reconstruct from declaration-level mapping alone. Admitting `OriginIndex` in v1 would mean either a mostly-identity mapping that duplicates `SourceMapIndex`, or speculative roles without concrete producers. Both violate evidence-first discipline. Deferred to ADR-022b (§11.2).
+
+### 1.5 A Note on Trace vs Source Map Granularity
+
+A natural question: if the current Core `TraceNode` already carries sub-declaration `sourcePath`, why does this ADR only map declarations, and why does v1 further promise only action-level highlighting?
+
+Because the stable, consumer-facing surface of the current Core trace contract is narrower than `TraceNode` as a whole. What v1 can lean on today is:
+
+- `TraceGraph.intent.type` — the action name that triggered computation. Stable, consumer-facing.
+- `TraceNode.kind` — stable.
+- `TraceNode.sourcePath` — **a Core-internal schema navigation string**, not yet a stabilized consumer contract.
+
+Promising "enclosing-declaration highlight including computeds" would require `sourcePath` parsing — walking up the schema-navigation string to find the containing declaration. That couples tooling to a string format this ADR explicitly cannot stabilize. v1 therefore promises only the `TraceGraph.intent.type` → `action:<name>` join. Everything above that is deferred to ADR-022c, which can co-specify `sourcePath` stability with Core.
+
+This is the honest version of what v1 can deliver from the current trace contract.
+
+---
+
+## 2. Decision
+
+### 2.1 Add One Compiler-Owned Sidecar
+
+`DomainModule` gains one tooling-only sidecar:
+
+```typescript
+type DomainModule = {
+  readonly schema: DomainSchema;
+  readonly graph: SchemaGraph;
+  readonly annotations: AnnotationIndex;
+  readonly sourceMap: SourceMapIndex;   // new, tooling-only
+};
+```
+
+### 2.2 Sidecar Boundary
+
+`SourceMapIndex` obeys the same boundary discipline as `AnnotationIndex` (ADR-021 META-2, META-4):
+
+- MUST NOT appear inside `DomainSchema`
+- MUST NOT affect `DomainSchema.hash`
+- MUST NOT affect `SchemaGraph` derivation
+- MUST NOT be accepted by any runtime entrypoint
+- MUST remain out-of-schema tooling data
+
+Runtime entrypoints (`createManifesto()`, Core `compute`, Host dispatch, SDK activation) continue to accept `DomainSchema` only. That boundary is reaffirmed, not extended.
+
+---
+
+## 3. Artifact Model
+
+### 3.1 Shape
+
+```typescript
+type SourceMapIndex = {
+  readonly schemaHash: string;            // semantic identity
+  readonly sourceHash: string;            // physical source identity
+  readonly format: "manifesto/source-map-v1";            // protocol version
+  readonly coordinateUnit: "utf16" | "bytes";            // observable payload encoding
+  readonly emissionFingerprint: string;                  // opaque cache identity (§3.2.2)
+  readonly entries: Record<LocalTargetKey, SourceMapEntry>;
+};
+
+type SourceMapEntry = {
+  readonly target: SourceMapPath;   // structured truth (§4)
+  readonly span: SourceSpan;         // physical coordinate
+};
+
+type SourceSpan = {
+  readonly start: SourcePoint;
+  readonly end: SourcePoint;
+};
+
+type SourcePoint = {
+  readonly line: number;      // 1-indexed
+  readonly column: number;    // 1-indexed, in the units specified by `SourceMapIndex.coordinateUnit`
+  readonly offset?: number;   // optional, in the units specified by `SourceMapIndex.coordinateUnit`
+};
+```
+
+### 3.2 Why `SourceSpan`, not `SourceLocation`
+
+v1 always emits a range (declarations have a beginning and an end). Calling it `Location` would either mislead consumers ("is this a point or a range?") or collide with whatever the compiler's AST layer already names a single-point location. `SourceSpan` with explicit `start` / `end` `SourcePoint`s is unambiguous and parallel to standard tooling ecosystems (LSP, TextMate).
+
+If the compiler's internal AST uses its own `SourceLocation` type, this ADR does *not* adopt or rename it. `SourceSpan` is a dedicated contract type on the sidecar boundary. Internal AST representations remain compiler-private.
+
+### 3.2.1 Coordinate Unit — Separate Field from Format
+
+`SourcePoint.column` and `SourcePoint.offset` must agree on a unit. The two viable choices are:
+
+- **UTF-16 code units** — what LSP and most JavaScript tooling assume
+- **bytes** — what some compiler front-ends (including some Manifesto compiler internals) may use natively
+
+This ADR does **not** fix the choice at v1. It is declared per emission via a dedicated `coordinateUnit` field on `SourceMapIndex` (see §3.1).
+
+**Why a dedicated field, not an extension of `format`.** An earlier draft encoded the unit inside `format` (e.g., `"manifesto/source-map-v1+utf16"`). That conflated two orthogonal concerns: `format` is an **artifact protocol version**, while unit is a **payload encoding choice**. A future `"manifesto/source-map-v2"` should be free to bump for reasons unrelated to coordinate encoding (e.g., extended `SourceMapPath` kinds per ADR-022c), and a compiler should be free to switch coordinate encoding within a single protocol version without version-bump ceremony. Separating the two fields preserves both axes of evolution.
+
+| ID | Level | Rule |
+|----|-------|------|
+| SMAP-OFFSET-1 | MUST | `SourceMapIndex.coordinateUnit` MUST be declared as exactly `"utf16"` or `"bytes"` |
+| SMAP-OFFSET-2 | MUST | A single emitted `SourceMapIndex` MUST use a single unit for all entries (determined by `coordinateUnit`) |
+| SMAP-OFFSET-3 | MUST | Mixing units across a single `SourceMapIndex` is a compiler bug; consumers MAY reject such output |
+| SMAP-OFFSET-4 | MUST | `coordinateUnit` MUST NOT participate in `SourceMapIndex.format`. The two are orthogonal axes of contract evolution |
+| SMAP-OFFSET-5 | SHOULD | Consumers that target LSP-based tooling SHOULD prefer `"utf16"`; consumers that target byte-oriented pipelines (e.g., external tree-sitter) SHOULD prefer `"bytes"`. The compiler may offer either, documented per release. |
+
+This is deliberately light-touch: v1 does not force a unit choice, but v1 does forbid silent ambiguity. Editor tooling will hit this immediately once adoption begins; declaring it as a distinct field prevents silent mismatches and preserves independent evolution of protocol version and coordinate encoding.
+
+### 3.2.2 Emission Fingerprint — Opaque Cache Identity
+
+`coordinateUnit` is observable: consumers read it directly and branch tooling accordingly (UTF-16 path vs byte path). But cache identity cannot rely on `coordinateUnit` alone, because future emission options (canonicalization mode, included span metadata, etc.) will also vary the payload without changing `(schemaHash, sourceHash)`. Encoding every such option into the cache key one-by-one would force consumer cache contracts to churn every time a new emission axis lands.
+
+`emissionFingerprint` exists to absorb that churn. It is an **opaque, deterministic hash** composed by the compiler over — at minimum — `coordinateUnit` and the compiler version, plus any future emission options that affect `SourceMapIndex` payload. Consumers treat it as an opaque string: equal fingerprint = interchangeable `SourceMapIndex`; unequal fingerprint = distinct emissions regardless of `(schemaHash, sourceHash)` match.
+
+Three identity axes, cleanly separated:
+
+| Axis | Field | Nature | Purpose |
+|---|---|---|---|
+| Semantic | `schemaHash` | observable | Is the `DomainSchema` the same? |
+| Physical source | `sourceHash` | observable | Is the source text byte-identical? |
+| Emission | `emissionFingerprint` | opaque | Is this the same compiler+options emission? |
+
+`format` is a literal protocol version (the *shape* contract). `coordinateUnit` is an observable encoding flag (the *payload* contract). `emissionFingerprint` is opaque cache identity. Keeping all three separate lets each evolve independently: `format` bumps for shape changes, `coordinateUnit` toggles per emission, `emissionFingerprint` absorbs everything else.
+
+| ID | Level | Rule |
+|----|-------|------|
+| SMAP-EMIT-FP-1 | MUST | `emissionFingerprint` MUST be a deterministic function of `SourceMapEmissionContext` (`coordinateUnit` + `compilerVersion` + `emissionOptionsFingerprint`). See §10.2 for how the compiler supplies this context to `extractSourceMap()`. |
+| SMAP-EMIT-FP-2 | MUST | Two emissions with the same `(schemaHash, sourceHash)` but different `emissionFingerprint` MUST be treated as distinct artifacts by consumer caches |
+| SMAP-EMIT-FP-3 | MUST | Two emissions with the same `(schemaHash, sourceHash, emissionFingerprint)` MUST be byte-identical (modulo structural equality on `entries`) |
+| SMAP-EMIT-FP-4 | MUST | Consumers MUST treat `emissionFingerprint` as opaque — no parsing, no substring assumptions, no cross-compiler comparison |
+| SMAP-EMIT-FP-5 | SHOULD | The compiler SHOULD document which inputs participate in `emissionFingerprint` in its release notes, even though the format itself is opaque |
+
+### 3.3 Why This Shape
+
+Three design choices, each ruling out a subtly-broken simpler alternative.
+
+**Choice 1 — Key reuses `LocalTargetKey` from ADR-021.**
+
+`AnnotationIndex.entries` and `SourceMapIndex.entries` share the same key space. A consumer holding a `LocalTargetKey` (from either sidecar, or derived from a `SchemaGraph` node via the mapping in §9.1) can join into both sidecars by string identity. No parallel enums, no divergent coordinate drift.
+
+**Choice 2 — `target` is structured, not a rendered string.**
+
+ADR-009 established that flattening structured paths into dotted strings at contract boundaries is a *representational impossibility*, not an ergonomic inconvenience. `SourceMapPath` is a discriminated union (§4). Any string rendering is a display helper, not the contract.
+
+**Choice 3 — `schemaHash` and `sourceHash` are independent identities.**
+
+Semantic identity (ADR-006 CAN-3/CAN-4) and physical source-text identity answer different questions and have different change profiles. Conflating them would either make whitespace reformatting change `DomainSchema.hash` (breaking ADR-021 INV-META-1) or let source-location maps silently mismatch their source text. See §5 for cardinality.
+
+---
+
+## 4. `SourceMapPath` Model
+
+### 4.1 Closed Discriminated Union
+
+```typescript
+type SourceMapPath =
+  | { readonly kind: "domain";       readonly name: string }
+  | { readonly kind: "type";         readonly name: string }
+  | { readonly kind: "type_field";   readonly typeName: string; readonly fieldName: string }
+  | { readonly kind: "state_field";  readonly name: string }
+  | { readonly kind: "computed";     readonly name: string }
+  | { readonly kind: "action";       readonly name: string };
+```
+
+### 4.2 Rationale
+
+The `kind` set is **exactly the currently-landed `AnnotationIndex` `LocalTargetKey` Kind set** (ADR-021 Companion Notes: "the current landed/documented subset excludes `action_param`; that grammar decision remains deferred"). Because current-truth rule places owning package SPEC and maintained docs above ADR-021's grammar text, v1 `SourceMapIndex` follows the landed subset.
+
+Consequence: `action_param` is **excluded from v1**. When ADR-021 (or a successor) lands `action_param` in the annotation grammar, `SourceMapIndex` extends in lockstep through an explicit format-version bump. Until then, `action_param` source spans are out of scope; consumers that need them can compute them from `ActionSpec.params` ordering + the action's span, or wait for the lockstep extension.
+
+**Why identical Kind set, not strict superset.** A superset approach ("v1 source map includes `action_param` even though v1 annotations do not") was considered and rejected. Two sibling sidecars with different Kind sets is exactly the coordinate drift the shared-key-space principle exists to prevent. The lockstep discipline is the slow-but-correct path.
+
+**The earlier draft's `domain` variant without a `name` field** was a round-trip bug: `LocalTargetKey` grammar requires `domain:<n>`, so a `{ kind: "domain" }` without a name could not serialize to its own key. Fixed in v3 §4.1.
+
+### 4.3 Key Rendering
+
+A `SourceMapPath` renders to `LocalTargetKey` by ADR-021 §2.4 grammar:
+
+```
+{ kind: "domain",       name: "TaskBoard"              } → domain:TaskBoard
+{ kind: "type",         name: "Task"                   } → type:Task
+{ kind: "type_field",   typeName: "Task",
+                        fieldName: "title"             } → type_field:Task.title
+{ kind: "state_field",  name: "tasks"                  } → state_field:tasks
+{ kind: "computed",     name: "visibleTasks"           } → computed:visibleTasks
+{ kind: "action",       name: "archive"                } → action:archive
+```
+
+The rendered `LocalTargetKey` is the `entries` map key. `target` inside each entry preserves the structured form.
+
+### 4.4 Rules
+
+| ID | Level | Rule |
+|----|-------|------|
+| SMAP-PATH-1 | MUST | `SourceMapPath.kind` is a closed union equal to ADR-021 `LocalTargetKey` **landed** Kind set |
+| SMAP-PATH-2 | MUST | Every emitted entry's `target`, when rendered by ADR-021 §2.4 grammar, MUST equal the entry's `LocalTargetKey` |
+| SMAP-PATH-3 | MUST | `SourceMapPath` extension (new kinds, body-level resolution) requires a new ADR and `format` version bump |
+| SMAP-PATH-4 | MUST | When ADR-021 lands a new Kind (e.g., `action_param`), `SourceMapPath` co-extends in the same release under an explicit format-version bump |
+| SMAP-PATH-5 | MUST NOT | Rendered dotted strings MUST NOT be accepted as public mutation API; they are tooling lookup keys only |
+
+---
+
+## 5. Identity: `schemaHash` × `sourceHash`
+
+### 5.1 Why Two Hashes
+
+- Same source text → same `schemaHash`, same `sourceHash`
+- Whitespace-only / comment-only / source-ordering reformatting → same `schemaHash`, **different** `sourceHash`
+- `@meta` addition or removal → same `schemaHash` (ADR-021 INV-META-1), different `sourceHash`
+- Semantic change → different `schemaHash`, different `sourceHash`
+
+The two hashes answer different questions, and consumer caches MUST apply them at different granularities depending on which artifact they hold. A single blanket rule would either let sidecars go stale (schemaHash alone) or block legitimate `SchemaGraph` reuse (tuple always).
+
+### 5.2 Per-Artifact Cache Scope
+
+The current sidecar contract already establishes that `@meta` presence does not affect `DomainSchema`, `DomainSchema.hash`, or `SchemaGraph` (ADR-021 INV-META-1/2/3). `SourceMapIndex` inherits the same property by SMAP-ARCH-5/6 and INV-SMAP-3/4. Consequently, **different sidecars cannot share the same cache-key discipline as runtime-semantic artifacts.** Further, `SourceMapIndex` has a *third* identity axis (`emissionFingerprint`, §3.2.2) because the same `(schemaHash, sourceHash)` can produce observably different emissions under different compiler versions or emission options (e.g., `coordinateUnit = "utf16"` vs `"bytes"`).
+
+| Artifact | Cache key | Why |
+|---|---|---|
+| `DomainSchema` (runtime) | `schemaHash` | Semantic identity; by construction unaffected by sidecars, reformatting, or emission options |
+| `SchemaGraph` (projected semantic) | `schemaHash` | Derived from `DomainSchema` alone (current contract) |
+| Runtime products derived from `DomainSchema` alone (e.g., activation artifacts) | `schemaHash` | Same reasoning |
+| `AnnotationIndex` (user sidecar) | `(schemaHash, sourceHash)` **under a fixed compiler version** | `@meta` presence/content varies with source text but not with emission options in the current contract. MUST NOT reuse on `schemaHash` alone |
+| `SourceMapIndex` (compiler sidecar) | `(schemaHash, sourceHash, emissionFingerprint)` | Emission options (`coordinateUnit`, future options) vary output under fixed `(schemaHash, sourceHash)`; fingerprint absorbs that variability |
+| `DomainModule` blob | `(schemaHash, sourceHash, emissionFingerprint)` | Transitively contains `SourceMapIndex`; inherits strictest key |
+
+Finer-grained sidecar cache keys (e.g., a separate `annotationHash`) are out of scope for this ADR. They may be introduced by future ADRs if sidecar-only invalidation becomes a measured hot path.
+
+**Why `emissionFingerprint` on `SourceMapIndex` but not on `AnnotationIndex`.** The current `@meta` contract is emission-option-independent: annotation extraction consumes AST structure and `@meta` literal content, not `coordinateUnit` or any option this ADR introduces. If a future ADR (or ADR-021 successor) adds emission options that affect `AnnotationIndex` payload, the correct response is to add a parallel `emissionFingerprint` to `AnnotationIndex` in that ADR. This ADR does not preemptively do so.
+
+### 5.3 Cardinality Rules
+
+| ID | Level | Rule |
+|----|-------|------|
+| SMAP-HASH-1 | MUST | `SourceMapIndex.schemaHash` equals the sibling `DomainSchema.hash` in the same `DomainModule` emission |
+| SMAP-HASH-2 | MUST | `sourceHash` is computed from the exact physical MEL source text passed to the compiler |
+| SMAP-HASH-3 | MUST | **Given a fixed compiler version and fixed compile options**, one `sourceHash` deterministically produces exactly one `schemaHash`. Consumers MUST NOT assume this holds across compiler versions or compile-option differences. |
+| SMAP-HASH-4 | MAY  | One `schemaHash` may correspond to many `sourceHash` values (whitespace, comment, ordering reformatting, and `@meta` edits that preserve semantics) |
+| SMAP-HASH-5a | MUST | Consumers caching `AnnotationIndex` MUST key on the tuple `(schemaHash, sourceHash)` **under a fixed compiler version**. If the compiler version changes, consumers MUST invalidate the cache entry |
+| SMAP-HASH-5b | MUST | Consumers caching `SourceMapIndex` MUST key on the triple `(schemaHash, sourceHash, emissionFingerprint)` |
+| SMAP-HASH-5c | MUST | Consumers caching `DomainModule` as a whole blob MUST key on the triple `(schemaHash, sourceHash, emissionFingerprint)` (inherits strictest key from `SourceMapIndex`) |
+| SMAP-HASH-6 | MUST NOT | Consumers caching `AnnotationIndex` or `SourceMapIndex` on `schemaHash` alone is forbidden — the underlying content can vary within a fixed `schemaHash` |
+| SMAP-HASH-7 | MAY  | Consumers caching `DomainSchema`, `SchemaGraph`, or runtime products derived from `DomainSchema` alone MAY key on `schemaHash` alone. ADR-021 INV-META-1/2 and INV-SMAP-3/4 together guarantee invariance under sidecar variation, and `emissionFingerprint` does not affect these artifacts |
+| SMAP-HASH-8 | MUST NOT | v1 MUST NOT apply source canonicalization; whitespace/comment changes MUST produce a different `sourceHash` |
+| SMAP-HASH-9 | MUST NOT | `sourceHash` MUST NOT participate in `DomainSchema.hash` computation (preserves ADR-021 INV-META-1 semantics) |
+
+SMAP-HASH-5a/5b/5c and SMAP-HASH-7 together resolve the blanket-rule contradiction and the `coordinateUnit` cache-identity gap in one pass. Runtime-semantic artifacts keep `schemaHash`-only reuse (which is their whole point — identity independent of sidecars and emission options). `AnnotationIndex` uses `(schemaHash, sourceHash)` because its content is option-independent under current contract. `SourceMapIndex` and the `DomainModule` blob use the triple `(schemaHash, sourceHash, emissionFingerprint)` because emission options (`coordinateUnit` today, more options tomorrow) do change their payload.
+
+SMAP-HASH-3 is deliberately scoped. The same source compiled by a future compiler version or with different compile options may legitimately produce a different schema. That is not a bug to paper over; it is a property consumers must respect when their cache keys cross version or option boundaries.
+
+SMAP-HASH-8 is the strict-but-explainable choice. Source canonicalization would collapse "is this the same source?" into a compiler-internal policy. v1 keeps that question local. A future ADR may relax it alongside an explicit canonicalization spec.
+
+---
+
+## 6. Boundary Rules
+
+| ID | Level | Rule |
+|----|-------|------|
+| SMAP-ARCH-1 | MUST | `sourceMap` MUST exist only in `DomainModule`, never in `DomainSchema` |
+| SMAP-ARCH-2 | MUST | Schema-only compile entrypoints MUST remain schema-only; they MUST NOT emit `sourceMap` |
+| SMAP-ARCH-3 | MUST | Module compile entrypoints MUST emit `sourceMap` as part of the returned `DomainModule` |
+| SMAP-ARCH-4 | MUST | `.mel` loader/bundler default export MUST remain compiled `DomainSchema` only |
+| SMAP-ARCH-5 | MUST | Core, Host, SDK, Lineage, Governance MUST NOT read or require `sourceMap` |
+| SMAP-ARCH-6 | MUST | `SchemaGraph` derivation MUST remain independent of `sourceMap` |
+| SMAP-ARCH-7 | MUST | `AnnotationIndex` and `SourceMapIndex` are sibling sidecars, not extensions of one another |
+| SMAP-ARCH-8 | MUST | Runtime entrypoints MUST continue to accept `DomainSchema` only, not `DomainModule` |
+| SMAP-ARCH-9 | MUST | `SourceMapIndex` MUST be total over every declaration present in the companion `DomainSchema` under the landed `SourceMapPath` Kind set (§4.1) |
+
+SMAP-ARCH-9 is the compiler-owned completeness guarantee. Unlike `AnnotationIndex` (user-authored, partial), `SourceMapIndex` is compiler-produced and consumers may rely on totality *within the currently-landed Kind set*. When the Kind set extends (§4.4 SMAP-PATH-4), totality extends with it through the same release.
+
+---
+
+## 7. Completeness Invariants (CI-Enforced)
+
+| ID | Invariant |
+|----|-----------|
+| INV-SMAP-1 | For every declaration in emitted `DomainSchema` under the landed `SourceMapPath` Kind set (domain, types, type fields, state fields, computeds, actions), `SourceMapIndex.entries` MUST contain exactly one entry with the matching `LocalTargetKey` |
+| INV-SMAP-2 | `SourceMapIndex.schemaHash` MUST equal `DomainSchema.hash` in the same emission |
+| INV-SMAP-3 | `DomainSchema` emitted with `SourceMapIndex` present MUST be byte-identical to `DomainSchema` emitted without `SourceMapIndex` (e.g., via a schema-only compile entrypoint) |
+| INV-SMAP-4 | `SchemaGraph` emitted alongside `SourceMapIndex` MUST be identical to `SchemaGraph` emitted without it |
+| INV-SMAP-5 | For any snapshot and intent, `compute()` / `getAvailableActions()` / `isIntentDispatchable()` results MUST be identical regardless of `SourceMapIndex` presence |
+| INV-SMAP-6 | `DomainModule` containing `SourceMapIndex` MUST NOT be accepted by `createManifesto()` or any runtime entrypoint |
+| INV-SMAP-7 | For any two MEL sources `A` and `B` with `schemaHash(A) = schemaHash(B)`, swapping `SourceMapIndex(A)` with `SourceMapIndex(B)` MUST NOT change any runtime semantics (runtime-independence) |
+| INV-SMAP-8 | For every entry, the rendered form of `entry.target` MUST equal the entry's `LocalTargetKey` (round-trip) |
+
+INV-SMAP-3/4 are the structural parallels of ADR-021 INV-META-1/2. INV-SMAP-7 is the runtime-independence backstop. INV-SMAP-8 is new in v3 — it catches the class of round-trip bug that the v2 `domain` variant had.
+
+---
+
+## 8. Relationship to `@meta` / `AnnotationIndex`
+
+### 8.1 Sibling Sidecars, Not a Hierarchy
+
+| Property | `AnnotationIndex` (ADR-021) | `SourceMapIndex` (this ADR) |
+|---|---|---|
+| Producer | User (via `@meta`) | Compiler |
+| Completeness | Partial | Total over landed Kind set |
+| Purpose | Semantic / tooling hint | Physical source coordinate |
+| Key space | `LocalTargetKey` (landed subset) | `LocalTargetKey` (same landed subset) |
+| Payload | `{ tag, payload? }[]` | `{ target, span }` |
+| Runtime impact | None | None |
+| Tag semantics | Opaque to compiler | N/A |
+
+### 8.2 Why the Completeness Difference Is Principled
+
+A user-authored sidecar **must** be partial: total `@meta` coverage would be punishing to write and would reduce annotations to noise. Its value is in the authored hint, not the density.
+
+A compiler-owned sidecar **must** be total (over the landed Kind set): the compiler has the information trivially, and consumers need a uniform contract to reason about. Partial compiler output silently shifts "what tooling can assume" into the compiler's implementation details.
+
+The *shared landed Kind set* is what keeps these asymmetric sidecars joinable. When the Kind set grows, it grows on both sides in the same release.
+
+### 8.3 Combined Consumer Flow
+
+```typescript
+// studio-core: from a graph node, get source span + authored annotations
+function navigateFromGraphNode(
+  node: SchemaGraphNode,
+  module: DomainModule,
+): { span: SourceSpan; hints: Annotation[] } {
+  const key: LocalTargetKey = graphNodeToLocalTargetKey(node);  // §9.1
+  return {
+    span:  module.sourceMap.entries[key].span,
+    hints: module.annotations.entries[key] ?? [],
+  };
+}
+```
+
+---
+
+## 9. Consumer Model
+
+### 9.1 Graph ↔ Source — Explicit Mapping
+
+`SchemaGraphNodeId` and `LocalTargetKey` use **different kind labels** for the same declarations:
+
+| Declaration | `SchemaGraphNodeId` | `LocalTargetKey` |
+|---|---|---|
+| state field `tasks` | `state:tasks` | `state_field:tasks` |
+| computed `visibleTasks` | `computed:visibleTasks` | `computed:visibleTasks` |
+| action `archive` | `action:archive` | `action:archive` |
+
+`state` ↔ `state_field` rename is the asymmetry. `computed` and `action` align. This ADR therefore specifies a compiler-owned mapping function rather than claiming a direct join.
+
+```typescript
+// Exposed by the compiler package alongside SourceMapIndex
+function graphNodeIdToLocalTargetKey(id: SchemaGraphNodeId): LocalTargetKey;
+// "state:X"     → "state_field:X"
+// "computed:X"  → "computed:X"
+// "action:X"    → "action:X"
+
+function graphNodeToLocalTargetKey(node: SchemaGraphNode): LocalTargetKey;
+// convenience over graphNodeIdToLocalTargetKey(node.id)
+```
+
+| ID | Level | Rule |
+|----|-------|------|
+| SMAP-GRAPH-1 | MUST | The compiler package MUST expose `graphNodeIdToLocalTargetKey()` as a pure, total function over `SchemaGraphNodeId` |
+| SMAP-GRAPH-2 | MUST | The mapping MUST preserve the declaration name unchanged |
+| SMAP-GRAPH-3 | MUST | Graph nodes not present in the landed `SourceMapPath` Kind set (none in v1, reserved for future Kind additions) MUST be handled explicitly by the mapping contract |
+
+`SchemaGraph` does not currently model type declarations, type fields, or domain-level metadata. Source navigation for those constructs uses `LocalTargetKey` directly without graph mediation. This is expected, not a gap.
+
+### 9.2 Trace Replay ↔ Source — Action-Level Highlight Only
+
+The current Core trace contract exposes `TraceNode.kind`, `TraceNode.sourcePath` (an opaque schema-navigation string), and `TraceGraph.intent.type`. Of these, only `TraceGraph.intent.type` is a stable consumer-facing coordinate today.
+
+v1 therefore uses **only** `TraceGraph.intent.type` as the join key:
+
+```typescript
+// v1-sanctioned trace highlight
+function actionLevelHighlight(
+  graph: TraceGraph,
+  module: DomainModule,
+): SourceSpan | undefined {
+  const key = `action:${graph.intent.type}` as LocalTargetKey;
+  return module.sourceMap.entries[key]?.span;
+}
+```
+
+| ID | Level | Rule |
+|----|-------|------|
+| SMAP-TRACE-1 | MUST | v1 trace replay tooling using `SourceMapIndex` MUST highlight **only** the action identified by `TraceGraph.intent.type`, rendered as `LocalTargetKey` `action:<intent.type>` |
+| SMAP-TRACE-2 | MUST NOT | v1 tooling MUST NOT claim computed-level, statement-precise, or expression-precise source highlighting from `SourceMapIndex` |
+| SMAP-TRACE-3 | MUST NOT | v1 tooling MUST NOT parse `TraceNode.sourcePath` to derive highlight targets. `sourcePath` is not a stabilized consumer contract in v1 |
+| SMAP-TRACE-4 | SHOULD | Computed-level, statement-precise, and expression-precise highlighting SHOULD wait for ADR-022c, which co-specifies `TraceNode.sourcePath` stability with Core and extends the `SourceMapPath` Kind set |
+
+Concretely: if a trace under `intent.type = "archive"` contains branches, computed evaluations, and effects, v1 highlights `action:archive`'s span. Nothing finer. Promising "the enclosing computed declaration of *this* trace node" would require `sourcePath` parsing, and that is exactly what v1 does not stabilize.
+
+This is a genuine scope reduction relative to v3, and the right one — v1 promises only what the current Core trace contract can back.
+
+### 9.3 Editor Navigation
+
+Cursor-position → source-map lookup is the reverse direction and requires a spatial index built by the consumer over `SourceMapIndex.entries`. v1 does not prescribe that index. A future ADR may standardize it once more than one consumer needs it.
+
+---
+
+## 10. Emission
+
+### 10.1 Entrypoints
+
+This ADR does **not** introduce new compiler entrypoints or change the shape of existing ones. Current compiler entrypoints already return result wrappers with optional `schema` / `module` fields alongside diagnostics; this ADR operates entirely within the existing wrapper form. The sole observable change is that `DomainModule.sourceMap` becomes present in the module-level result.
+
+```typescript
+// Schema-only entrypoint result — wrapper shape unchanged by this ADR
+type CompileMelDomainResult = {
+  readonly schema?: DomainSchema;
+  // existing success discriminant, diagnostics, errors, and metadata fields unchanged
+};
+
+// Module entrypoint result — wrapper shape unchanged by this ADR;
+// the embedded `DomainModule` now carries an additional `sourceMap` field per §3.1
+type CompileMelModuleResult = {
+  readonly module?: DomainModule;  // DomainModule gains `sourceMap` (§3.1); other fields unchanged
+  // existing success discriminant, diagnostics, errors, and metadata fields unchanged
+};
+```
+
+The type blocks above are **illustrative**: they show only the field this ADR introduces, not a re-declaration of the current compile-result contract. Any field not listed here is inherited from the current compiler output contract unchanged. No result field is removed, renamed, or re-typed by this ADR.
+
+| ID | Level | Rule |
+|----|-------|------|
+| SMAP-API-1 | MUST | Schema-only compile result shape MUST be unchanged by this ADR |
+| SMAP-API-2 | MUST | Module compile result shape MUST be unchanged by this ADR except for `DomainModule` gaining `sourceMap` (§3.1) |
+| SMAP-API-3 | MUST | No existing compile-result field MAY be removed, renamed, or re-typed as a consequence of this ADR |
+| SMAP-API-4 | MUST | The addition of `sourceMap` to `DomainModule` MUST preserve the "No — additive tooling-only sidecar" promise in this ADR's header |
+
+This framing makes the scope of the ADR exact: **one new field on `DomainModule`**, nothing else in the compile-result surface.
+
+### 10.2 Extraction
+
+```typescript
+type SourceMapEmissionContext = {
+  readonly coordinateUnit: "utf16" | "bytes";
+  readonly compilerVersion: string;
+  readonly emissionOptionsFingerprint: string;   // opaque hash of any other compile/emission options that affect SourceMapIndex payload (future extensibility)
+};
+
+function extractSourceMap(
+  ast: MelAst,
+  source: string,
+  schema: DomainSchema,
+  ctx: SourceMapEmissionContext,
+): SourceMapIndex;
+```
+
+`SourceMapEmissionContext` makes the fingerprint's inputs first-class in the extraction contract rather than smuggling them in through compiler-global state. The compiler populates `ctx` from its own version and the active compile options; `extractSourceMap()` composes `ctx.coordinateUnit`, `ctx.compilerVersion`, and `ctx.emissionOptionsFingerprint` into the resulting `SourceMapIndex.emissionFingerprint` per SMAP-EMIT-FP-1.
+
+`emissionOptionsFingerprint` exists so that the extract contract does not have to re-enumerate every future emission option as a new parameter. When ADR-022c (or any later ADR) adds emission options, they fold into `emissionOptionsFingerprint` without changing `extractSourceMap()`'s signature.
+
+| ID | Level | Rule |
+|----|-------|------|
+| SMAP-EMIT-1 | MUST | `extractSourceMap()` MUST depend only on AST, source text, `DomainSchema`, and `SourceMapEmissionContext` |
+| SMAP-EMIT-2 | MUST | `extractSourceMap()` MUST NOT consult `AnnotationIndex` or `SchemaGraph` |
+| SMAP-EMIT-3 | MUST | `extractAnnotations()` and `extractGraph()` MUST NOT consult `SourceMapIndex` or `SourceMapEmissionContext` |
+| SMAP-EMIT-4 | MUST | Emission order: `schema` → `graph` / `annotations` / `sourceMap` (three siblings, independent) |
+| SMAP-EMIT-5 | MUST | The compiler MUST populate `SourceMapEmissionContext` before invoking `extractSourceMap()`; `ctx.compilerVersion` MUST match the actual compiler build, and `ctx.emissionOptionsFingerprint` MUST deterministically reflect the active compile options |
+| SMAP-EMIT-6 | SHOULD | Implementations MAY share AST traversal with other passes for performance, provided isolation invariants (SMAP-EMIT-2, SMAP-EMIT-3) hold |
+
+### 10.3 Completeness Audit
+
+Per INV-SMAP-1 and SMAP-ARCH-9, the compiler MUST fail compilation if any declaration in the emitted `DomainSchema` under the landed `SourceMapPath` Kind set lacks a corresponding source-map entry. This is the compiler's internal invariant, not a consumer validation.
+
+---
+
+## 11. Non-Goals and Deferred Items
+
+### 11.1 Non-Goals
+
+This ADR does **not**:
+
+- change Core, Host, SDK, Lineage, or Governance contracts
+- change `DomainSchema` structure or hash computation
+- change `SchemaGraph` structure, edges, or derivation
+- change `TraceEvent` / `TraceNode` shape or runtime trace semantics
+- stabilize Core `TraceNode.sourcePath` for consumer use (reserved for ADR-022c co-specification)
+- replace `@meta` / `AnnotationIndex`
+- define UI rendering or Studio behavior
+- define a public runtime path DSL
+- introduce source canonicalization
+- introduce multi-file / multi-document MEL compilation
+
+### 11.2 Deferred to ADR-022b (`OriginIndex`)
+
+Entry criteria:
+
+1. At least one landed lowering path that demonstrably produces 1:N source→semantic fan-out consumers cannot reconstruct from `SourceMapIndex` + `DomainSchema` alone.
+2. At least two concrete consumer use cases that require `role: "expansion-site" | "generated-from"` distinction.
+3. Explicit cardinality rules parallel to §5.2.
+
+### 11.3 Deferred to ADR-022c (Computed-Level + Statement / Expression Resolution + Trace Co-Spec)
+
+Entry criteria:
+
+1. A concrete consumer (trace stepper, guard debugger, or equivalent) that demonstrably requires computed-level or sub-declaration resolution.
+2. Co-specification with Core on `TraceNode.sourcePath` stability, including which sub-declaration positions and which enclosing-declaration walks are guaranteed to be addressable across compiler versions.
+3. Stable extension of `SourceMapPath` that does not leak AST internals.
+4. Invariants parallel to INV-SMAP-1 over the extended coordinate space.
+
+### 11.4 Deferred: `action_param`
+
+Entry criteria:
+
+1. ADR-021 (or successor) lands `action_param` in the annotation grammar.
+2. `SourceMapPath` extends `{ kind: "action_param", actionName: string, paramName: string }` in the same release under explicit format-version bump (SMAP-PATH-4).
+
+---
+
+## 12. Consequences
+
+### 12.1 Positive
+
+1. Declaration-level source navigation becomes a first-class tooling contract.
+2. Graph↔source joins reduce to one compiler-owned mapping function + shared-key lookup.
+3. Annotation↔source joins reduce to a shared-key lookup (identical key space by construction).
+4. Per-artifact identity gives consumers exact cache-invalidation signals: `schemaHash` for semantic artifacts, `(schemaHash, sourceHash)` for `AnnotationIndex` under a fixed compiler version, and `(schemaHash, sourceHash, emissionFingerprint)` for `SourceMapIndex` and `DomainModule`.
+5. Runtime contracts (Core/Host/SDK/Lineage/Governance) remain byte-unchanged.
+6. Kind-set lockstep with `AnnotationIndex` removes a whole class of future drift.
+
+### 12.2 Trade-offs
+
+1. `DomainModule` grows from three artifacts to four.
+2. Closed `SourceMapPath` union couples v1 to the current landed declaration set. Extensions are explicit ADRs + format-version bumps. Intended cost.
+3. v1 trace replay highlighting is **action-level only** (via `TraceGraph.intent.type`). Consumers wanting computed-level, statement-precise, or expression-precise highlighting wait for ADR-022c. Intended cost.
+4. `action_param` spans are unavailable in v1. Consumers can approximate via `ActionSpec.params` + action span, or wait for the lockstep landing.
+
+### 12.3 Explicit Trade-off Rejections
+
+- **Render `SourceMapPath` as a dotted string.** Rejected under ADR-009.
+- **Expose raw `AstNodeKind`.** Rejected; `LocalTargetKey` Kind is the established closed enum.
+- **Merge into `AnnotationIndex` under a reserved namespace.** Rejected; would force `@meta` to become total and compiler-authored.
+- **Ship `OriginIndex` in v1 as mostly-identity mapping.** Rejected as YAGNI without 1:N evidence.
+- **Superset Kind set (include `action_param` even though annotation landed subset excludes it).** Rejected; sibling sidecar drift is exactly what shared-key-space prevents.
+- **Claim statement-precise trace replay with declaration-only source map.** Rejected; user promise would exceed artifact resolution.
+- **Promise "enclosing-declaration highlight including computed-level" in v1 by parsing `TraceNode.sourcePath`.** Rejected; couples v1 tooling to a Core-internal string format this ADR explicitly cannot stabilize. Computed-level highlighting defers to ADR-022c where `sourcePath` stability can be co-specified with Core.
+
+---
+
+## 13. Rollout
+
+### Phase 0 — Consumer Evidence Collection (precondition)
+
+Before Phase 1, at least two concrete consumer use cases MUST be documented:
+
+- studio-core graph→source navigation
+- one of: **action-level** trace highlight (via `TraceGraph.intent.type`), coverage reporting, or editor jump-to-definition
+
+Evidence annex notes:
+
+- The current SDK `SimulateResult` does **not** expose trace. Phase 0 evidence for trace-highlight use cases MUST cite a concrete trace surface path — Core `TraceGraph` via compiler/host integration, or a documented future tooling surface. Citing `simulate()` as the trace source is invalid.
+- Claims beyond action-level highlight (computed-level, statement-precise, expression-precise) do not satisfy Phase 0 for v1; they are evidence for ADR-022c, not v1.
+
+This preserves "separation by evidence." v1 design was shaped by anticipated consumers; Phase 0 confirms they are real before compiler surface area grows.
+
+### Phase 1 — ADR Acceptance
+
+- sidecar boundary accepted
+- `LocalTargetKey` reuse (landed subset) confirmed with ADR-021 authors
+- `DomainModule` expansion accepted
+- `(schemaHash, sourceHash, emissionFingerprint)` three-axis identity model accepted, with per-artifact cache scope (§5.2)
+- `graphNodeIdToLocalTargetKey()` exposure accepted
+
+### Phase 2 — Compiler SPEC Patch
+
+- Compiler SPEC v1.0.0 companion subsection for `SourceMapIndex`
+- Module compile entrypoint result wrapper carries an expanded `DomainModule` (gains `sourceMap` per §3.1); wrapper shape itself is unchanged
+- `extractSourceMap()` contract added
+- `graphNodeIdToLocalTargetKey()` exposed from compiler package
+- INV-SMAP-* invariants added to compiler CI
+- no runtime package SPEC changes
+
+### Phase 3 — Tooling Adoption
+
+- studio-core graph↔source navigation
+- action-level trace replay highlight via `TraceGraph.intent.type` (consumer-side, no runtime changes)
+- coverage / inspection utilities
+
+---
+
+## 14. Specification Changes Summary
+
+### Compiler SPEC
+
+- `DomainModule` gains `sourceMap: SourceMapIndex`
+- Current output contract expands from three artifacts to four
+- New types: `SourceMapIndex`, `SourceMapEntry`, `SourceMapPath`, `SourceSpan`, `SourcePoint`, `SourceMapEmissionContext`
+- New function exposure: `graphNodeIdToLocalTargetKey()`
+- `extractSourceMap()` emission rule added
+- INV-SMAP-* invariants added
+
+### API Docs
+
+```typescript
+// Module compile result wrapper — shape unchanged by this ADR.
+// `result.module` embeds DomainModule; DomainModule now includes sourceMap (§3.1):
+if (result.module) {
+  const { schema, graph, annotations, sourceMap } = result.module;
+}
+```
+
+Runtime examples (`createManifesto()`, Core `compute`, Host dispatch, SDK activation) remain unchanged.
+
+### Other Packages
+
+- Core: no changes
+- Host: no changes
+- SDK: no changes
+- Lineage: no changes
+- Governance: no changes
+
+---
+
+## 15. Review Checklist
+
+**Cache key quick reference** (detailed in §5.2):
+
+| Artifact | Cache key |
+|---|---|
+| `DomainSchema` / `SchemaGraph` / runtime products | `schemaHash` |
+| `AnnotationIndex` | `(schemaHash, sourceHash)` under fixed compiler version |
+| `SourceMapIndex` / `DomainModule` blob | `(schemaHash, sourceHash, emissionFingerprint)` |
+
+Before acceptance, reviewers MUST confirm:
+
+- [ ] Phase 0 consumer evidence annex populated with at least two use cases
+- [ ] `SourceMapPath.kind` set is byte-identical to ADR-021 `LocalTargetKey` **landed** Kind set
+- [ ] `{ kind: "domain", name }` round-trips via §4.3 grammar
+- [ ] `graphNodeIdToLocalTargetKey()` behavior is specified for every `SchemaGraphNodeKind`
+- [ ] `(schemaHash, sourceHash, emissionFingerprint)` cardinality rules (SMAP-HASH-1..9, SMAP-EMIT-FP-1..5) are unambiguous
+- [ ] SMAP-HASH-3 scope ("fixed compiler version and compile options") is acceptable to consumer caches
+- [ ] **Per-artifact cache scope table (§5.2) matches consumer intuition** — `DomainSchema` / `SchemaGraph` on `schemaHash` alone; `AnnotationIndex` on `(schemaHash, sourceHash)` under a fixed compiler version; `SourceMapIndex` and `DomainModule` on `(schemaHash, sourceHash, emissionFingerprint)`
+- [ ] **SMAP-HASH-5a/5b/5c and SMAP-HASH-7 explicitly do not contradict** — `AnnotationIndex` on `(schemaHash, sourceHash)` under a fixed compiler version; `SourceMapIndex` and `DomainModule` on `(schemaHash, sourceHash, emissionFingerprint)`; runtime-semantic artifacts on `schemaHash` alone
+- [ ] `extractSourceMap()` receives `SourceMapEmissionContext` as an explicit input (SMAP-EMIT-1, SMAP-EMIT-5); its signature and SMAP-EMIT-FP-1 do not contradict
+- [ ] §10.1 entrypoint description reads as wrapper-form result types (`CompileMelDomainResult` / `CompileMelModuleResult`), not as new function signatures (SMAP-API-1..4)
+- [ ] The only change to compile-result surface is `DomainModule` gaining `sourceMap` (SMAP-API-2)
+- [ ] No existing compile-result field is removed, renamed, or re-typed (SMAP-API-3)
+- [ ] `SourceMapIndex` declares `format` (protocol version), `coordinateUnit` (utf16 or bytes), and `emissionFingerprint` (opaque cache identity) as three separate fields (SMAP-OFFSET-1, SMAP-OFFSET-4, SMAP-EMIT-FP-1)
+- [ ] `emissionFingerprint` is deterministic over `coordinateUnit` + compiler version + any future emission options (SMAP-EMIT-FP-1)
+- [ ] Cache rules split explicitly: `AnnotationIndex` on `(schemaHash, sourceHash)` under fixed compiler version (SMAP-HASH-5a); `SourceMapIndex` and `DomainModule` blob on `(schemaHash, sourceHash, emissionFingerprint)` (SMAP-HASH-5b, 5c)
+- [ ] INV-SMAP-3, INV-SMAP-4, INV-SMAP-7, INV-SMAP-8 tests are implementable in existing compiler CI
+- [ ] `SMAP-TRACE-*` scope (**action-level only via `TraceGraph.intent.type`**) is acceptable to trace-replay tooling owners
+- [ ] Phase 0 trace-highlight evidence cites a concrete trace surface (not SDK `SimulateResult`)
+- [ ] No runtime SPEC (Core/Host/SDK/Lineage/Governance) requires modification
+- [ ] `OriginIndex`, body-level resolution, **computed-level resolution**, and `action_param` all remain deferred with explicit entry criteria
+
+---
+
+*End of ADR-022 v11 — Accepted*

--- a/docs/internals/adr/index.md
+++ b/docs/internals/adr/index.md
@@ -52,6 +52,7 @@ These ADRs affect multiple packages across the monorepo:
 | [ADR-019](./019-post-activation-extension-kernel) | Post-Activation Extension Kernel — Safe Public Seam for Arbitrary-Snapshot Operations | Implemented | 2026-04-07 | SDK |
 | [ADR-020](./020-intent-level-dispatchability) | Intent-Level Dispatchability — `dispatchable when` Clause | Implemented | 2026-04-07 | Compiler, Core, SDK, Studio/Introspection, Docs |
 | [ADR-021](./021-mel-structural-annotation-system-meta-sidecar) | MEL Structural Annotation System — `@meta` Sidecar | Accepted | 2026-04-15 | Compiler, Tooling, Docs |
+| [ADR-022](./022-compiler-owned-source-location-sidecar-source-map-index) | Compiler-Owned Source Location Sidecar (`SourceMapIndex`) | Accepted | 2026-04-16 | Compiler, Tooling, Docs |
 
 ### ADR-006 Companion Evidence (Non-Normative)
 
@@ -96,7 +97,7 @@ These ADRs affect multiple packages across the monorepo:
 
 - There is no standalone `ADR-013` file in the repository.
 - The original mixed ADR-013 draft was withdrawn and split into `ADR-013a` (`flow`/`include`) and `ADR-013b` (entity collection primitives).
-- Both split tracks are now implemented in the compiler current contract, reflected in [SPEC-v1.0.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md), and covered by the compiler compliance suites.
+- Both split tracks are now implemented in the compiler current contract, reflected in [SPEC-v1.1.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md), and covered by the compiler compliance suites.
 
 ### ADR-014 Companion Notes
 
@@ -127,7 +128,7 @@ These ADRs affect multiple packages across the monorepo:
 ### ADR-020 Companion Notes
 
 - ADR-020 is implemented in the current compiler, core, and SDK contracts.
-- The current behavior now lives in [SPEC-v1.0.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md), [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), and the maintained MEL docs.
+- The current behavior now lives in [SPEC-v1.1.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md), [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), and the maintained MEL docs.
 - This ADR remains the architectural rationale for `dispatchable when`; the owning package specs define the current runtime and compiler behavior.
 
 ### ADR-021 Companion Notes
@@ -135,6 +136,12 @@ These ADRs affect multiple packages across the monorepo:
 - ADR-021 is accepted and reflected in the current compiler contract and maintained MEL docs for the current v1 surface.
 - The current landed/documented subset excludes `action_param`; that grammar decision remains deferred.
 - Core, Host, and SDK runtime entrypoints remain annotation-blind.
+
+### ADR-022 Companion Notes
+
+- ADR-022 is accepted as the compiler-owned source-location sidecar decision for declaration-level MEL provenance.
+- The canonical accepted record is [ADR-022 v11](./022-compiler-owned-source-location-sidecar-source-map-index); earlier review iterations are preserved in the inline revision history rather than separate archived ADR files.
+- `SourceMapIndex` is additive tooling-only output and does not change `DomainSchema.hash`, `SchemaGraph`, or runtime entrypoints.
 
 ### ADR-017 Version Notes
 

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -162,14 +162,27 @@
 
 ### DomainModule
 
-**Definition:** A compiler tooling artifact returned by additive seams such as `compileMelModule()`. It carries the compiled `DomainSchema` plus compiler-owned helper artifacts such as `SchemaGraph` and `AnnotationIndex`.
+**Definition:** A compiler tooling artifact returned by additive seams such as `compileMelModule()`. It carries the compiled `DomainSchema` plus compiler-owned helper artifacts such as `SchemaGraph` and tooling-only sidecars including `AnnotationIndex` and `SourceMapIndex`.
 
 **Key properties:**
-- Contains `schema`, `graph`, and `annotations`
+- Contains `schema`, `graph`, `annotations`, and `sourceMap`
 - Exists for tooling, inspection, and external consumers
 - Is not accepted by runtime seams such as `createManifesto()`; runtime consumes `DomainSchema` only
 
 **See also:** [Compiler](#compiler), [DomainSchema](#domainschema)
+
+---
+
+### SourceMapIndex
+
+**Definition:** A compiler-owned tooling sidecar that records declaration-level MEL source spans for emitted schema targets.
+
+**Key properties:**
+- Keyed to the emitted schema by `schemaHash` and to the physical source text by `sourceHash`
+- Carries explicit coordinate encoding via `coordinateUnit` and emission identity via `emissionFingerprint`
+- Remains outside `DomainSchema`, `SchemaGraph`, and runtime input seams
+
+**See also:** [Compiler](#compiler), [DomainModule](#domainmodule)
 
 ---
 

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -57,6 +57,7 @@ Records of significant architectural decisions:
 | [ADR-019](./adr/019-post-activation-extension-kernel) | Post-Activation Extension Kernel — Safe Public Seam for Arbitrary-Snapshot Operations | Implemented |
 | [ADR-020](./adr/020-intent-level-dispatchability) | Intent-Level Dispatchability — `dispatchable when` Clause | Implemented |
 | [ADR-021](./adr/021-mel-structural-annotation-system-meta-sidecar) | MEL Structural Annotation System — `@meta` Sidecar | Accepted |
+| [ADR-022](./adr/022-compiler-owned-source-location-sidecar-source-map-index) | Compiler-Owned Source Location Sidecar (`SourceMapIndex`) | Accepted |
 
 Status meanings (Proposed, Accepted, Implemented, Withdrawn, etc.) are defined in [ADR Status Definitions](./adr/#adr-status-definitions).
 

--- a/docs/internals/spec/current-contract.md
+++ b/docs/internals/spec/current-contract.md
@@ -1,7 +1,7 @@
 # Current Contract
 
 > **Status:** Living Document
-> **Last Updated:** 2026-04-14
+> **Last Updated:** 2026-04-16
 > **Purpose:** Single-source current contract for external consumers, canonical-doc exports, and current-surface onboarding
 
 This document is the current-only contract summary for the active Manifesto workspace.
@@ -38,7 +38,7 @@ This is the canonical entry story for new integrations.
 | `@manifesto-ai/core` | [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md) (current through v4.2.0) | Pure semantic runtime, schema validation, patch/apply semantics |
 | `@manifesto-ai/host` | [host-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC.md) (current through v4.0.0) | Effect execution, compute loop orchestration, canonical snapshot substrate |
 | `@manifesto-ai/sdk` | [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md) (current v3.x surface) | Activation-first application surface, intent creation/dispatch, additive base write reports, simulation, projected introspection |
-| `@manifesto-ai/compiler` | [SPEC-v1.0.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md) | Full current MEL compiler contract |
+| `@manifesto-ai/compiler` | [SPEC-v1.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md) | Full current MEL compiler contract |
 | `@manifesto-ai/lineage` | [lineage-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/lineage/docs/lineage-SPEC.md) (current v3.x decorator surface) | Seal-aware continuity, additive lineage write reports, canonical snapshot persistence, restore |
 | `@manifesto-ai/governance` | [governance-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/governance-SPEC.md) (current v3.x decorator surface) | Proposal legitimacy, governed runtime gate over lineage-composed manifesto, settlement observation and settlement reports |
 
@@ -104,7 +104,7 @@ Current extension seam:
 
 `@manifesto-ai/compiler` is now described by one current full contract:
 
-- [SPEC-v1.0.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md)
+- [SPEC-v1.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)
 
 Current MEL/compiler highlights:
 
@@ -112,6 +112,8 @@ Current MEL/compiler highlights:
 - `dispatchable when` is the bound-intent fine gate.
 - `dispatchable when` may read state, computed values, and bare action parameters.
 - `dispatchable when` does not allow direct `$input.*`, `$meta.*`, `$system.*`, or effects.
+- tooling-only compiler sidecars now include structural annotations and declaration-level source maps through `DomainModule`
+- runtime seams continue to consume `DomainSchema` only; `DomainModule` remains tooling-only
 - The compiler preserves precise type information through `TypeDefinition`.
 - `state.fields` / `action.input` remain compatibility surfaces.
 - `state.fieldTypes` / `action.inputType` / `action.params` are the authoritative emitted typing seams for current consumers.

--- a/docs/internals/spec/index.md
+++ b/docs/internals/spec/index.md
@@ -7,7 +7,7 @@ If you need a single current-surface document without version-history context, s
 :::
 
 ::: tip Single Source of Truth
-Specifications are maintained in canonical package docs with version indexes. The current hard-cut surface is: `@manifesto-ai/core` v4.2.0, `@manifesto-ai/host` v4.0.0, `@manifesto-ai/sdk` v3.5.0 activation-first plus `sdk/extensions`, and `@manifesto-ai/compiler` v1.0.0 as the rolled-up MEL compiler contract, with `@manifesto-ai/lineage` / `@manifesto-ai/governance` as the governed decorator packages. Draft package work that is not yet implemented is listed separately below.
+Specifications are maintained in canonical package docs with version indexes. The current hard-cut surface is: `@manifesto-ai/core` v4.2.0, `@manifesto-ai/host` v4.0.0, `@manifesto-ai/sdk` v3.5.0 activation-first plus `sdk/extensions`, and `@manifesto-ai/compiler` v1.1.0 as the rolled-up MEL compiler contract, with `@manifesto-ai/lineage` / `@manifesto-ai/governance` as the governed decorator packages. Draft package work that is not yet implemented is listed separately below.
 :::
 
 If you want the governing documentation rules, see [Documentation Governance](../documentation-governance.md).
@@ -39,7 +39,7 @@ If an older ADR conflicts with a current package SPEC on runtime surface details
 | **@manifesto-ai/governance** | [Living Document](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/governance-SPEC.md) (v3.x surface) | Normative (decorator legitimacy package + additive `waitForProposal()` settlement observer + additive `waitForProposalWithReport()` settlement-report helper) | [VERSION-INDEX](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/VERSION-INDEX.md) |
 | **@manifesto-ai/runtime** | Retired | Superseded (ADR-010, no successor) — package removed from workspace | — |
 | **App facade (retired)** | Removed (R2) | Historical reference only | [Retired Page](/internals/retired/app) |
-| **@manifesto-ai/compiler** | [SPEC-v1.0.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md) | Normative full MEL compiler contract | [VERSION-INDEX](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/VERSION-INDEX.md) |
+| **@manifesto-ai/compiler** | [SPEC-v1.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md) | Normative full MEL compiler contract | [VERSION-INDEX](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/VERSION-INDEX.md) |
 
 > **Current Governed Direction:** `createManifesto() -> withLineage() -> withGovernance() -> activate()`
 
@@ -94,8 +94,8 @@ The `@manifesto-ai/runtime` package is **retired**. Its responsibilities are abs
 
 ### Compiler (MEL)
 
-- **Compiler SPEC v1.0.0** (Current Full)
-  - [SPEC-v1.0.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.0.0.md)
+- **Compiler SPEC v1.1.0** (Current Full)
+  - [SPEC-v1.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)
   - Rolls up `SchemaGraph`, `dispatchable when`, `TypeDefinition`-backed schema-position lowering, and pure collection builtins into the current MEL compiler contract
 
 ---
@@ -111,16 +111,16 @@ The `@manifesto-ai/runtime` package is **retired**. Its responsibilities are abs
 | 03-31 | Governance | v2.0.0 | Governance v2 landed: remove accumulated-error assumptions, remap provenance to `SealAttempt`, and align governance/world seam to the current typed surface |
 | 03-31 | Host | v4.0.0 | Current Host alignment follows the Core v4 Snapshot contract and removes `system.errors` from Host-facing Snapshot references |
 | 03-31 | SDK | v2.0.0 | Historical pre-ADR-017 SDK surface aligned to the Core v4 Snapshot contract before the activation-first hard cut |
-| 03-28 | Governance | v1.0.0 | Governance living SPEC created; package version index added |
+| 03-28 | Governance | v1.1.0 | Governance living SPEC created; package version index added |
 | 03-28 | Lineage | v1.0.1 | Lineage living SPEC patch release: adds `BranchInfo.epoch`, `LineageService.getBranch()`, and public-contract epoch reads |
 | 03-24 | Compiler | v0.7.0 | Draft compiler SPEC refreshed for ADR-013a (`flow`/`include`) and ADR-013b entity collection primitives |
-| 03-02 | SDK | v1.0.0 | ADR-010 hard cut: `createManifesto()` sole entrypoint, Runtime retired |
+| 03-02 | SDK | v1.1.0 | ADR-010 hard cut: `createManifesto()` sole entrypoint, Runtime retired |
 
 ### Recent Changes (2026-04)
 
 | Date | Package | Version | Change |
 |------|---------|---------|--------|
-| 04-08 | Compiler | v1.0.0 | Current full compiler spec rolls up v0.7.0 + addenda and lands `TypeDefinition`-backed nullable/record schema-position lowering plus expression-level collection builtins |
+| 04-08 | Compiler | v1.1.0 | Current full compiler spec rolls up v0.7.0 + addenda and lands `TypeDefinition`-backed nullable/record schema-position lowering plus expression-level collection builtins |
 | 04-08 | Core | v4.2.0 | Living Core spec now treats `state.fieldTypes` / `action.inputType` as the normative runtime typing seam while keeping `FieldSpec` as the compatibility surface |
 | 04-07 | Core | v4.1.0 | Living Core spec adds `ActionSpec.dispatchable` and the pure `isIntentDispatchable()` query without changing `available` semantics |
 | 04-07 | SDK | v3.4.0 | Living SDK spec adds intent dispatchability queries, blocker explanations, metadata flagging, and dispatch/simulate rejection split |

--- a/docs/mel/REFERENCE.md
+++ b/docs/mel/REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Purpose:** The single document a user reads to learn and use MEL. Covers every function, construct, and pattern with examples.
 > **Audience:** Developers writing MEL domains. Both beginners and experienced users.
-> **Normative sources:** SPEC-v1.0.0.md (current full compiler contract), validator.ts (function signatures), lower-expr.ts (supported functions).
+> **Normative sources:** SPEC-v1.1.0.md (current full compiler contract), validator.ts (function signatures), lower-expr.ts (supported functions).
 
 ---
 
@@ -1823,4 +1823,4 @@ domain Toggles {
 
 ---
 
-*Authoritative sources: SPEC-v1.0.0.md, packages/compiler/src/analyzer/validator.ts, packages/compiler/src/lowering/lower-expr.ts.*
+*Authoritative sources: SPEC-v1.1.0.md, packages/compiler/src/analyzer/validator.ts, packages/compiler/src/lowering/lower-expr.ts.*

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -216,7 +216,7 @@ type CompileOptions = {
 | [MEL Syntax](../../docs/mel/SYNTAX.md) | Grammar and syntax |
 | [MEL Examples](../../docs/mel/EXAMPLES.md) | Example library |
 | [MEL Error Guide](../../docs/mel/ERROR-GUIDE.md) | Error codes and fixes |
-| [Compiler Spec](docs/SPEC-v1.0.0.md) | Current full compiler and MEL spec |
+| [Compiler Spec](docs/SPEC-v1.1.0.md) | Current full compiler and MEL spec |
 | [Compiler FDR](docs/FDR-v0.5.0.md) | Design rationale |
 | [Compiler Compliance Suite](docs/compiler-SPEC-compilance-test-suite.md) | CCTS structure, rule modes, and execution guide |
 

--- a/packages/compiler/docs/SPEC-v1.1.0.md
+++ b/packages/compiler/docs/SPEC-v1.1.0.md
@@ -1,0 +1,663 @@
+# MEL Compiler SPEC v1.1.0
+
+> **Version:** 1.1.0
+> **Type:** Full
+> **Status:** Normative
+> **Date:** 2026-04-16
+> **Replaces:** v1.0.0 as the current full compiler contract
+> **Compatible with:** Core SPEC v4.2.0, current SDK activation-first contract
+
+---
+
+## Changelog
+
+### v1.1.0
+
+- add `SourceMapIndex` as a compiler-owned, tooling-only declaration-level source location sidecar on `DomainModule`
+- add `SourceMapEmissionContext` as the explicit emission-context contract for deterministic source-map extraction
+- split sidecar cache identity by artifact class while preserving the existing runtime-facing `DomainSchema` contract
+- reaffirm that action-level trace replay is the current stable join scope for source-map consumers
+
+---
+
+## 1. Purpose
+
+This document is the **current full MEL compiler contract**.
+
+It consolidates the landed compiler surface into one current contract, including:
+
+- the active full MEL/compiler baseline
+- `SchemaGraph` extraction
+- structural annotations via `@meta` with a tooling-only sidecar
+- compiler-owned declaration-level source locations via `SourceMapIndex`
+- `dispatchable when`
+- current landed compiler/runtime alignment for `Record<string, T>` and `T | null` in schema positions
+- current landed support for pure collection builtins in expression contexts
+- current clarification that additive MEL surface forms must preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary
+
+Historical compiler docs remain useful for archaeology, but **this file is the current truth**.
+
+---
+
+## 2. Current Output Contract
+
+The current compiler contract defines four distinct artifacts:
+
+- `DomainSchema` as the semantic runtime artifact returned by existing schema-only compile entrypoints
+- `SchemaGraph` as the projected static dependency artifact
+- `AnnotationIndex` as the tooling-only structural sidecar
+- `SourceMapIndex` as the tooling-only declaration-level source location sidecar
+
+Additive compiler/tooling entrypoints MAY expose those artifacts together through a module envelope:
+
+```typescript
+type DomainModule = {
+  readonly schema: DomainSchema;
+  readonly graph: SchemaGraph;
+  readonly annotations: AnnotationIndex;
+  readonly sourceMap: SourceMapIndex;
+};
+```
+
+Within `DomainSchema`, the compiler emits three distinct type-carrying seams:
+
+```typescript
+type DomainSchema = {
+  readonly types: Record<string, TypeSpec>;
+  readonly state: StateSpec;
+  readonly actions: Record<string, ActionSpec>;
+  // ...
+};
+
+type StateSpec = {
+  readonly fields: Record<string, FieldSpec>;
+  readonly fieldTypes?: Record<string, TypeDefinition>;
+};
+
+type ActionSpec = {
+  readonly flow: FlowNode;
+  readonly input?: FieldSpec;
+  readonly inputType?: TypeDefinition;
+  readonly params?: readonly string[];
+  readonly available?: ExprNode;
+  readonly dispatchable?: ExprNode;
+  readonly description?: string;
+};
+```
+
+Normative meaning:
+
+- `schema` is the semantic runtime artifact. Core, Host, and SDK runtime entrypoints remain `DomainSchema`-only.
+- `graph` is the projected static dependency artifact extracted from `schema` alone.
+- `annotations` is a tooling-only structural sidecar and MUST remain out-of-schema.
+- `sourceMap` is a tooling-only declaration-level source location sidecar and MUST remain out-of-schema.
+- schema-only compiler entrypoints MAY continue to expose `DomainSchema` without wrapping it in `DomainModule`.
+- `types` preserves named MEL type declarations losslessly.
+- `state.fields` and `action.input` are the **compatibility / coarse introspection seam**.
+- `state.fieldTypes` and `action.inputType` are the **normative runtime typing seam** when present.
+- `action.params` is the normative parameter-order seam.
+
+The compiler MUST preserve precise type information in `fieldTypes` / `inputType` whenever the source schema uses shapes that are wider than `FieldSpec`.
+
+---
+
+## 3. Type Lowering
+
+### 3.1 Lossless Type Preservation
+
+The compiler MUST preserve full MEL type information in `DomainSchema.types` using `TypeDefinition`.
+
+```typescript
+type TypeDefinition =
+  | { kind: "primitive"; type: string }
+  | { kind: "array"; element: TypeDefinition }
+  | { kind: "record"; key: TypeDefinition; value: TypeDefinition }
+  | { kind: "object"; fields: Record<string, { type: TypeDefinition; optional: boolean }> }
+  | { kind: "union"; types: TypeDefinition[] }
+  | { kind: "literal"; value: string | number | boolean | null }
+  | { kind: "ref"; name: string };
+```
+
+### 3.2 Compatibility FieldSpec Lowering
+
+`FieldSpec` is still emitted, but it is no longer the sole normative runtime boundary.
+
+The compiler MUST lower schema-position types according to the following table:
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| TYPE-LOWER-1 | MUST | Action parameters MUST lower to `ActionSpec.input` as a compatibility `FieldSpec` object with named fields |
+| TYPE-LOWER-2 | MUST | Named object types MUST inline into compatibility `FieldSpec.fields` when representable |
+| TYPE-LOWER-3 | MUST | `Array<T>` MUST lower to `FieldSpec { type: "array", items: ... }` when `T` is compatibility-representable |
+| TYPE-LOWER-4 | MUST | Literal-only unions MUST lower to enum `FieldSpec` where sound |
+| TYPE-LOWER-5 | MUST | Inline object types in schema positions MUST remain visible to users through diagnostics/introspection |
+| TYPE-LOWER-6 | MUST | `T \| null` in state/action-input positions MUST compile and preserve precise nullability through `fieldTypes` / `inputType` |
+| TYPE-LOWER-7 | MUST | `Record<string, T>` in state/action-input positions MUST compile and preserve precise value typing through `fieldTypes` / `inputType` |
+| TYPE-LOWER-8 | MUST | Non-trivial unions that are not nullable or literal-enum compatible MUST remain compile errors (`E043`) |
+| TYPE-LOWER-9 | MUST | Recursive schema-position refs that cannot be soundly lowered for runtime validation MUST remain compile errors (`E044`) |
+
+### 3.3 Nullable Types
+
+`T | null` is supported in state fields and action input positions.
+
+Normative rules:
+
+- nullable lowering MUST preserve the exact branch structure in `fieldTypes` / `inputType`
+- compatibility `FieldSpec` MAY degrade to the non-null branch for coarse shape/tooling
+- runtime validation MUST distinguish:
+  - missing field
+  - explicit `null`
+  - non-null value of type `T`
+
+`nullable` means **present-or-null**, not “optional by another name.”
+
+### 3.4 Record Types
+
+`Record<string, T>` is supported in state fields and action input positions.
+
+Normative rules:
+
+- record keys remain string-keyed only
+- `fieldTypes` / `inputType` MUST preserve the declared record value type
+- compatibility `FieldSpec` MAY degrade records to coarse `{ type: "object" }`
+- runtime validation MUST validate each record entry value against `T`
+
+### 3.5 Action Input Lowering
+
+For actions with declared parameters, the compiler MUST emit:
+
+- `action.params` in declared source order
+- `action.inputType` as an object-shaped `TypeDefinition`
+- `action.input` as the compatibility/coarse `FieldSpec` seam
+
+This split is normative. Consumers that need exact typing MUST prefer `params` plus `inputType`.
+
+---
+
+## 4. State Initializers and Literal Checking
+
+The compiler MUST evaluate state initializer expressions to concrete JSON values where the source expression is statically literal.
+
+When a concrete literal value is available:
+
+- compatibility checks MAY use `FieldSpec`
+- precise checks MUST use `TypeDefinition` when available
+
+Static literal mismatch diagnostics MUST continue to point at nested locations such as:
+
+- `current.id`
+- `current.done`
+- `nums[1]`
+
+---
+
+## 5. Pure Collection Builtins
+
+The current compiler surface supports the following collection builtins in expression contexts:
+
+- `filter(arr, pred)`
+- `map(arr, expr)`
+- `find(arr, pred)`
+- `every(arr, pred)`
+- `some(arr, pred)`
+
+Normative rules:
+
+- these functions are expression-level builtins, not effects
+- `$item` is valid only inside the predicate/mapper expression they introduce
+- hidden accumulation remains forbidden
+- aggregation composition rules remain unchanged: `sum()`, `min()`, and `max()` require a direct state/computed reference, not an inline transformed expression
+
+Examples:
+
+```mel
+computed active = filter(items, eq($item.active, true))
+computed firstOpen = find(items, eq($item.status, "open"))
+computed allDone = every(tasks, eq($item.done, true))
+
+// still forbidden
+computed bad = sum(filter(prices, gt($item, 0)))
+```
+
+### 5.1 Additional Explicit MEL Surface Forms
+
+The builtin and collection surface defined in this spec is the **current** MEL source contract.
+
+Any additive MEL surface form beyond the builtin set explicitly defined here MUST satisfy all of the following:
+
+- it MUST be admitted explicitly at the MEL source level rather than appearing as an undocumented parser or lowering convenience
+- it MUST preserve the current meanings of existing builtin names such as `floor`, `ceil`, `min`, `max`, `filter`, `map`, `find`, `every`, and `some`
+- it MUST remain representable as an explicit MEL canonical expression or flow form through validation and type checking
+- lowering to Core Runtime IR MUST occur only at the existing MEL → Core lowering boundary
+- the lowered result MUST use existing Core/runtime expression and flow kinds only
+- user-defined accumulation, runtime-shaped iteration, dynamic dispatch, and other general-computation constructs remain forbidden
+
+Entity primitives are the current precedent for this pattern: they remain explicit MEL surface forms until the lowering boundary and then lower into existing Core/runtime kinds without changing the underlying runtime model.
+
+Only ordinary function-call forms are part of this contract. No new arm syntax, named arguments, or parser-only shorthand is implied here.
+
+The following bounded function forms are admitted under that rule:
+
+#### `absDiff(a, b)`
+
+- signature: `(number, number) -> number`
+- lowering: `abs(sub(a, b))`
+- both arguments MUST be numbers
+
+#### `clamp(x, lo, hi)`
+
+- signature: `(number, number, number) -> number`
+- lowering: `min(max(x, lo), hi)`
+- all arguments MUST be numbers
+- bounds MUST NOT be reordered implicitly
+- when both bounds are statically literal numbers and `lo > hi`, the compiler MUST reject the call
+- this does NOT change the existing meanings of unary `floor()` or `ceil()`
+
+#### `idiv(a, b)`
+
+- signature: `(number, number) -> number | null`
+- lowering: `floor(div(a, b))`
+- both arguments MUST be numbers
+- negative results MUST follow mathematical floor semantics, not truncation toward zero
+- zero-divisor behavior MUST inherit existing `div()` semantics, including `null` on zero
+
+#### `streak(prev, cond)`
+
+- signature: `(number, boolean) -> number`
+- lowering: `cond(cond, add(prev, 1), 0)`
+- `prev` MUST be a number
+- `cond` MUST be a boolean
+
+#### `match(key, [k1, v1], [k2, v2], ..., defaultValue)`
+
+- source form example: `match(status, ["open", 1], ["closed", 0], -1)`
+- the call MUST contain at least one arm and one default value
+- each arm MUST be an inline 2-item array literal `[matchKey, value]`
+- each `matchKey` MUST be a literal `string`, `number`, or `boolean`
+- the final positional argument MUST be the default value
+- `key` and every `matchKey` MUST have the same comparable primitive type: `string`, `number`, or `boolean`
+- duplicate literal arm keys MUST be rejected
+- all arm values and the default value MUST unify to one result type
+- lowering: nested `cond(eq(key, kN), vN, ...)` in source order
+
+#### `argmax([label, eligible, score], ..., tieBreak)`
+
+- source form example: `argmax(["a", aOk, aScore], ["b", bOk, bScore], "first")`
+- the call MUST contain at least one candidate and one tie-break literal
+- each candidate MUST be an inline 3-item array literal `[label, eligible, score]`
+- `eligible` MUST be boolean
+- `score` MUST be number
+- all labels MUST unify to one primitive scalar type: `string`, `number`, or `boolean`
+- the final positional argument MUST be the literal `"first"` or `"last"`
+- runtime-array forms such as `argmax(items, "first")` are NOT part of this contract
+- if no candidate is eligible, the result MUST be `null`
+- `"first"` MUST select the earliest source-order candidate among equal eligible maxima
+- `"last"` MUST select the latest source-order candidate among equal eligible maxima
+- lowering MUST use only existing conditional and comparison structure; tie-break determinism MUST be expressed through `gt`/`gte` selection order
+
+#### `argmin([label, eligible, score], ..., tieBreak)`
+
+- source form example: `argmin(["a", aOk, aScore], ["b", bOk, bScore], "last")`
+- candidate shape, label rules, and tie-break rules are identical to `argmax`
+- runtime-array forms are NOT part of this contract
+- if no candidate is eligible, the result MUST be `null`
+- `"first"` MUST select the earliest source-order candidate among equal eligible minima
+- `"last"` MUST select the latest source-order candidate among equal eligible minima
+- lowering MUST use only existing conditional and comparison structure; tie-break determinism MUST be expressed through `lt`/`lte` selection order
+
+Non-goals of this admission rule:
+
+- no `match(expr, "k" => v)` arrow-arm syntax
+- no `tieBreak: "first"` named-argument syntax
+- no runtime-array `argmax(items, scoreFn)` or `argmin(items, scoreFn)`
+- no reinterpretation of existing builtin meanings such as `floor`, `ceil`, `min`, `max`, `filter`, `map`, `find`, `every`, or `some`
+
+---
+
+## 6. Intent Dispatchability
+
+`available when` remains the coarse action-family gate.
+
+`dispatchable when` is part of the current full compiler contract:
+
+- it MAY reference state, computed values, and bare action parameter names
+- it MUST NOT allow direct `$input.*` syntax in source
+- it MUST NOT allow `$meta.*`, `$system.*`, or effects
+- it MUST lower to `ActionSpec.dispatchable`
+
+If both clauses are present, ordering is fixed:
+
+```ebnf
+ActionDecl ::= 'action' Identifier '(' Params? ')' AvailableClause? DispatchableClause? '{' ActionBody '}'
+```
+
+---
+
+## 7. SchemaGraph
+
+`SchemaGraph` is part of the current compiler contract.
+
+The compiler MUST continue to extract the projected static graph with:
+
+- nodes: `state`, `computed`, `action`
+- edges: `feeds`, `mutates`, `unlocks`
+
+`dispatchable when` is input-bound and MUST NOT be projected into `SchemaGraph`.
+`unlocks` remains derived from `available when` only.
+Structural annotations and source-map sidecars MUST NOT alter graph nodes, graph edges, or graph derivation.
+
+---
+
+## 8. Tooling Sidecars
+
+### 8.1 Surface and Target Model
+
+`@meta` is part of the current MEL surface as a structural annotation form.
+
+Source form:
+
+```mel
+@meta("namespace:kind")
+@meta("namespace:kind", { key: "value", enabled: true })
+```
+
+Normative rules:
+
+- `@meta` uses prefix syntax and attaches to the immediately following construct.
+- Multiple annotations MAY stack on the same target.
+- The compiler MUST treat the tag string as opaque. Namespace or kind semantics are consumer-owned.
+- Current v1 attachable targets are:
+  - `domain`
+  - `type`
+  - `type_field`
+  - `state_field`
+  - `computed`
+  - `action`
+- For `type_field` and `state_field`, the same prefix form appears immediately above the field declaration inside the enclosing block.
+- `action_param` annotations are deferred from the current v1 contract and are NOT part of current MEL syntax.
+
+Examples:
+
+```mel
+@meta("doc:summary", { area: "tasks" })
+domain TaskBoard {
+  @meta("doc:entity")
+  type Task = {
+    id: string,
+    @meta("ui:hidden")
+    internalNote: string | null
+  }
+
+  state {
+    @meta("analytics:track")
+    lastArchivedId: string | null = null
+  }
+
+  @meta("ui:primary-list")
+  computed hasArchivedTask = isNotNull(lastArchivedId)
+
+  @meta("ui:button", { variant: "secondary" })
+  action archive(id: string) {
+    when true {
+      patch lastArchivedId = id
+    }
+  }
+}
+```
+
+### 8.2 Sidecar Types and Boundaries
+
+Annotations compile into a tooling-only sidecar. They MUST NOT appear inside `DomainSchema` or `SchemaGraph`.
+
+```typescript
+type AnnotationIndex = {
+  readonly schemaHash: string;
+  readonly entries: Record<LocalTargetKey, readonly Annotation[]>;
+};
+
+type LocalTargetKey = string;
+
+type Annotation = {
+  readonly tag: string;
+  readonly payload?: JsonLiteral;
+};
+
+type JsonLiteral =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonLiteral[]
+  | { readonly [key: string]: JsonLiteral };
+```
+
+Current v1 `LocalTargetKey` forms are:
+
+```text
+domain:<DomainName>
+type:<TypeName>
+type_field:<TypeName>.<FieldName>
+state_field:<FieldName>
+computed:<ComputedName>
+action:<ActionName>
+```
+
+Current v1 emission rules:
+
+- `schemaHash` MUST equal `hash` on the emitted `DomainSchema`.
+- `entries` MUST include only targets that carry at least one annotation.
+- `entries` MUST NOT contain empty annotation arrays.
+- stacked annotations on the same target MUST preserve source order.
+- repeated tags on the same target MUST NOT be deduplicated by the compiler.
+- sidecar emission order MUST be deterministic for a fixed source input.
+
+Normative rules:
+
+- `schemaHash` scopes the entire annotation sidecar to one emitted semantic schema.
+- Every emitted `LocalTargetKey` MUST map to an existing construct in the emitted `DomainSchema`.
+- Child targets use exactly one dotted segment (`Parent.Child`) in the current contract.
+- The sidecar MAY be exposed only by additive compiler/tooling entrypoints. It MUST NOT become a runtime input artifact.
+
+### 8.3 Payload Model
+
+Payloads are JSON-like literals only.
+
+Permitted payload values:
+
+- strings
+- numbers
+- booleans
+- `null`
+- arrays of JSON-like literals
+- objects whose values are JSON-like literals
+
+Current v1 payload restrictions:
+
+- payload is optional
+- maximum nesting depth is 2
+- MEL expressions are forbidden
+- semantic references are forbidden
+- guard references or runtime predicates are forbidden
+
+Examples:
+
+```mel
+// valid
+@meta("ui:button", { variant: "primary", size: "lg" })
+@meta("doc:priority", 3)
+
+// invalid: MEL expression in payload
+@meta("ui:button", { disabled: eq(len(items), 0) })
+
+// invalid: depth > 2
+@meta("ui:card", { config: { pricing: { free: "$0" } } })
+```
+
+### 8.4 Annotation Rules and Invariants
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| META-1 | MUST | The compiler MUST remain namespace-blind for annotation tags and payload meaning |
+| META-2 | MUST | Annotations MUST exist only in `AnnotationIndex`, never in `DomainSchema` or `SchemaGraph` |
+| META-3 | MUST | Annotation presence or absence MUST NOT affect schema hash, `compute()`, availability, dispatchability, or other runtime semantics |
+| META-4 | MUST | Runtime entrypoints MUST continue to accept `DomainSchema` only, not `DomainModule` |
+| META-5 | MUST | The compiler MUST validate emitted annotation targets against the emitted `DomainSchema` structure |
+| META-6 | MUST | Payloads MUST be JSON-like literals only, with current v1 nesting depth capped at 2 |
+| META-7 | MUST | Semantic validation of namespace-specific annotation meaning MUST remain consumer-owned |
+| META-8 | MUST | Stacked annotations on the same target MUST preserve source order and repeated tags MUST NOT be deduplicated |
+| META-9 | MUST | `AnnotationIndex.schemaHash` MUST equal `hash` on the emitted `DomainSchema` |
+| META-10 | MUST | `AnnotationIndex.entries` MUST omit unannotated targets and empty arrays, and emission order MUST be deterministic |
+
+Current invariants:
+
+| Invariant | Meaning |
+|-----------|---------|
+| INV-META-1 | Removing all `@meta` from MEL source MUST leave emitted `DomainSchema` byte-identical |
+| INV-META-2 | Removing all `@meta` from MEL source MUST leave emitted `SchemaGraph` identical |
+| INV-META-3 | For any snapshot and intent, `compute()` results MUST remain identical regardless of annotation presence |
+| INV-META-4 | For any snapshot, `getAvailableActions()` MUST remain identical regardless of annotation presence |
+| INV-META-5 | For any snapshot and intent, `isIntentDispatchable()` MUST remain identical regardless of annotation presence |
+| INV-META-6 | Tooling-only `DomainModule` artifacts MUST remain outside runtime schema-input seams |
+
+### 8.5 Compiler-Owned Source Location Sidecar
+
+`SourceMapIndex` is a compiler-owned sibling sidecar to `AnnotationIndex`. It records declaration-level MEL source spans for tooling and inspection consumers.
+
+It MUST remain outside `DomainSchema`, `SchemaGraph`, and runtime entrypoint contracts.
+
+```typescript
+type SourceMapIndex = {
+  readonly schemaHash: string;
+  readonly sourceHash: string;
+  readonly format: "manifesto/source-map-v1";
+  readonly coordinateUnit: "utf16" | "bytes";
+  readonly emissionFingerprint: string;
+  readonly entries: Record<LocalTargetKey, SourceMapEntry>;
+};
+
+type SourceMapEntry = {
+  readonly target: SourceMapPath;
+  readonly span: SourceSpan;
+};
+
+type SourceMapPath =
+  | { readonly kind: "domain"; readonly domain: { readonly name: string } }
+  | { readonly kind: "type"; readonly type: { readonly name: string } }
+  | {
+      readonly kind: "type_field";
+      readonly type: { readonly name: string };
+      readonly field: { readonly name: string };
+    }
+  | { readonly kind: "state_field"; readonly field: { readonly name: string } }
+  | { readonly kind: "computed"; readonly computed: { readonly name: string } }
+  | { readonly kind: "action"; readonly action: { readonly name: string } };
+
+type SourceSpan = {
+  readonly start: SourcePoint;
+  readonly end: SourcePoint;
+};
+
+type SourcePoint = {
+  readonly line: number;
+  readonly column: number;
+  readonly offset?: number;
+};
+
+type SourceMapEmissionContext = {
+  readonly coordinateUnit: "utf16" | "bytes";
+  readonly compilerVersion: string;
+  readonly emissionOptionsFingerprint: string;
+};
+```
+
+Current v1 `SourceMapPath.kind` forms are byte-identical to the landed `LocalTargetKey` kind set:
+
+```text
+domain
+type
+type_field
+state_field
+computed
+action
+```
+
+Current v1 source-map scope:
+
+- declaration-level mappings only
+- no body-statement resolution
+- no `action_param` mappings in the current landed subset
+
+Current v1 cache scope by artifact:
+
+| Artifact | Cache identity |
+|---------|----------------|
+| `DomainSchema` / `SchemaGraph` | `schemaHash` |
+| `AnnotationIndex` | `(schemaHash, sourceHash)` under a fixed compiler version |
+| `SourceMapIndex` / `DomainModule` | `(schemaHash, sourceHash, emissionFingerprint)` |
+
+Normative rules:
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SMAP-1 | MUST | `SourceMapIndex` MUST exist only as a tooling-only out-of-schema sidecar |
+| SMAP-2 | MUST | `DomainModule.sourceMap` MUST be the only current compiler-owned source-location surface |
+| SMAP-3 | MUST | `SourceMapIndex.schemaHash` MUST equal `hash` on the emitted `DomainSchema` |
+| SMAP-4 | MUST | `SourceMapIndex.entries` MUST use the same current landed target-key universe as `AnnotationIndex` |
+| SMAP-5 | MUST | `SourceMapEntry.target` MUST structurally agree with its `LocalTargetKey` entry key |
+| SMAP-6 | MUST | `format` and `coordinateUnit` MUST remain separate fields; `format` is protocol version, `coordinateUnit` is payload encoding |
+| SMAP-7 | MUST | `emissionFingerprint` MUST be deterministic for a fixed semantic source and `SourceMapEmissionContext` |
+| SMAP-8 | MUST | source-map extraction MUST be modeled as a deterministic compiler operation over emitted source/module inputs plus explicit `SourceMapEmissionContext` |
+| SMAP-9 | MUST | `SourceMapIndex` and `DomainModule` caching MUST use `(schemaHash, sourceHash, emissionFingerprint)` rather than `schemaHash` alone |
+| SMAP-10 | MUST | current stable trace replay scope for source-map consumers is action-level only through `TraceGraph.intent.type -> action:<ActionName>` |
+| SMAP-11 | MUST NOT | consumers MUST NOT treat `TraceNode.sourcePath` as a stabilized compiler-side source-map contract in the current version |
+
+Current invariants:
+
+| Invariant | Meaning |
+|-----------|---------|
+| INV-SMAP-1 | Adding or removing `SourceMapIndex` emission MUST leave emitted `DomainSchema` byte-identical |
+| INV-SMAP-2 | Adding or removing `SourceMapIndex` emission MUST leave emitted `SchemaGraph` identical |
+| INV-SMAP-3 | For any snapshot and intent, runtime legality and compute results MUST remain identical regardless of source-map emission |
+| INV-SMAP-4 | Tooling-only `DomainModule` artifacts that carry `sourceMap` MUST remain outside runtime schema-input seams |
+
+---
+
+## 9. Diagnostics
+
+The following diagnostics remain active in this area:
+
+- `E043` for unsupported non-trivial schema-position unions
+- `E044` for recursive schema-position refs that cannot be soundly lowered
+- `E047` / `E048` for `dispatchable when` scope violations
+- `E053` for misplaced or floating `@meta`, including unsupported attachment sites
+- `E054` for unsupported `action_param` annotation syntax in the current contract
+- `E055` for annotation payload values that are not JSON-like literals, including MEL expressions and semantic references
+- `E056` for annotation payload nesting depth overflow
+- `E057` for emitted annotation targets that do not map to the emitted `DomainSchema`
+- `E058` for emitted source-map targets that do not map to the emitted `DomainSchema`
+
+The following historical diagnostics are superseded in the current contract:
+
+- `E045` nullable schema-position rejection
+- `E046` record schema-position rejection
+
+They remain historical references only and are no longer part of the current compiler surface.
+
+---
+
+## 10. Summary
+
+The current compiler contract is:
+
+- rich MEL types stay precise through `TypeDefinition`
+- compatibility `FieldSpec` remains available for coarse tooling and legacy consumers
+- nullable and record schema-position types are supported
+- pure collection builtins are supported in expressions
+- additive MEL surface expansions MUST preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary
+- structural annotations via `@meta` compile into a tooling-only `AnnotationIndex` sidecar
+- declaration-level source locations compile into a tooling-only `SourceMapIndex` sidecar on `DomainModule`
+- `action_param` annotations remain outside the current v1 surface
+- `dispatchable when` is part of the full action contract
+- `SchemaGraph` remains availability-only and input-independent
+
+This is the current full compiler surface to use for implementation, tooling, and documentation.

--- a/packages/compiler/docs/VERSION-INDEX.md
+++ b/packages/compiler/docs/VERSION-INDEX.md
@@ -1,18 +1,18 @@
 # MEL Compiler Documentation Index
 
 > **Package:** `@manifesto-ai/compiler`
-> **Last Updated:** 2026-04-15
+> **Last Updated:** 2026-04-16
 
 ---
 
 ## Latest Version
 
-- **Current Full SPEC:** [v1.0.0](SPEC-v1.0.0.md) (Full)
+- **Current Full SPEC:** [v1.1.0](SPEC-v1.1.0.md) (Full)
 - **FDR:** [v0.5.0](FDR-v0.5.0.md) (Full)
 
-**Note:** [v1.0.0](SPEC-v1.0.0.md) is the current integrated compiler contract. It rolls up the old v0.7.0 baseline plus the v0.8.0 `SchemaGraph` and v0.9.0 `dispatchable when` addenda, reflects the landed `TypeDefinition`-backed support for nullable and record schema-position types, clarifies that any future additive MEL surface forms must preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary, records the admitted bounded sugar function forms in parser-free function-call shape, and now includes tooling-only structural annotations via `@meta` with `action_param` explicitly deferred from the current v1 surface.
+**Note:** [v1.1.0](SPEC-v1.1.0.md) is the current integrated compiler contract. It carries forward the v1.0.0 baseline and adds the compiler-owned declaration-level source location sidecar `SourceMapIndex`, explicit source-map emission context, and artifact-specific cache identity rules while preserving the existing runtime-facing `DomainSchema` contract.
 
-**ADR Source:** [ADR-021](../../../docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md) is the architectural source for the current structural-annotation contract.
+**ADR Sources:** [ADR-021](../../../docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md) defines the current structural-annotation sidecar contract, and [ADR-022](../../../docs/internals/adr/022-compiler-owned-source-location-sidecar-source-map-index.md) defines the current source-location sidecar contract.
 
 ---
 
@@ -20,7 +20,8 @@
 
 | Version | SPEC | FDR | Type | Status |
 |---------|------|-----|------|--------|
-| v1.0.0 | [SPEC](SPEC-v1.0.0.md) | [FDR](FDR-v0.5.0.md) | Full | Current |
+| v1.1.0 | [SPEC](SPEC-v1.1.0.md) | [FDR](FDR-v0.5.0.md) | Full | Current |
+| v1.0.0 | [SPEC](SPEC-v1.0.0.md) | [FDR](FDR-v0.5.0.md) | Historical Full Predecessor | Superseded |
 | v0.9.0 | [SPEC](SPEC-v0.9.0.md) | [FDR](../../sdk/docs/FDR-v3.1.0-draft.md) | Historical Addendum (merged into v1.0.0) | Superseded |
 | v0.8.0 | [SPEC](SPEC-v0.8.0.md) | [FDR](../../sdk/docs/FDR-v3.1.0-draft.md) | Historical Addendum (merged into v1.0.0) | Superseded |
 | v0.7.0 | [SPEC](SPEC-v0.7.0.md) | [FDR](FDR-v0.5.0.md) | Historical Full Baseline | Superseded |
@@ -40,10 +41,10 @@
 
 ### For Current
 
-1. Read [SPEC-v1.0.0.md](SPEC-v1.0.0.md) for the current full compiler contract.
+1. Read [SPEC-v1.1.0.md](SPEC-v1.1.0.md) for the current full compiler contract.
 2. Use [SPEC-v0.8.0.md](SPEC-v0.8.0.md) and [SPEC-v0.9.0.md](SPEC-v0.9.0.md) only for historical addendum context.
 3. For rationale history, use [FDR-v0.5.0.md](FDR-v0.5.0.md).
-4. If you are working on structural annotations, read [SPEC-v1.0.0.md](SPEC-v1.0.0.md) for the current v1 contract, then [ADR-021](../../../docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md) for the architectural rationale and deferred `action_param` decision.
+4. If you are working on tooling sidecars, read [SPEC-v1.1.0.md](SPEC-v1.1.0.md) for the current v1.1 contract, then [ADR-021](../../../docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md) and [ADR-022](../../../docs/internals/adr/022-compiler-owned-source-location-sidecar-source-map-index.md) for architectural rationale.
 
 ### For v0.4.0 (Historical Patch)
 

--- a/packages/compiler/docs/compiler-SPEC-compilance-test-suite.md
+++ b/packages/compiler/docs/compiler-SPEC-compilance-test-suite.md
@@ -1,6 +1,6 @@
 # Compiler SPEC Compilance Test Suite (CCTS)
 
-> **Purpose:** Define the compliance harness for `@manifesto-ai/compiler` against the current MEL compiler contract in SPEC-v1.0.0.
+> **Purpose:** Define the compliance harness for `@manifesto-ai/compiler` against the current MEL compiler contract in SPEC-v1.1.0.
 > **Audience:** Compiler maintainers and contributors extending MEL semantics.
 > **Status:** Operational
 
@@ -48,7 +48,7 @@ packages/compiler/src/__tests__/compliance/
 
 The suite mirrors the Host HCTS shape, but adds explicit inventory and coverage layers:
 
-- spec inventory (`SPEC-v1.0.0.md` rule surface)
+- spec inventory (`SPEC-v1.1.0.md` rule surface)
 - shared rule registry
 - case/rule coverage map
 - test adapter wrapping exported APIs
@@ -101,7 +101,7 @@ Blocking rules reflect currently implemented compiler behavior:
 - `flow` / `include` composition and diagnostics (ADR-013a, `FLOW-*`, `E013`-`E024`)
 - entity primitives and placement/type diagnostics (ADR-013b, `ENTITY-*`, `TRANSFORM-*`, `E030`-`E035`)
 - schema-position lowering hardening (`A26`, `A28`, `A33`, `TYPE-LOWER-6`-`TYPE-LOWER-9`, `E040`-`E044`; `E045`/`E046` retained only as superseded inventory items)
-- structural annotations via `@meta`, including valid v1 target placement, literal-only payload enforcement, payload-depth enforcement, deterministic sidecar emission, semantic erasure invariants, and the runtime-boundary guard between `DomainSchema` and tooling-only `DomainModule`
+- structural annotations via `@meta`, plus declaration-level source maps via `SourceMapIndex`, including valid v1 target placement, literal-only payload enforcement, deterministic sidecar emission, source-map cache identity, semantic erasure invariants, and the runtime-boundary guard between `DomainSchema` and tooling-only `DomainModule`
 - deterministic compile/lower output
 
 ### Pending

--- a/packages/compiler/src/__tests__/annotations.test.ts
+++ b/packages/compiler/src/__tests__/annotations.test.ts
@@ -5,6 +5,10 @@ import { compileMelDomain, compileMelModule } from "../api/index.js";
 import { parse } from "../parser/index.js";
 import { tokenize } from "../lexer/index.js";
 import { extractSchemaGraph } from "../schema-graph.js";
+import {
+  createDefaultSourceMapEmissionContext,
+  extractSourceMap,
+} from "../source-map.js";
 
 const ANNOTATED_SOURCE = `
   @meta("doc:summary", { area: "tasks" })
@@ -72,7 +76,7 @@ describe("structural annotations", () => {
     expect(JSON.stringify(annotated.schema)).toBe(JSON.stringify(stripped.schema));
   });
 
-  it("emits deterministic AnnotationIndex sidecars through compileMelModule", () => {
+  it("emits deterministic tooling sidecars through compileMelModule", () => {
     const first = compileMelModule(ANNOTATED_SOURCE, { mode: "module" });
     const second = compileMelModule(ANNOTATED_SOURCE, { mode: "module" });
 
@@ -85,9 +89,15 @@ describe("structural annotations", () => {
     const secondModule = second.module!;
 
     expect(firstModule.annotations.schemaHash).toBe(firstModule.schema.hash);
+    expect(firstModule.sourceMap.schemaHash).toBe(firstModule.schema.hash);
+    expect(firstModule.sourceMap.format).toBe("manifesto/source-map-v1");
+    expect(firstModule.sourceMap.coordinateUnit).toBe("utf16");
+    expect(firstModule.sourceMap.sourceHash.startsWith("fnv1a32:")).toBe(true);
+    expect(firstModule.sourceMap.emissionFingerprint.startsWith("fnv1a32:")).toBe(true);
     expect(firstModule.graph).toEqual(extractSchemaGraph(firstModule.schema));
     expect(firstModule.graph).toEqual(extractSchemaGraph(compileMelDomain(STRIPPED_SOURCE, { mode: "domain" }).schema!));
     expect(JSON.stringify(firstModule.annotations)).toBe(JSON.stringify(secondModule.annotations));
+    expect(JSON.stringify(firstModule.sourceMap)).toBe(JSON.stringify(secondModule.sourceMap));
     expect(Object.keys(firstModule.annotations.entries)).toEqual([
       "action:archive",
       "computed:hasArchivedTask",
@@ -96,14 +106,39 @@ describe("structural annotations", () => {
       "type:Task",
       "type_field:Task.internalNote",
     ]);
+    expect(Object.keys(firstModule.sourceMap.entries)).toEqual([
+      "action:archive",
+      "computed:hasArchivedTask",
+      "domain:TaskBoard",
+      "state_field:lastArchivedId",
+      "type:Task",
+      "type_field:Task.id",
+      "type_field:Task.internalNote",
+    ]);
     expect(firstModule.annotations.entries["computed:hasArchivedTask"]).toEqual([
       { tag: "ui:panel" },
       { tag: "ui:panel" },
       { tag: "ui:status", payload: { variant: "compact" } },
     ]);
+    expect(firstModule.sourceMap.entries["action:archive"]?.target).toEqual({
+      kind: "action",
+      action: { name: "archive" },
+    });
+    expect(firstModule.sourceMap.entries["computed:hasArchivedTask"]?.target).toEqual({
+      kind: "computed",
+      computed: { name: "hasArchivedTask" },
+    });
+    expect(firstModule.sourceMap.entries["domain:TaskBoard"]?.span.start.line).toBeGreaterThan(0);
+    expect(firstModule.sourceMap.entries["action:archive"]?.span.end.line).toBeGreaterThanOrEqual(
+      firstModule.sourceMap.entries["action:archive"]!.span.start.line,
+    );
     expect(Object.isFrozen(firstModule)).toBe(true);
     expect(Object.isFrozen(firstModule.graph)).toBe(true);
     expect(Object.isFrozen(firstModule.annotations)).toBe(true);
+    expect(Object.isFrozen(firstModule.sourceMap)).toBe(true);
+    expect(Object.isFrozen(firstModule.sourceMap.entries)).toBe(true);
+    expect(Object.isFrozen(firstModule.sourceMap.entries["action:archive"])).toBe(true);
+    expect(Object.isFrozen(firstModule.sourceMap.entries["action:archive"]?.target)).toBe(true);
     expect(Object.isFrozen(firstModule.annotations.entries)).toBe(true);
     expect(Object.isFrozen(firstModule.annotations.entries["computed:hasArchivedTask"])).toBe(true);
     expect(Object.isFrozen(firstModule.annotations.entries["computed:hasArchivedTask"]?.[2]?.payload)).toBe(true);
@@ -224,5 +259,30 @@ describe("structural annotations", () => {
     const result = buildAnnotationIndex(parsed.program!, tamperedSchema);
 
     expect(result.diagnostics.some((diagnostic) => diagnostic.code === "E057")).toBe(true);
+  });
+
+  it("reports E058 when extracted source-map targets do not match the emitted schema", () => {
+    const lexed = tokenize(ANNOTATED_SOURCE);
+    const parsed = parse(lexed.tokens);
+    const compiled = compileMelDomain(ANNOTATED_SOURCE, { mode: "domain" });
+
+    expect(parsed.diagnostics).toEqual([]);
+    expect(compiled.errors).toEqual([]);
+    expect(parsed.program).not.toBeNull();
+    expect(compiled.schema).not.toBeNull();
+
+    const { archive: _archive, ...actions } = compiled.schema!.actions;
+    const tamperedSchema = {
+      ...compiled.schema!,
+      actions,
+    };
+    const result = extractSourceMap(
+      parsed.program!,
+      ANNOTATED_SOURCE,
+      tamperedSchema,
+      createDefaultSourceMapEmissionContext("3.5.0"),
+    );
+
+    expect(result.diagnostics.some((diagnostic) => diagnostic.code === "E058")).toBe(true);
   });
 });

--- a/packages/compiler/src/__tests__/annotations.test.ts
+++ b/packages/compiler/src/__tests__/annotations.test.ts
@@ -285,4 +285,50 @@ describe("structural annotations", () => {
 
     expect(result.diagnostics.some((diagnostic) => diagnostic.code === "E058")).toBe(true);
   });
+
+  it("converts source-map columns to bytes when byte coordinates are requested", () => {
+    const source = `
+      domain Demo {
+        state {
+          label: string = "한"
+        }
+      }
+    `;
+    const lexed = tokenize(source);
+    const parsed = parse(lexed.tokens);
+    const compiled = compileMelDomain(source, { mode: "domain" });
+
+    expect(parsed.diagnostics).toEqual([]);
+    expect(compiled.errors).toEqual([]);
+    expect(parsed.program).not.toBeNull();
+    expect(compiled.schema).not.toBeNull();
+
+    const utf16Result = extractSourceMap(
+      parsed.program!,
+      source,
+      compiled.schema!,
+      createDefaultSourceMapEmissionContext("3.5.0"),
+    );
+    const byteResult = extractSourceMap(
+      parsed.program!,
+      source,
+      compiled.schema!,
+      {
+        ...createDefaultSourceMapEmissionContext("3.5.0"),
+        coordinateUnit: "bytes",
+      },
+    );
+
+    expect(utf16Result.diagnostics).toEqual([]);
+    expect(byteResult.diagnostics).toEqual([]);
+    expect(byteResult.sourceMap.coordinateUnit).toBe("bytes");
+
+    const utf16Span = utf16Result.sourceMap.entries["state_field:label"]!.span;
+    const byteSpan = byteResult.sourceMap.entries["state_field:label"]!.span;
+
+    expect(byteSpan.start.line).toBe(utf16Span.start.line);
+    expect(byteSpan.end.line).toBe(utf16Span.end.line);
+    expect(byteSpan.start.column).toBe(utf16Span.start.column);
+    expect(byteSpan.end.column).toBe(utf16Span.end.column + 2);
+  });
 });

--- a/packages/compiler/src/__tests__/compliance/ccts-coverage.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-coverage.ts
@@ -83,11 +83,11 @@ export const COMPILER_COMPLIANCE_CASES: readonly CompilerComplianceCase[] = [
   complianceCase(CCTS_CASES.GRAMMAR_INVALID_SYSTEM_REF, "grammar", "Invalid system references are diagnosed."),
   complianceCase(CCTS_CASES.GRAMMAR_ONCE_INTENT_CONTEXTUAL, "grammar", "onceIntent is parsed contextually."),
 
-  complianceCase(CCTS_CASES.ANNOTATIONS_SURFACE, "annotations", "@meta target placement, target-key shape, and sidecar emission determinism are staged."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_SURFACE, "annotations", "@meta target placement, sibling sidecar target-key shape, and tooling sidecar emission determinism are staged."),
   complianceCase(CCTS_CASES.ANNOTATIONS_PAYLOAD, "annotations", "@meta payload literal-only and depth constraints are staged."),
-  complianceCase(CCTS_CASES.ANNOTATIONS_INVARIANTS, "annotations", "@meta semantic erasure invariants are staged."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_INVARIANTS, "annotations", "Tooling sidecar semantic erasure invariants are staged."),
   complianceCase(CCTS_CASES.ANNOTATIONS_RUNTIME_BOUNDARY, "annotations", "Tooling-only DomainModule runtime-boundary guards are staged."),
-  complianceCase(CCTS_CASES.ANNOTATIONS_DIAGNOSTICS, "annotations", "@meta diagnostic families are staged."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_DIAGNOSTICS, "annotations", "Annotation and source-map diagnostic families are staged."),
 
   complianceCase(CCTS_CASES.CONTEXT_COMPUTED_SYSTEM, "context", "$system is rejected in computed expressions."),
   complianceCase(CCTS_CASES.CONTEXT_STATE_INIT_SYSTEM, "context", "$system is rejected in state initializers."),
@@ -189,7 +189,7 @@ export const COMPILER_RULE_COVERAGE: readonly CompilerComplianceCoverageEntry[] 
   ...coverMany(["META-6"], [CCTS_CASES.ANNOTATIONS_PAYLOAD]),
   ...coverMany(["META-3", "INV-META-1", "INV-META-2", "INV-META-3", "INV-META-4", "INV-META-5"], [CCTS_CASES.ANNOTATIONS_INVARIANTS]),
   ...coverMany(["META-4", "INV-META-6"], [CCTS_CASES.ANNOTATIONS_RUNTIME_BOUNDARY]),
-  ...coverMany(["E053", "E054", "E055", "E056", "E057"], [CCTS_CASES.ANNOTATIONS_DIAGNOSTICS]),
+  ...coverMany(["E053", "E054", "E055", "E056", "E057", "E058"], [CCTS_CASES.ANNOTATIONS_DIAGNOSTICS]),
 
   ...coverMany(["E003"], [CCTS_CASES.GRAMMAR_INVALID_SYSTEM_REF]),
   ...coverMany(["E006", "E007", "E008"], [CCTS_CASES.ACTIONS_FAIL_STOP_DIAGNOSTICS]),

--- a/packages/compiler/src/__tests__/compliance/ccts-rules.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-rules.ts
@@ -63,7 +63,7 @@ export const COMPILER_COMPLIANCE_RULES: readonly CompilerComplianceRule[] = [
   ...registryMany(["E001", "E002", "E003", "E004", "E005", "E009", "E010", "E011"], "blocking"),
   ...registryMany(["E006", "E007", "E008"], "blocking"),
   ...registryMany(["E012", "E013", "E014", "E015", "E016", "E017", "E018", "E019", "E020", "E021", "E022", "E023", "E024", "E030", "E030a", "E030b", "E031", "E032", "E033", "E034", "E035", "E041", "E042", "E043", "E044", "E049", "E050", "E051", "E052"], "blocking"),
-  ...registryMany(["E053", "E054", "E055", "E056", "E057"], "blocking"),
+  ...registryMany(["E053", "E054", "E055", "E056", "E057", "E058"], "blocking"),
   registry("E045", "informational"),
   registry("E046", "informational"),
   registry("E040", "blocking"),

--- a/packages/compiler/src/__tests__/compliance/ccts-spec-inventory.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-spec-inventory.ts
@@ -107,7 +107,7 @@ export const COMPILER_SPEC_INVENTORY: readonly CompilerComplianceInventoryItem[]
   ...inventoryMany(["E030", "E030a", "E030b", "E031", "E032", "E033", "E034", "E035"], "§13.6", "MUST", "entity-primitives"),
   ...inventoryMany(["E040", "E041", "E042", "E043", "E044"], "§13.6", "MUST", "state-and-computed"),
   ...inventoryMany(["E049", "E050", "E051", "E052"], "§13.6", "MUST", "lowering-and-ir"),
-  ...inventoryMany(["E053", "E054", "E055", "E056", "E057"], "§9", "MUST", "annotations"),
+  ...inventoryMany(["E053", "E054", "E055", "E056", "E057", "E058"], "§9", "MUST", "annotations"),
   inventory("E045", "§13.6", "MUST", "state-and-computed", {
     lifecycle: "superseded",
     notes: "Superseded when nullable schema-position types became supported through TypeDefinition-backed runtime validation.",

--- a/packages/compiler/src/__tests__/compliance/suite/annotations.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/annotations.spec.ts
@@ -14,6 +14,10 @@ import { getRuleOrThrow } from "../ccts-rules.js";
 import { parse } from "../../../parser/index.js";
 import { tokenize } from "../../../lexer/index.js";
 import { extractSchemaGraph } from "../../../schema-graph.js";
+import {
+  createDefaultSourceMapEmissionContext,
+  extractSourceMap,
+} from "../../../source-map.js";
 
 type AnnotationInvariantDomain = {
   actions: {
@@ -99,10 +103,22 @@ describe("CCTS Annotation Suite", () => {
         actions: {},
       })
       : null;
+    const tamperedSourceMap = first.module && parsed.program
+      ? extractSourceMap(
+        parsed.program,
+        ANNOTATED_SOURCE,
+        {
+          ...first.module.schema,
+          actions: {},
+        },
+        createDefaultSourceMapEmissionContext("3.5.0"),
+      )
+      : null;
 
     const firstModule = first.module;
     const secondModule = second.module;
     const sortedKeys = firstModule ? Object.keys(firstModule.annotations.entries) : [];
+    const sourceMapKeys = firstModule ? Object.keys(firstModule.sourceMap.entries) : [];
     const noEmptyArrays = firstModule
       ? Object.values(firstModule.annotations.entries).every((entry) => entry.length > 0)
       : false;
@@ -115,18 +131,23 @@ describe("CCTS Annotation Suite", () => {
       }),
       evaluateRule(getRuleOrThrow("META-2"), Boolean(firstModule)
         && !("annotations" in firstModule.schema)
+        && !("sourceMap" in firstModule.schema)
         && JSON.stringify(firstModule.graph) === JSON.stringify(extractSchemaGraph(firstModule.schema)), {
-        passMessage: "Annotations stay outside DomainSchema and SchemaGraph.",
-        failMessage: "Annotations leaked into semantic compiler artifacts.",
+        passMessage: "Tooling sidecars stay outside DomainSchema and SchemaGraph.",
+        failMessage: "Tooling sidecars leaked into semantic compiler artifacts.",
         evidence: firstModule ? [
           noteEvidence("Annotation entry keys", sortedKeys),
+          noteEvidence("Source map entry keys", sourceMapKeys),
         ] : diagnosticEvidence(first.errors),
       }),
-      evaluateRule(getRuleOrThrow("META-5"), Boolean(tamperedIndex)
-        && hasDiagnosticCode(tamperedIndex!.diagnostics, "E057"), {
-        passMessage: "Annotation targets are validated against emitted DomainSchema structure.",
-        failMessage: "Target validation no longer reports dangling annotation targets.",
-        evidence: tamperedIndex ? diagnosticEvidence(tamperedIndex.diagnostics) : diagnosticEvidence(first.errors),
+      evaluateRule(getRuleOrThrow("META-5"), Boolean(tamperedIndex && tamperedSourceMap)
+        && hasDiagnosticCode(tamperedIndex!.diagnostics, "E057")
+        && hasDiagnosticCode(tamperedSourceMap!.diagnostics, "E058"), {
+        passMessage: "Tooling sidecar targets are validated against emitted DomainSchema structure.",
+        failMessage: "Target validation no longer reports dangling sidecar targets.",
+        evidence: tamperedIndex && tamperedSourceMap
+          ? [...diagnosticEvidence(tamperedIndex.diagnostics), ...diagnosticEvidence(tamperedSourceMap.diagnostics)]
+          : diagnosticEvidence(first.errors),
       }),
       evaluateRule(getRuleOrThrow("META-7"), namespaceBlind.errors.length === 0, {
         passMessage: "Namespace-specific semantics remain consumer-owned.",
@@ -156,11 +177,13 @@ describe("CCTS Annotation Suite", () => {
       }),
       evaluateRule(getRuleOrThrow("META-10"), Boolean(firstModule && secondModule)
         && JSON.stringify(firstModule.annotations) === JSON.stringify(secondModule.annotations)
+        && JSON.stringify(firstModule.sourceMap) === JSON.stringify(secondModule.sourceMap)
         && noEmptyArrays, {
-        passMessage: "Annotation sidecar emission is deterministic and omits empty targets.",
-        failMessage: "Annotation sidecar emission is unstable or includes empty target entries.",
+        passMessage: "Tooling sidecar emission is deterministic and omits empty annotation targets.",
+        failMessage: "Tooling sidecar emission is unstable or includes invalid target entries.",
         evidence: firstModule ? [
           noteEvidence("Annotation entry keys", sortedKeys),
+          noteEvidence("Source map entry keys", sourceMapKeys),
         ] : diagnosticEvidence(first.errors),
       }),
     ]);
@@ -317,7 +340,7 @@ describe("CCTS Annotation Suite", () => {
     ]);
   });
 
-  it(caseTitle(CCTS_CASES.ANNOTATIONS_DIAGNOSTICS, "(E053-E057) annotation diagnostic families are enforced"), () => {
+  it(caseTitle(CCTS_CASES.ANNOTATIONS_DIAGNOSTICS, "(E053-E058) annotation and source-map diagnostic families are enforced"), () => {
     const invalidPlacement = compileMelDomain(`
       domain Demo {
         state { count: number = 0 }
@@ -363,6 +386,17 @@ describe("CCTS Annotation Suite", () => {
         actions: {},
       })
       : null;
+    const danglingSourceMap = moduleResult.module && parsed.program
+      ? extractSourceMap(
+        parsed.program,
+        ANNOTATED_SOURCE,
+        {
+          ...moduleResult.module.schema,
+          actions: {},
+        },
+        createDefaultSourceMapEmissionContext("3.5.0"),
+      )
+      : null;
 
     expectAllCompliance([
       evaluateRule(getRuleOrThrow("E053"), hasDiagnosticCode(invalidPlacement.errors, "E053"), {
@@ -389,6 +423,11 @@ describe("CCTS Annotation Suite", () => {
         passMessage: "Dangling annotation targets emit E057.",
         failMessage: "Dangling annotation targets no longer emit E057.",
         evidence: dangling ? diagnosticEvidence(dangling.diagnostics) : diagnosticEvidence(moduleResult.errors),
+      }),
+      evaluateRule(getRuleOrThrow("E058"), Boolean(danglingSourceMap) && hasDiagnosticCode(danglingSourceMap!.diagnostics, "E058"), {
+        passMessage: "Dangling source-map targets emit E058.",
+        failMessage: "Dangling source-map targets no longer emit E058.",
+        evidence: danglingSourceMap ? diagnosticEvidence(danglingSourceMap.diagnostics) : diagnosticEvidence(moduleResult.errors),
       }),
     ]);
   });

--- a/packages/compiler/src/annotations.ts
+++ b/packages/compiler/src/annotations.ts
@@ -9,6 +9,7 @@ import type {
   TypeExprNode,
 } from "./parser/ast.js";
 import type { SchemaGraph } from "./schema-graph.js";
+import type { SourceMapIndex } from "./source-map.js";
 
 export type JsonLiteral =
   | string
@@ -40,6 +41,7 @@ export interface DomainModule {
   readonly schema: DomainSchema;
   readonly graph: SchemaGraph;
   readonly annotations: AnnotationIndex;
+  readonly sourceMap: SourceMapIndex;
 }
 
 export interface AnnotationExtractionResult {

--- a/packages/compiler/src/api/compile-mel.ts
+++ b/packages/compiler/src/api/compile-mel.ts
@@ -16,6 +16,14 @@ import type {
   JsonLiteral,
   LocalTargetKey,
 } from "../annotations.js";
+import type {
+  SourceMapEmissionContext,
+  SourceMapEntry,
+  SourceMapIndex,
+  SourceMapPath,
+  SourcePoint,
+  SourceSpan,
+} from "../source-map.js";
 
 import { buildAnnotationIndex } from "../annotations.js";
 import { tokenize, type Token } from "../lexer/index.js";
@@ -25,7 +33,13 @@ import { analyzeScope } from "../analyzer/scope.js";
 import { validateSemantics } from "../analyzer/validator.js";
 import { validateAndExpandFlows } from "../analyzer/flow-composition.js";
 import { extractSchemaGraph } from "../schema-graph.js";
+import {
+  createDefaultSourceMapEmissionContext,
+  extractSourceMap,
+} from "../source-map.js";
 import { compileMelPatchText } from "./compile-mel-patch.js";
+
+const COMPILER_VERSION = "3.5.0";
 
 // ============ Types ============
 
@@ -107,6 +121,14 @@ export type {
   JsonLiteral,
   LocalTargetKey,
 } from "../annotations.js";
+export type {
+  SourceMapEmissionContext,
+  SourceMapEntry,
+  SourceMapIndex,
+  SourceMapPath,
+  SourcePoint,
+  SourceSpan,
+} from "../source-map.js";
 
 /**
  * Patch compilation options.
@@ -192,7 +214,7 @@ export function compileMelModule(
 ): CompileMelModuleResult {
   const result = compileMelArtifacts(melText, options);
 
-  if (result.errors.length > 0 || !result.schema || !result.annotations) {
+  if (result.errors.length > 0 || !result.schema || !result.annotations || !result.sourceMap) {
     return {
       module: null,
       trace: result.trace,
@@ -202,7 +224,7 @@ export function compileMelModule(
   }
 
   return {
-    module: createDomainModule(result.schema, result.annotations),
+    module: createDomainModule(result.schema, result.annotations, result.sourceMap),
     trace: result.trace,
     warnings: result.warnings,
     errors: result.errors,
@@ -213,6 +235,7 @@ interface CompileMelArtifactsResult {
   program: ProgramNode | null;
   schema: DomainSchema | null;
   annotations: AnnotationIndex | null;
+  sourceMap: SourceMapIndex | null;
   trace: CompileTrace[];
   warnings: Diagnostic[];
   errors: Diagnostic[];
@@ -238,7 +261,7 @@ function compileMelArtifacts(
     if (lexErrors.length > 0) {
       errors.push(...lexErrors);
       trace.push({ phase: "lex", durationMs: performance.now() - lexStart, details: { tokenCount: tokens.length } });
-      return { program: null, schema: null, annotations: null, trace, warnings, errors };
+      return { program: null, schema: null, annotations: null, sourceMap: null, trace, warnings, errors };
     }
     const lexWarnings = lexResult.diagnostics.filter(d => d.severity === "warning");
     warnings.push(...lexWarnings);
@@ -251,7 +274,7 @@ function compileMelArtifacts(
       location: { start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 1, offset: 0 } },
     });
     trace.push({ phase: "lex", durationMs: performance.now() - lexStart });
-    return { program: null, schema: null, annotations: null, trace, warnings, errors };
+    return { program: null, schema: null, annotations: null, sourceMap: null, trace, warnings, errors };
   }
   trace.push({ phase: "lex", durationMs: performance.now() - lexStart, details: { tokenCount: tokens.length } });
 
@@ -264,7 +287,7 @@ function compileMelArtifacts(
     if (parseErrors.length > 0) {
       errors.push(...parseErrors);
       trace.push({ phase: "parse", durationMs: performance.now() - parseStart });
-      return { program: null, schema: null, annotations: null, trace, warnings, errors: capDiagnostics(errors) };
+      return { program: null, schema: null, annotations: null, sourceMap: null, trace, warnings, errors: capDiagnostics(errors) };
     }
     ast = parseResult.program as ProgramNode;
   } catch (e) {
@@ -276,7 +299,7 @@ function compileMelArtifacts(
       location: { start: { line: 1, column: 1, offset: 0 }, end: { line: 1, column: 1, offset: 0 } },
     });
     trace.push({ phase: "parse", durationMs: performance.now() - parseStart });
-    return { program: null, schema: null, annotations: null, trace, warnings, errors };
+    return { program: null, schema: null, annotations: null, sourceMap: null, trace, warnings, errors };
   }
   trace.push({ phase: "parse", durationMs: performance.now() - parseStart });
 
@@ -307,6 +330,7 @@ function compileMelArtifacts(
       program: flowResult.program,
       schema: null,
       annotations: null,
+      sourceMap: null,
       trace,
       warnings,
       errors: capDiagnostics(errors),
@@ -339,6 +363,32 @@ function compileMelArtifacts(
         program: flowResult.program,
         schema: null,
         annotations: null,
+        sourceMap: null,
+        trace,
+        warnings,
+        errors: capDiagnostics(errors),
+      };
+    }
+
+    const sourceMapContext: SourceMapEmissionContext =
+      createDefaultSourceMapEmissionContext(COMPILER_VERSION);
+    const sourceMapResult = extractSourceMap(
+      flowResult.program,
+      melText,
+      genResult.schema,
+      sourceMapContext,
+    );
+    const sourceMapWarnings = sourceMapResult.diagnostics.filter((d) => d.severity === "warning");
+    const sourceMapErrors = sourceMapResult.diagnostics.filter((d) => d.severity === "error");
+    warnings.push(...sourceMapWarnings);
+    errors.push(...sourceMapErrors);
+
+    if (sourceMapErrors.length > 0) {
+      return {
+        program: flowResult.program,
+        schema: null,
+        annotations: null,
+        sourceMap: null,
         trace,
         warnings,
         errors: capDiagnostics(errors),
@@ -349,6 +399,7 @@ function compileMelArtifacts(
       program: flowResult.program,
       schema: genResult.schema,
       annotations: annotationResult.annotations,
+      sourceMap: sourceMapResult.sourceMap,
       trace,
       warnings,
       errors: capDiagnostics(errors),
@@ -359,6 +410,7 @@ function compileMelArtifacts(
     program: flowResult.program,
     schema: null,
     annotations: null,
+    sourceMap: null,
     trace,
     warnings,
     errors: capDiagnostics(errors),
@@ -368,11 +420,13 @@ function compileMelArtifacts(
 function createDomainModule(
   schema: DomainSchema,
   annotations: AnnotationIndex,
+  sourceMap: SourceMapIndex,
 ): DomainModule {
   return Object.freeze({
     schema,
     graph: deepFreeze(extractSchemaGraph(schema)),
     annotations,
+    sourceMap,
   });
 }
 

--- a/packages/compiler/src/api/index.ts
+++ b/packages/compiler/src/api/index.ts
@@ -19,6 +19,12 @@ export type {
   DomainModule,
   JsonLiteral,
   LocalTargetKey,
+  SourceMapEmissionContext,
+  SourceMapEntry,
+  SourceMapIndex,
+  SourceMapPath,
+  SourcePoint,
+  SourceSpan,
 } from "./compile-mel.js";
 
 export { compileMelDomain, compileMelModule, compileMelPatch } from "./compile-mel.js";

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -97,11 +97,17 @@ import { validateAndExpandFlows } from "./analyzer/flow-composition.js";
 import { buildAnnotationIndex } from "./annotations.js";
 import { generate, type GenerateResult } from "./generator/ir.js";
 import { lowerSystemValues, type DomainSchema } from "./generator/index.js";
+import {
+  createDefaultSourceMapEmissionContext,
+  extractSourceMap,
+} from "./source-map.js";
 import type { CompileTrace } from "./api/index.js";
 import { tokenize } from "./lexer/index.js";
 import { parse } from "./parser/index.js";
 import { hasErrors } from "./diagnostics/types.js";
 import type { Diagnostic } from "./diagnostics/types.js";
+
+const COMPILER_VERSION = "3.5.0";
 
 export interface CompileOptions {
   /** Whether to lower system values during compilation */
@@ -193,6 +199,13 @@ export function compile(source: string, options: CompileOptions = {}): CompileRe
   if (!options.skipSemanticAnalysis && genResult.schema) {
     const annotationResult = buildAnnotationIndex(flowResult.program, genResult.schema);
     diagnostics.push(...annotationResult.diagnostics);
+    const sourceMapResult = extractSourceMap(
+      flowResult.program,
+      source,
+      genResult.schema,
+      createDefaultSourceMapEmissionContext(COMPILER_VERSION),
+    );
+    diagnostics.push(...sourceMapResult.diagnostics);
   }
 
   if (options.skipSemanticAnalysis) {

--- a/packages/compiler/src/source-map.ts
+++ b/packages/compiler/src/source-map.ts
@@ -1,0 +1,486 @@
+import { createError, type Diagnostic } from "./diagnostics/types.js";
+import type { DomainSchema } from "./generator/ir.js";
+import type { ProgramNode, TypeExprNode } from "./parser/ast.js";
+import type { LocalTargetKey } from "./annotations.js";
+
+export interface SourcePoint {
+  readonly line: number;
+  readonly column: number;
+  readonly offset?: number;
+}
+
+export interface SourceSpan {
+  readonly start: SourcePoint;
+  readonly end: SourcePoint;
+}
+
+export type SourceMapPath =
+  | { readonly kind: "domain"; readonly domain: { readonly name: string } }
+  | { readonly kind: "type"; readonly type: { readonly name: string } }
+  | {
+      readonly kind: "type_field";
+      readonly type: { readonly name: string };
+      readonly field: { readonly name: string };
+    }
+  | { readonly kind: "state_field"; readonly field: { readonly name: string } }
+  | { readonly kind: "computed"; readonly computed: { readonly name: string } }
+  | { readonly kind: "action"; readonly action: { readonly name: string } };
+
+export interface SourceMapEntry {
+  readonly target: SourceMapPath;
+  readonly span: SourceSpan;
+}
+
+export interface SourceMapIndex {
+  readonly schemaHash: string;
+  readonly sourceHash: string;
+  readonly format: "manifesto/source-map-v1";
+  readonly coordinateUnit: "utf16" | "bytes";
+  readonly emissionFingerprint: string;
+  readonly entries: Record<LocalTargetKey, SourceMapEntry>;
+}
+
+export interface SourceMapEmissionContext {
+  readonly coordinateUnit: "utf16" | "bytes";
+  readonly compilerVersion: string;
+  readonly emissionOptionsFingerprint: string;
+}
+
+export interface SourceMapExtractionResult {
+  readonly sourceMap: SourceMapIndex;
+  readonly diagnostics: Diagnostic[];
+}
+
+const DANGLING_TARGET_MESSAGE =
+  "Source-map target does not map to the emitted DomainSchema.";
+const MISSING_TARGET_MESSAGE =
+  "Source-map entry missing for emitted DomainSchema target.";
+
+type EntryMap = Map<LocalTargetKey, SourceMapEntry>;
+
+export function createDefaultSourceMapEmissionContext(
+  compilerVersion: string,
+): SourceMapEmissionContext {
+  return Object.freeze({
+    coordinateUnit: "utf16" as const,
+    compilerVersion,
+    emissionOptionsFingerprint: "default",
+  });
+}
+
+export function extractSourceMap(
+  program: ProgramNode,
+  sourceText: string,
+  schema: DomainSchema,
+  ctx: SourceMapEmissionContext,
+): SourceMapExtractionResult {
+  const diagnostics: Diagnostic[] = [];
+  const entries: EntryMap = new Map();
+  const domain = program.domain;
+
+  entries.set(
+    `domain:${domain.name}`,
+    freezeEntry({
+      target: { kind: "domain", domain: { name: domain.name } },
+      span: toSourceSpan(domain.location),
+    }),
+  );
+
+  for (const typeDecl of domain.types) {
+    entries.set(
+      `type:${typeDecl.name}`,
+      freezeEntry({
+        target: { kind: "type", type: { name: typeDecl.name } },
+        span: toSourceSpan(typeDecl.location),
+      }),
+    );
+    collectTypeFieldEntries(typeDecl.typeExpr, typeDecl.name, 0, entries);
+  }
+
+  for (const member of domain.members) {
+    switch (member.kind) {
+      case "state":
+        for (const field of member.fields) {
+          entries.set(
+            `state_field:${field.name}`,
+            freezeEntry({
+              target: { kind: "state_field", field: { name: field.name } },
+              span: toSourceSpan(field.location),
+            }),
+          );
+        }
+        break;
+
+      case "computed":
+        entries.set(
+          `computed:${member.name}`,
+          freezeEntry({
+            target: { kind: "computed", computed: { name: member.name } },
+            span: toSourceSpan(member.location),
+          }),
+        );
+        break;
+
+      case "action":
+        entries.set(
+          `action:${member.name}`,
+          freezeEntry({
+            target: { kind: "action", action: { name: member.name } },
+            span: toSourceSpan(member.location),
+          }),
+        );
+        break;
+
+      case "flow":
+        break;
+    }
+  }
+
+  const sortedEntries = {} as Record<LocalTargetKey, SourceMapEntry>;
+  for (const key of [...entries.keys()].sort()) {
+    if (!hasSchemaTarget(schema, key)) {
+      diagnostics.push(
+        createError(
+          "E058",
+          DANGLING_TARGET_MESSAGE,
+          inferTargetLocation(program, key) ?? domain.location,
+        ),
+      );
+      continue;
+    }
+
+    const entry = entries.get(key);
+    if (entry) {
+      sortedEntries[key] = entry;
+    }
+  }
+
+  for (const key of expectedTargetKeys(program, schema)) {
+    if (!Object.hasOwn(sortedEntries, key)) {
+      diagnostics.push(
+        createError(
+          "E058",
+          MISSING_TARGET_MESSAGE,
+          inferTargetLocation(program, key) ?? domain.location,
+        ),
+      );
+    }
+  }
+
+  return {
+    sourceMap: Object.freeze({
+      schemaHash: schema.hash,
+      sourceHash: stableHashString(sourceText),
+      format: "manifesto/source-map-v1",
+      coordinateUnit: ctx.coordinateUnit,
+      emissionFingerprint: stableHashString(
+        `${ctx.coordinateUnit}\u0000${ctx.compilerVersion}\u0000${ctx.emissionOptionsFingerprint}`,
+      ),
+      entries: Object.freeze(sortedEntries),
+    }),
+    diagnostics,
+  };
+}
+
+function collectTypeFieldEntries(
+  typeExpr: TypeExprNode,
+  typeName: string,
+  depth: number,
+  entries: EntryMap,
+): void {
+  switch (typeExpr.kind) {
+    case "objectType":
+      for (const field of typeExpr.fields) {
+        if (depth === 0) {
+          entries.set(
+            `type_field:${typeName}.${field.name}`,
+            freezeEntry({
+              target: {
+                kind: "type_field",
+                type: { name: typeName },
+                field: { name: field.name },
+              },
+              span: toSourceSpan(field.location),
+            }),
+          );
+        }
+
+        collectTypeFieldEntries(field.typeExpr, typeName, depth + 1, entries);
+      }
+      return;
+
+    case "arrayType":
+      collectTypeFieldEntries(typeExpr.elementType, typeName, depth + 1, entries);
+      return;
+
+    case "recordType":
+      collectTypeFieldEntries(typeExpr.keyType, typeName, depth + 1, entries);
+      collectTypeFieldEntries(typeExpr.valueType, typeName, depth + 1, entries);
+      return;
+
+    case "unionType":
+      for (const member of typeExpr.types) {
+        collectTypeFieldEntries(member, typeName, depth + 1, entries);
+      }
+      return;
+
+    case "simpleType":
+    case "literalType":
+      return;
+  }
+}
+
+function expectedTargetKeys(
+  program: ProgramNode,
+  schema: DomainSchema,
+): readonly LocalTargetKey[] {
+  const keys = new Set<LocalTargetKey>();
+
+  keys.add(`domain:${program.domain.name}`);
+
+  for (const [typeName, typeSpec] of Object.entries(schema.types)) {
+    keys.add(`type:${typeName}`);
+    if (typeSpec.definition.kind === "object") {
+      for (const fieldName of Object.keys(typeSpec.definition.fields)) {
+        keys.add(`type_field:${typeName}.${fieldName}`);
+      }
+    }
+  }
+
+  for (const fieldName of Object.keys(schema.state.fields)) {
+    keys.add(`state_field:${fieldName}`);
+  }
+
+  for (const computedName of Object.keys(schema.computed.fields)) {
+    keys.add(`computed:${computedName}`);
+  }
+
+  for (const actionName of Object.keys(schema.actions)) {
+    keys.add(`action:${actionName}`);
+  }
+
+  return [...keys].sort();
+}
+
+function hasSchemaTarget(schema: DomainSchema, targetKey: LocalTargetKey): boolean {
+  const separator = targetKey.indexOf(":");
+  if (separator < 0) {
+    return false;
+  }
+
+  const kind = targetKey.slice(0, separator);
+  const name = targetKey.slice(separator + 1);
+
+  switch (kind) {
+    case "domain":
+      return schema.meta?.name === name || schema.id === `mel:${name.toLowerCase()}`;
+
+    case "type":
+      return Object.hasOwn(schema.types, name);
+
+    case "type_field": {
+      const dotIndex = name.indexOf(".");
+      if (dotIndex <= 0 || dotIndex !== name.lastIndexOf(".")) {
+        return false;
+      }
+
+      const typeName = name.slice(0, dotIndex);
+      const fieldName = name.slice(dotIndex + 1);
+      const typeSpec = schema.types[typeName];
+      if (!typeSpec || typeSpec.definition.kind !== "object") {
+        return false;
+      }
+
+      return Object.hasOwn(typeSpec.definition.fields, fieldName);
+    }
+
+    case "state_field":
+      return Object.hasOwn(schema.state.fields, name);
+
+    case "computed":
+      return Object.hasOwn(schema.computed.fields, name);
+
+    case "action":
+      return Object.hasOwn(schema.actions, name);
+
+    default:
+      return false;
+  }
+}
+
+function inferTargetLocation(
+  program: ProgramNode,
+  targetKey: LocalTargetKey,
+): ProgramNode["location"] | null {
+  const separator = targetKey.indexOf(":");
+  if (separator < 0) {
+    return null;
+  }
+
+  const kind = targetKey.slice(0, separator);
+  const name = targetKey.slice(separator + 1);
+
+  switch (kind) {
+    case "domain":
+      return program.domain.name === name ? program.domain.location : null;
+
+    case "type":
+      return program.domain.types.find((typeDecl) => typeDecl.name === name)?.location ?? null;
+
+    case "type_field": {
+      const dotIndex = name.indexOf(".");
+      if (dotIndex <= 0 || dotIndex !== name.lastIndexOf(".")) {
+        return null;
+      }
+
+      const typeName = name.slice(0, dotIndex);
+      const fieldName = name.slice(dotIndex + 1);
+      const typeDecl = program.domain.types.find((candidate) => candidate.name === typeName);
+      return typeDecl ? findTypeFieldLocation(typeDecl.typeExpr, fieldName, 0) : null;
+    }
+
+    case "state_field":
+      for (const member of program.domain.members) {
+        if (member.kind !== "state") {
+          continue;
+        }
+
+        const field = member.fields.find((candidate) => candidate.name === name);
+        if (field) {
+          return field.location;
+        }
+      }
+      return null;
+
+    case "computed":
+      return program.domain.members.find(
+        (member) => member.kind === "computed" && member.name === name,
+      )?.location ?? null;
+
+    case "action":
+      return program.domain.members.find(
+        (member) => member.kind === "action" && member.name === name,
+      )?.location ?? null;
+
+    default:
+      return null;
+  }
+}
+
+function findTypeFieldLocation(
+  typeExpr: TypeExprNode,
+  fieldName: string,
+  depth: number,
+): ProgramNode["location"] | null {
+  switch (typeExpr.kind) {
+    case "objectType":
+      for (const field of typeExpr.fields) {
+        if (depth === 0 && field.name === fieldName) {
+          return field.location;
+        }
+
+        const nested = findTypeFieldLocation(field.typeExpr, fieldName, depth + 1);
+        if (nested) {
+          return nested;
+        }
+      }
+      return null;
+
+    case "arrayType":
+      return findTypeFieldLocation(typeExpr.elementType, fieldName, depth + 1);
+
+    case "recordType":
+      return (
+        findTypeFieldLocation(typeExpr.keyType, fieldName, depth + 1)
+        ?? findTypeFieldLocation(typeExpr.valueType, fieldName, depth + 1)
+      );
+
+    case "unionType":
+      for (const member of typeExpr.types) {
+        const nested = findTypeFieldLocation(member, fieldName, depth + 1);
+        if (nested) {
+          return nested;
+        }
+      }
+      return null;
+
+    case "simpleType":
+    case "literalType":
+      return null;
+  }
+}
+
+function toSourceSpan(location: ProgramNode["location"]): SourceSpan {
+  return Object.freeze({
+    start: Object.freeze({
+      line: location.start.line,
+      column: location.start.column,
+    }),
+    end: Object.freeze({
+      line: location.end.line,
+      column: location.end.column,
+    }),
+  });
+}
+
+function freezeEntry(entry: SourceMapEntry): SourceMapEntry {
+  return Object.freeze({
+    target: freezePath(entry.target),
+    span: Object.freeze({
+      start: Object.freeze({ ...entry.span.start }),
+      end: Object.freeze({ ...entry.span.end }),
+    }),
+  });
+}
+
+function freezePath(path: SourceMapPath): SourceMapPath {
+  switch (path.kind) {
+    case "domain":
+      return Object.freeze({
+        kind: path.kind,
+        domain: Object.freeze({ ...path.domain }),
+      });
+
+    case "type":
+      return Object.freeze({
+        kind: path.kind,
+        type: Object.freeze({ ...path.type }),
+      });
+
+    case "type_field":
+      return Object.freeze({
+        kind: path.kind,
+        type: Object.freeze({ ...path.type }),
+        field: Object.freeze({ ...path.field }),
+      });
+
+    case "state_field":
+      return Object.freeze({
+        kind: path.kind,
+        field: Object.freeze({ ...path.field }),
+      });
+
+    case "computed":
+      return Object.freeze({
+        kind: path.kind,
+        computed: Object.freeze({ ...path.computed }),
+      });
+
+    case "action":
+      return Object.freeze({
+        kind: path.kind,
+        action: Object.freeze({ ...path.action }),
+      });
+  }
+}
+
+function stableHashString(input: string): string {
+  let hash = 0x811c9dc5;
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+
+  return `fnv1a32:${hash.toString(16).padStart(8, "0")}`;
+}

--- a/packages/compiler/src/source-map.ts
+++ b/packages/compiler/src/source-map.ts
@@ -57,6 +57,9 @@ const MISSING_TARGET_MESSAGE =
   "Source-map entry missing for emitted DomainSchema target.";
 
 type EntryMap = Map<LocalTargetKey, SourceMapEntry>;
+type SourceSpanConverter = (location: ProgramNode["location"]) => SourceSpan;
+
+const UTF8_ENCODER = new TextEncoder();
 
 export function createDefaultSourceMapEmissionContext(
   compilerVersion: string,
@@ -77,12 +80,13 @@ export function extractSourceMap(
   const diagnostics: Diagnostic[] = [];
   const entries: EntryMap = new Map();
   const domain = program.domain;
+  const toSpan = createSourceSpanConverter(sourceText, ctx.coordinateUnit);
 
   entries.set(
     `domain:${domain.name}`,
     freezeEntry({
       target: { kind: "domain", domain: { name: domain.name } },
-      span: toSourceSpan(domain.location),
+      span: toSpan(domain.location),
     }),
   );
 
@@ -91,10 +95,10 @@ export function extractSourceMap(
       `type:${typeDecl.name}`,
       freezeEntry({
         target: { kind: "type", type: { name: typeDecl.name } },
-        span: toSourceSpan(typeDecl.location),
+        span: toSpan(typeDecl.location),
       }),
     );
-    collectTypeFieldEntries(typeDecl.typeExpr, typeDecl.name, 0, entries);
+    collectTypeFieldEntries(typeDecl.typeExpr, typeDecl.name, 0, entries, toSpan);
   }
 
   for (const member of domain.members) {
@@ -105,7 +109,7 @@ export function extractSourceMap(
             `state_field:${field.name}`,
             freezeEntry({
               target: { kind: "state_field", field: { name: field.name } },
-              span: toSourceSpan(field.location),
+              span: toSpan(field.location),
             }),
           );
         }
@@ -116,7 +120,7 @@ export function extractSourceMap(
           `computed:${member.name}`,
           freezeEntry({
             target: { kind: "computed", computed: { name: member.name } },
-            span: toSourceSpan(member.location),
+            span: toSpan(member.location),
           }),
         );
         break;
@@ -126,7 +130,7 @@ export function extractSourceMap(
           `action:${member.name}`,
           freezeEntry({
             target: { kind: "action", action: { name: member.name } },
-            span: toSourceSpan(member.location),
+            span: toSpan(member.location),
           }),
         );
         break;
@@ -187,6 +191,7 @@ function collectTypeFieldEntries(
   typeName: string,
   depth: number,
   entries: EntryMap,
+  toSpan: SourceSpanConverter,
 ): void {
   switch (typeExpr.kind) {
     case "objectType":
@@ -200,27 +205,27 @@ function collectTypeFieldEntries(
                 type: { name: typeName },
                 field: { name: field.name },
               },
-              span: toSourceSpan(field.location),
+              span: toSpan(field.location),
             }),
           );
         }
 
-        collectTypeFieldEntries(field.typeExpr, typeName, depth + 1, entries);
+        collectTypeFieldEntries(field.typeExpr, typeName, depth + 1, entries, toSpan);
       }
       return;
 
     case "arrayType":
-      collectTypeFieldEntries(typeExpr.elementType, typeName, depth + 1, entries);
+      collectTypeFieldEntries(typeExpr.elementType, typeName, depth + 1, entries, toSpan);
       return;
 
     case "recordType":
-      collectTypeFieldEntries(typeExpr.keyType, typeName, depth + 1, entries);
-      collectTypeFieldEntries(typeExpr.valueType, typeName, depth + 1, entries);
+      collectTypeFieldEntries(typeExpr.keyType, typeName, depth + 1, entries, toSpan);
+      collectTypeFieldEntries(typeExpr.valueType, typeName, depth + 1, entries, toSpan);
       return;
 
     case "unionType":
       for (const member of typeExpr.types) {
-        collectTypeFieldEntries(member, typeName, depth + 1, entries);
+        collectTypeFieldEntries(member, typeName, depth + 1, entries, toSpan);
       }
       return;
 
@@ -410,7 +415,18 @@ function findTypeFieldLocation(
   }
 }
 
-function toSourceSpan(location: ProgramNode["location"]): SourceSpan {
+function createSourceSpanConverter(
+  sourceText: string,
+  coordinateUnit: SourceMapEmissionContext["coordinateUnit"],
+): SourceSpanConverter {
+  if (coordinateUnit === "utf16") {
+    return (location) => toUtf16SourceSpan(location);
+  }
+
+  return (location) => toByteSourceSpan(location, sourceText);
+}
+
+function toUtf16SourceSpan(location: ProgramNode["location"]): SourceSpan {
   return Object.freeze({
     start: Object.freeze({
       line: location.start.line,
@@ -420,6 +436,27 @@ function toSourceSpan(location: ProgramNode["location"]): SourceSpan {
       line: location.end.line,
       column: location.end.column,
     }),
+  });
+}
+
+function toByteSourceSpan(location: ProgramNode["location"], sourceText: string): SourceSpan {
+  return Object.freeze({
+    start: toByteSourcePoint(location.start, sourceText),
+    end: toByteSourcePoint(location.end, sourceText),
+  });
+}
+
+function toByteSourcePoint(
+  position: ProgramNode["location"]["start"],
+  sourceText: string,
+): SourcePoint {
+  const byteOffset = utf8ByteLength(sourceText.slice(0, position.offset));
+  const lineStartOffset = position.offset - (position.column - 1);
+  const lineStartByteOffset = utf8ByteLength(sourceText.slice(0, lineStartOffset));
+
+  return Object.freeze({
+    line: position.line,
+    column: byteOffset - lineStartByteOffset + 1,
   });
 }
 
@@ -483,4 +520,8 @@ function stableHashString(input: string): string {
   }
 
   return `fnv1a32:${hash.toString(16).padStart(8, "0")}`;
+}
+
+function utf8ByteLength(input: string): number {
+  return UTF8_ENCODER.encode(input).length;
 }

--- a/packages/sdk/docs/VERSION-INDEX.md
+++ b/packages/sdk/docs/VERSION-INDEX.md
@@ -15,16 +15,16 @@
 |---------|----------|-------------|-------|--------|
 | v3.1.0 | [FDR](FDR-v3.1.0-draft.md) | [ADR-015](../../../docs/internals/adr/015-snapshot-ontological-purification.md) | Rationale companion for the current v3.1.0 introspection surface: `SchemaGraph` (`feeds` / `mutates` / `unlocks`) and full-transition `simulate()` | Draft |
 
-The companion compiler contract now lives in [../../compiler/docs/SPEC-v1.0.0.md](../../compiler/docs/SPEC-v1.0.0.md). Historical addenda remain available in [../../compiler/docs/SPEC-v0.8.0.md](../../compiler/docs/SPEC-v0.8.0.md) and [../../compiler/docs/SPEC-v0.9.0.md](../../compiler/docs/SPEC-v0.9.0.md).
+The companion compiler contract now lives in [../../compiler/docs/SPEC-v1.1.0.md](../../compiler/docs/SPEC-v1.1.0.md). Historical addenda remain available in [../../compiler/docs/SPEC-v0.8.0.md](../../compiler/docs/SPEC-v0.8.0.md) and [../../compiler/docs/SPEC-v0.9.0.md](../../compiler/docs/SPEC-v0.9.0.md).
 
 ## Reading Order
 
 1. Read [../README.md](../README.md) for package entrypoint guidance.
 2. Read [GUIDE.md](GUIDE.md) for current usage and decorator/provider authoring boundaries.
 3. Read [sdk-SPEC.md](sdk-SPEC.md) for the current living SDK contract.
-4. If you are studying the current introspection surface, read [sdk-SPEC.md](sdk-SPEC.md) §5.5 and §7.4-§7.5, then [../../compiler/docs/SPEC-v1.0.0.md](../../compiler/docs/SPEC-v1.0.0.md), then [FDR-v3.1.0-draft.md](FDR-v3.1.0-draft.md).
+4. If you are studying the current introspection surface, read [sdk-SPEC.md](sdk-SPEC.md) §5.5 and §7.4-§7.5, then [../../compiler/docs/SPEC-v1.1.0.md](../../compiler/docs/SPEC-v1.1.0.md), then [FDR-v3.1.0-draft.md](FDR-v3.1.0-draft.md).
 5. If you are building helper/tooling work against arbitrary snapshots, read [ADR-019](../../../docs/internals/adr/019-post-activation-extension-kernel.md) and [sdk-SPEC.md](sdk-SPEC.md) §7.10 + §8. This is the canonical home for post-activation branching helpers and simulation-session work.
-6. If you need input-aware legality checks, read [ADR-020](../../../docs/internals/adr/020-intent-level-dispatchability.md), [sdk-SPEC.md](sdk-SPEC.md) §7.2-§7.5, and [../../compiler/docs/SPEC-v1.0.0.md](../../compiler/docs/SPEC-v1.0.0.md).
+6. If you need input-aware legality checks, read [ADR-020](../../../docs/internals/adr/020-intent-level-dispatchability.md), [sdk-SPEC.md](sdk-SPEC.md) §7.2-§7.5, and [../../compiler/docs/SPEC-v1.1.0.md](../../compiler/docs/SPEC-v1.1.0.md).
 7. If you need first-party write reports for tooling or agent callers, read [sdk-SPEC.md](sdk-SPEC.md) §7.2-§7.2.2 and [GUIDE.md](GUIDE.md) §5 before reaching for custom wrappers.
 
 ## Historical Note

--- a/packages/sdk/docs/sdk-SPEC.md
+++ b/packages/sdk/docs/sdk-SPEC.md
@@ -8,7 +8,7 @@
 
 > **Historical Note:** Pre-ADR-017 SDK surfaces live in Git history. They are no longer kept as active package docs in the working tree.
 >
-> **Current Contract Status:** Projected introspection, intent-level dispatchability, refined single-parameter object binding in `createIntent()`, the `@manifesto-ai/sdk/extensions` Extension Kernel, the first-party `createSimulationSession()` helper on that seam, additive intent explanation reads via `explainIntentFor()`, `explainIntent()`, `why()`, and `whyNot()`, and the additive base write-report companion `dispatchAsyncWithReport()` are all part of the current SDK contract. The compiler-side extraction contract now lives in [SPEC-v1.0.0](../../compiler/docs/SPEC-v1.0.0.md), including tooling-only structural annotations via `@meta`.
+> **Current Contract Status:** Projected introspection, intent-level dispatchability, refined single-parameter object binding in `createIntent()`, the `@manifesto-ai/sdk/extensions` Extension Kernel, the first-party `createSimulationSession()` helper on that seam, additive intent explanation reads via `explainIntentFor()`, `explainIntent()`, `why()`, and `whyNot()`, and the additive base write-report companion `dispatchAsyncWithReport()` are all part of the current SDK contract. The compiler-side extraction contract now lives in [SPEC-v1.1.0](../../compiler/docs/SPEC-v1.1.0.md), including tooling-only structural annotations via `@meta` and declaration-level source maps through `DomainModule.sourceMap`.
 
 ## 1. Purpose
 
@@ -1448,5 +1448,5 @@ An SDK v3.x implementation complies with this living contract only if all of the
 - [ADR-017](../../../docs/internals/adr/017-capability-decorator-pattern.md)
 - [Core SPEC v4.2.0](../../core/docs/core-SPEC.md)
 - [Host Contract v4.0.0](../../host/docs/host-SPEC.md)
-- [Compiler SPEC v1.0.0](../../compiler/docs/SPEC-v1.0.0.md)
+- [Compiler SPEC v1.1.0](../../compiler/docs/SPEC-v1.1.0.md)
 - [SDK FDR v3.1.0 Rationale Track](FDR-v3.1.0-draft.md)


### PR DESCRIPTION
## Summary
- add compiler-owned declaration-level `SourceMapIndex` sidecar emission to `compileMelModule()`
- promote the compiler current contract to `SPEC-v1.1.0` and align current-facing docs for ADR-022
- harden compliance/docs inventory coverage, regenerate API public surface inventory, and clean stale current-spec references in maintained docs and historical ADR pointers

## Why
ADR-022 introduced a tooling-only source location sidecar owned by the compiler. The compiler implementation, current contract docs, and compliance/docs checks needed to be brought into alignment so the feature is usable and the repo stays release-ready.

## Impact
- `DomainModule` now includes `sourceMap: SourceMapIndex`
- runtime seams remain `DomainSchema`-only
- compiler/docs/current-contract/public surface now point to `SPEC-v1.1.0`
- repo-wide build, test, and docs release checks pass with the updated surface

## Validation
- `pnpm build`
- `pnpm test`
- `pnpm docs:release:check`