### PR TITLE
fix(sdk): move base runtime helper to provider seam

### DIFF
--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -1167,6 +1167,7 @@ _Source: `packages/sdk/src/provider.ts`_
 - `assertComposableNotActivated`
 - `attachExtensionKernel`
 - `attachRuntimeKernelFactory`
+- `createBaseRuntimeInstance`
 - `createRuntimeKernel`
 - `getActivationState`
 - `getRuntimeKernelFactory`

--- a/packages/sdk/docs/GUIDE.md
+++ b/packages/sdk/docs/GUIDE.md
@@ -266,10 +266,15 @@ The stable authoring seam is the activation/runtime composition layer:
 - `RuntimeKernel`
 - `RuntimeKernelFactory`
 - `attachRuntimeKernelFactory()`
+- `createBaseRuntimeInstance()`
 - `getRuntimeKernelFactory()`
 - `getActivationState()`
 - `activateComposable()`
 - `assertComposableNotActivated()`
+
+If you want to turn a provider-authored `RuntimeKernel` back into the standard
+base SDK runtime contract, use `createBaseRuntimeInstance(kernel)` from the
+provider seam rather than reaching into an internal subpath.
 
 For decorators that need hypothetical planning or availability checks against
 non-live state, `RuntimeKernel` also exposes pure arbitrary-snapshot helpers:
@@ -292,6 +297,7 @@ import type {
 import {
   activateComposable,
   attachRuntimeKernelFactory,
+  createBaseRuntimeInstance,
   getActivationState,
   getRuntimeKernelFactory,
 } from "@manifesto-ai/sdk/provider";
@@ -307,23 +313,7 @@ function withExampleDecorator<T extends ManifestoDomainShape>(
     schema: manifesto.schema,
     activate() {
       activateComposable(decorated);
-      const kernel = createKernel();
-      return {
-        createIntent: kernel.createIntent,
-        dispatchAsync: async (intent) => kernel.executeHost(intent).then((result) => result.snapshot),
-        subscribe: kernel.subscribe,
-        on: kernel.on,
-        getSnapshot: kernel.getSnapshot,
-        getCanonicalSnapshot: kernel.getCanonicalSnapshot,
-        getAvailableActions: kernel.getAvailableActions,
-        getActionMetadata: kernel.getActionMetadata,
-        isActionAvailable: kernel.isActionAvailable,
-        getSchemaGraph: kernel.getSchemaGraph,
-        simulate: kernel.simulate,
-        MEL: kernel.MEL,
-        schema: kernel.schema,
-        dispose: kernel.dispose,
-      };
+      return createBaseRuntimeInstance(createKernel());
     },
   };
 

--- a/packages/sdk/docs/VERSION-INDEX.md
+++ b/packages/sdk/docs/VERSION-INDEX.md
@@ -7,7 +7,7 @@
 
 | Version | Document | ADR | Notes | Status |
 |---------|----------|-----|-------|--------|
-| v3.x | [SPEC](sdk-SPEC.md) | [ADR-017](../../../docs/internals/adr/017-capability-decorator-pattern.md), [ADR-019](../../../docs/internals/adr/019-post-activation-extension-kernel.md), [ADR-020](../../../docs/internals/adr/020-intent-level-dispatchability.md) | Activation-first SDK with `activate()`, typed `createIntent()` including non-ambiguous single-parameter object binding, dequeue-time rejection codes for coarse vs fine legality, current-snapshot blocker explanations, projected `SchemaGraph`, `simulate()`, the additive base write-report companion `dispatchAsyncWithReport()`, the `@manifesto-ai/sdk/extensions` Extension Kernel including arbitrary-snapshot `isIntentDispatchableFor()`, the first-party `createSimulationSession()` helper, and the public provider authoring seam | Current |
+| v3.x | [SPEC](sdk-SPEC.md) | [ADR-017](../../../docs/internals/adr/017-capability-decorator-pattern.md), [ADR-019](../../../docs/internals/adr/019-post-activation-extension-kernel.md), [ADR-020](../../../docs/internals/adr/020-intent-level-dispatchability.md) | Activation-first SDK with `activate()`, typed `createIntent()` including non-ambiguous single-parameter object binding, dequeue-time rejection codes for coarse vs fine legality, current-snapshot blocker explanations, projected `SchemaGraph`, `simulate()`, the additive base write-report companion `dispatchAsyncWithReport()`, the `@manifesto-ai/sdk/extensions` Extension Kernel including arbitrary-snapshot `isIntentDispatchableFor()`, the first-party `createSimulationSession()` helper, and the public provider authoring seam including `createBaseRuntimeInstance()` | Current |
 
 ## Draft Rationale Track
 

--- a/packages/sdk/docs/sdk-SPEC.md
+++ b/packages/sdk/docs/sdk-SPEC.md
@@ -1307,6 +1307,8 @@ That subpath is for helper and tool authors who need safe arbitrary-snapshot rea
 
 The public decorator/provider authoring seam lives at `@manifesto-ai/sdk/provider`.
 That subpath exposes `RuntimeKernel`, `RuntimeKernelFactory`, focused consumer aliases such as `LineageRuntimeKernel`, `GovernanceRuntimeKernel`, and `WaitForProposalRuntimeKernel`, plus the activation-state helpers used by `withLineage()` and `withGovernance()`.
+It also exposes `createBaseRuntimeInstance(kernel)` as the standard helper for
+reifying the base SDK runtime contract from a provider-authored kernel.
 
 `RuntimeKernel` remains the compatibility aggregate for provider authors. Focused consumer aliases are narrower views over that same provider seam and MUST NOT weaken the compatibility contract of `RuntimeKernel`.
 
@@ -1346,6 +1348,7 @@ Those are defined by ADR-017 and their owning package specs.
 | SDK-BOUNDARY-5 | MUST | once lineage or governance laws are composed, `activate()` MUST return the runtime type defined by the owning package rather than the base SDK runtime |
 | SDK-BOUNDARY-6 | MUST | `@manifesto-ai/sdk/provider` MUST expose arbitrary-snapshot `RuntimeKernel` helpers `simulateSync()`, `getAvailableActionsFor()`, and `isActionAvailableFor()` for decorator authors |
 | SDK-BOUNDARY-6a | MUST | `@manifesto-ai/sdk/provider` MAY expose focused consumer aliases, but those aliases MUST remain narrower views over the same provider seam and MUST NOT replace `RuntimeKernel` as the compatibility aggregate |
+| SDK-BOUNDARY-6b | MUST | `@manifesto-ai/sdk/provider` MUST expose `createBaseRuntimeInstance(kernel)` as the standard helper for wrapping a provider-authored `RuntimeKernel` back into the base SDK runtime contract |
 | SDK-BOUNDARY-7 | MUST NOT | provider-seam arbitrary-snapshot helpers MUST NOT mutate, publish, or otherwise replace the visible runtime snapshot |
 | SDK-BOUNDARY-8 | MUST | `@manifesto-ai/sdk/extensions` MUST expose post-activation observationally pure arbitrary-snapshot helpers for activated runtimes |
 | SDK-BOUNDARY-9 | MUST NOT | `@manifesto-ai/sdk/extensions` MUST NOT expose runtime-control methods or provider-only activation/composition helpers |

--- a/packages/sdk/src/__tests__/public-exports.test.ts
+++ b/packages/sdk/src/__tests__/public-exports.test.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import * as sdk from "../index.js";
 import * as effectHelpers from "../effects.js";
 import * as extensions from "../extensions.js";
+import * as provider from "../provider.js";
 
 describe("SDK public runtime exports", () => {
   it("exposes the v3 hard-cut runtime surface", () => {
@@ -35,5 +38,23 @@ describe("SDK public runtime exports", () => {
     expect(extensions.createSimulationSession).toBeDefined();
     expect("getExtensionKernel" in sdk).toBe(false);
     expect("createSimulationSession" in sdk).toBe(false);
+  });
+
+  it("keeps provider helpers on the provider subpath", () => {
+    expect(provider.createRuntimeKernel).toBeDefined();
+    expect(provider.createBaseRuntimeInstance).toBeDefined();
+    expect("createRuntimeKernel" in sdk).toBe(false);
+    expect("createBaseRuntimeInstance" in sdk).toBe(false);
+  });
+
+  it("does not publish the internal compat subpath", () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as {
+      exports?: Record<string, unknown>;
+    };
+
+    expect(packageJson.exports?.["./provider"]).toBeDefined();
+    expect(packageJson.exports?.["./compat/internal"]).toBeUndefined();
   });
 });

--- a/packages/sdk/src/__tests__/types/provider-seam.typecheck.ts
+++ b/packages/sdk/src/__tests__/types/provider-seam.typecheck.ts
@@ -2,6 +2,7 @@ import type {
   BaseComposableLaws,
   ComposableManifesto,
   DispatchBlocker,
+  ManifestoBaseInstance,
   ManifestoDomainShape,
 } from "../../index.ts";
 import type {
@@ -20,6 +21,7 @@ import {
   activateComposable,
   assertComposableNotActivated,
   attachRuntimeKernelFactory,
+  createBaseRuntimeInstance,
   getActivationState,
   getRuntimeKernelFactory,
 } from "../../provider.ts";
@@ -57,9 +59,11 @@ const intent = kernel.createIntent(kernel.MEL.actions.ping);
 const isDispatchableFor: boolean = kernel.isIntentDispatchableFor(canonical, intent);
 const blockersFor: readonly DispatchBlocker[] = kernel.getIntentBlockersFor(canonical, intent);
 const simulation: SimulateResult<DemoDomain> = kernel.simulateSync(canonical, intent);
+const baseRuntime: ManifestoBaseInstance<DemoDomain> = createBaseRuntimeInstance(kernel);
 
 void activationState;
 void availableFor;
+void baseRuntime;
 void canonical;
 void governanceFactory;
 void governanceKernel;

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -24,3 +24,4 @@ export {
   getActivationState,
   getRuntimeKernelFactory,
 } from "./compat/internal.js";
+export { createBaseRuntimeInstance } from "./runtime/base-runtime.js";


### PR DESCRIPTION
## Summary
- expose `createBaseRuntimeInstance()` on `@manifesto-ai/sdk/provider`
- stop publishing `@manifesto-ai/sdk/compat/internal` as a public package subpath
- update SDK provider seam docs, tests, and public surface inventory to match the new contract

## Why
Studio only needed the base runtime reification helper, not the full `compat/internal` surface. Moving that helper onto the documented provider seam keeps the public contract narrow while preserving the Studio integration path.

## Testing
- `pnpm --filter @manifesto-ai/sdk test`
- `pnpm --filter @manifesto-ai/sdk build`
- `pnpm docs:api:check`