### PR TITLE
fix(compiler): harden MEL type-checking and compliance coverage

### DIFF
--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -471,6 +471,34 @@ describe("Expression type checking", () => {
     expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
   });
 
+  it("keeps argmax results nullable when predicates read through index access", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Entry = { mode: "ship" | "pickup" }
+
+        state {
+          entries: Record<string, Entry> = {}
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["pickup", eq(entries["active"].mode, "pickup"), 100],
+          ["ship", eq(entries["active"].mode, "ship"), 80],
+          "first"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
+
   it("accepts argmin results as non-null when candidate eligibility is exhaustively covered", () => {
     const result = compileSource(`
       domain Demo {

--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -443,6 +443,34 @@ describe("Expression type checking", () => {
     expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
   });
 
+  it("keeps argmax results nullable when predicates read through optional property access", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Selection = { mode?: "ship" | "pickup" }
+
+        state {
+          selection: Selection = {}
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["pickup", eq(selection.mode, "pickup"), 100],
+          ["ship", eq(selection.mode, "ship"), 80],
+          "first"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
+
   it("accepts argmin results as non-null when candidate eligibility is exhaustively covered", () => {
     const result = compileSource(`
       domain Demo {

--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -216,6 +216,27 @@ describe("Expression type checking", () => {
     expect(result.success).toBe(true);
   });
 
+  it("keeps coalesce nullable when every branch may be null", () => {
+    const result = compileSource(`
+      domain Demo {
+        state {
+          primary: string | null = null
+          secondary: string | null = null
+          chosen: string = ""
+        }
+
+        action copy() {
+          when true {
+            patch chosen = coalesce(primary, secondary)
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
+
   it("accepts typed values(record) mapping for direct array assignment", () => {
     const result = compileSource(`
       domain Demo {

--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -180,4 +180,284 @@ describe("Expression type checking", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("accepts coalesce as a numeric fallback for bounded numeric calls", () => {
+    const result = compileSource(`
+      domain Demo {
+        state { count: number = 1 }
+        computed maybe = idiv(count, 2)
+        computed safe = clamp(coalesce(maybe, 0), 0, 10)
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts coalesce as a non-null selector fallback for match", () => {
+    const result = compileSource(`
+      domain Demo {
+        state { mode: "ship" | "pickup" = "ship" }
+
+        computed carrier = argmax(
+          ["pickup", eq(mode, "pickup"), 100],
+          ["ship", eq(mode, "ship"), 80],
+          "first"
+        )
+
+        computed tier = match(
+          coalesce(carrier, "manual"),
+          ["pickup", "pickup"],
+          ["ship", "ship"],
+          "manual"
+        )
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts typed values(record) mapping for direct array assignment", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Item = { id: string, qty: number }
+        type Line = { id: string, qty: number }
+
+        state {
+          items: Record<string, Item> = {}
+          lines: Array<Line> = []
+        }
+
+        action copy() {
+          when true {
+            patch lines = map(values(items), {
+              id: $item.id,
+              qty: $item.qty
+            })
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects mistyped values(record) mapping for direct array assignment", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Item = { id: string, qty: number }
+        type Line = { id: string, qty: number }
+
+        state {
+          items: Record<string, Item> = {}
+          lines: Array<Line> = []
+        }
+
+        action copy() {
+          when true {
+            patch lines = map(values(items), {
+              id: 1,
+              qty: "x"
+            })
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
+
+  it("accepts typed values(record) mapping nested inside object literals", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Item = { id: string, qty: number }
+        type Line = { id: string, qty: number }
+        type Order = { id: string, lines: Array<Line> }
+
+        state {
+          items: Record<string, Item> = {}
+          orders: Record<string, Order> = {}
+        }
+
+        action submit(orderId: string) {
+          when true {
+            patch orders[orderId] = {
+              id: orderId,
+              lines: map(values(items), {
+                id: $item.id,
+                qty: $item.qty
+              })
+            }
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts argmax results as non-null when candidate eligibility is exhaustively covered", () => {
+    const result = compileSource(`
+      domain Demo {
+        state {
+          mode: "ship" | "pickup" = "ship"
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["pickup", eq(mode, "pickup"), 100],
+          ["ship", eq(mode, "ship"), 80],
+          "first"
+        )
+
+        computed tier = match(
+          carrier,
+          ["pickup", "pickup"],
+          ["ship", "ship"],
+          "manual"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("keeps argmax results nullable when candidate eligibility is not exhaustively covered", () => {
+    const result = compileSource(`
+      domain Demo {
+        state {
+          flag: boolean = false
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["a", flag, 1],
+          ["b", false, 0],
+          "first"
+        )
+
+        computed tier = match(
+          carrier,
+          ["a", "A"],
+          ["b", "B"],
+          "manual"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
+
+  it("keeps argmax results nullable when literal-union coverage is incomplete", () => {
+    const result = compileSource(`
+      domain Demo {
+        state {
+          mode: "ship" | "pickup" | "digital" = "ship"
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["pickup", eq(mode, "pickup"), 100],
+          ["ship", eq(mode, "ship"), 80],
+          "first"
+        )
+
+        computed tier = match(
+          carrier,
+          ["pickup", "pickup"],
+          ["ship", "ship"],
+          "manual"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
+
+  it("accepts argmin results as non-null when candidate eligibility is exhaustively covered", () => {
+    const result = compileSource(`
+      domain Demo {
+        state {
+          mode: "pickup" | "ship" = "ship"
+          note: string = ""
+        }
+
+        computed carrier = argmin(
+          ["pickup", eq(mode, "pickup"), 100],
+          ["ship", eq(mode, "ship"), 80],
+          "first"
+        )
+
+        computed tier = match(
+          carrier,
+          ["pickup", "pickup"],
+          ["ship", "ship"],
+          "manual"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the CommerceFulfillmentEngine preferredCarrier pattern without explicit fallback", () => {
+    const result = compileSource(`
+      domain Demo {
+        state {
+          fulfillmentMode: "ship" | "pickup" = "ship"
+          shippingCountry: "KR" | "US" = "KR"
+          note: string = ""
+        }
+
+        computed preferredCarrier = argmax(
+          ["pickup", eq(fulfillmentMode, "pickup"), 100],
+          ["domestic_ship", and(eq(fulfillmentMode, "ship"), eq(shippingCountry, "KR")), 80],
+          ["international_ship", and(eq(fulfillmentMode, "ship"), neq(shippingCountry, "KR")), 60],
+          "first"
+        )
+
+        computed fulfillmentTier = match(
+          preferredCarrier,
+          ["pickup", "pickup"],
+          ["domestic_ship", "standard"],
+          ["international_ship", "review"],
+          "manual"
+        )
+
+        action remember() {
+          when true {
+            patch note = preferredCarrier
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -415,6 +415,34 @@ describe("Expression type checking", () => {
     expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
   });
 
+  it("keeps argmax results nullable when predicates read through nullable property access", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Selection = { mode: "ship" | "pickup" }
+
+        state {
+          selection: Selection | null = null
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["pickup", eq(selection.mode, "pickup"), 100],
+          ["ship", eq(selection.mode, "ship"), 80],
+          "first"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
+
   it("accepts argmin results as non-null when candidate eligibility is exhaustively covered", () => {
     const result = compileSource(`
       domain Demo {

--- a/packages/compiler/__tests__/type-checking/literal-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/literal-type-check.test.ts
@@ -255,6 +255,265 @@ describe("Literal type checking", () => {
     });
   });
 
+  describe("nullable object patch literals", () => {
+    it("accepts partially dynamic object literals for non-null object patch targets", () => {
+      const result = compileSource(`
+        domain Test {
+          type RuntimeOperation = {
+            kind: string,
+            targetId: string
+          }
+
+          state {
+            lastOperation: RuntimeOperation = {
+              kind: "seed",
+              targetId: "seed"
+            }
+          }
+
+          action setOp(id: string) {
+            when true {
+              patch lastOperation = {
+                kind: "a",
+                targetId: id
+              }
+            }
+          }
+        }
+      `);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts all-literal object literals for nullable object patch targets", () => {
+      const result = compileSource(`
+        domain Test {
+          type RuntimeOperation = {
+            kind: string,
+            targetId: string
+          }
+
+          state {
+            lastOperation: RuntimeOperation | null = null
+          }
+
+          action setOp() {
+            when true {
+              patch lastOperation = {
+                kind: "a",
+                targetId: "fixed"
+              }
+            }
+          }
+        }
+      `);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts partially dynamic object literals for nullable named object patch targets", () => {
+      const result = compileSource(`
+        domain Test {
+          type RuntimeOperation = {
+            kind: "a" | "b",
+            targetId: string
+          }
+
+          state {
+            lastOperation: RuntimeOperation | null = null
+          }
+
+          action setOp(id: string) {
+            when true {
+              patch lastOperation = {
+                kind: "a",
+                targetId: id
+              }
+            }
+          }
+        }
+      `);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts partially dynamic object literals for nullable inline object patch targets", () => {
+      const result = compileSource(`
+        domain Test {
+          state {
+            lastOperation: { kind: "a" | "b", targetId: string } | null = null
+          }
+
+          action setOp(id: string) {
+            when true {
+              patch lastOperation = {
+                kind: "a",
+                targetId: id
+              }
+            }
+          }
+        }
+      `);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects static field mismatches for nullable object patch targets", () => {
+      const result = compileSource(`
+        domain Test {
+          type RuntimeOperation = {
+            kind: string,
+            targetId: string
+          }
+
+          state {
+            lastOperation: RuntimeOperation | null = null
+          }
+
+          action setOp() {
+            when true {
+              patch lastOperation = {
+                kind: "a",
+                targetId: 1
+              }
+            }
+          }
+        }
+      `);
+      expect(result.success).toBe(false);
+      expect(result.errors.some((diagnostic) =>
+        diagnostic.code === "E_TYPE_MISMATCH"
+          && diagnostic.message.includes("Patch value for 'lastOperation' must be assignable")
+      )).toBe(true);
+    });
+
+    it("does not flag plain nullable primitive patch assignments", () => {
+      const result = compileSource(`
+        domain Test {
+          state {
+            selectedId: string | null = null
+          }
+
+          action setSelected(id: string) {
+            when true {
+              patch selectedId = id
+            }
+          }
+        }
+      `);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("patch merge type checking", () => {
+    it("accepts partial merge payloads for object targets", () => {
+      const result = compileSource(`
+        domain Test {
+          type User = {
+            name: string,
+            age: number
+          }
+
+          state {
+            user: User = {
+              name: "a",
+              age: 1
+            }
+          }
+
+          action rename() {
+            when true {
+              patch user merge {
+                name: "b"
+              }
+            }
+          }
+        }
+      `);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts partial merge payloads for nullable object targets", () => {
+      const result = compileSource(`
+        domain Test {
+          type Draft = {
+            customerId: string,
+            submissionState: "idle" | "ready"
+          }
+
+          state {
+            draft: Draft | null = null
+          }
+
+          action markReady() {
+            when true {
+              patch draft merge {
+                submissionState: "ready"
+              }
+            }
+          }
+        }
+      `);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects wrong field types in merge payloads", () => {
+      const result = compileSource(`
+        domain Test {
+          type User = {
+            name: string,
+            age: number
+          }
+
+          state {
+            user: User = {
+              name: "a",
+              age: 1
+            }
+          }
+
+          action rename() {
+            when true {
+              patch user merge {
+                age: "oops"
+              }
+            }
+          }
+        }
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+    });
+
+    it("rejects unknown fields in merge payloads", () => {
+      const result = compileSource(`
+        domain Test {
+          type User = {
+            name: string,
+            age: number
+          }
+
+          state {
+            user: User = {
+              name: "a",
+              age: 1
+            }
+          }
+
+          action rename() {
+            when true {
+              patch user merge {
+                nickname: "b"
+              }
+            }
+          }
+        }
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+    });
+  });
+
   describe("valid MEL compiles successfully", () => {
     it("accepts correct types", () => {
       const result = compileSource(`

--- a/packages/compiler/src/__tests__/compliance/ccts-coverage.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-coverage.ts
@@ -39,6 +39,10 @@ export const CCTS_CASES = {
   STATE_COMPUTED_DEPS: "CCTS-STATE-005",
   STATE_SCHEMA_REFS: "CCTS-STATE-006",
   STATE_UNSUPPORTED_TYPES: "CCTS-STATE-007",
+  STATE_PATCH_MERGE: "CCTS-STATE-008",
+  STATE_COALESCE_NARROWING: "CCTS-STATE-009",
+  STATE_VALUES_RECORD_TYPING: "CCTS-STATE-010",
+  STATE_ARG_SELECTION_COVERAGE: "CCTS-STATE-011",
 
   ACTIONS_GUARDED_BODY: "CCTS-ACT-001",
   ACTIONS_ONCE_DESUGARING: "CCTS-ACT-002",
@@ -100,6 +104,10 @@ export const COMPILER_COMPLIANCE_CASES: readonly CompilerComplianceCase[] = [
   complianceCase(CCTS_CASES.STATE_COMPUTED_DEPS, "state-and-computed", "Computed deps are extracted and ordered."),
   complianceCase(CCTS_CASES.STATE_SCHEMA_REFS, "state-and-computed", "Schema-position references and computed cycles are diagnosed."),
   complianceCase(CCTS_CASES.STATE_UNSUPPORTED_TYPES, "state-and-computed", "Unsupported FieldSpec-lowering types are tracked."),
+  complianceCase(CCTS_CASES.STATE_PATCH_MERGE, "state-and-computed", "patch merge remains a shallow partial-object operation."),
+  complianceCase(CCTS_CASES.STATE_COALESCE_NARROWING, "state-and-computed", "coalesce narrows compatible nullable branches for downstream typing."),
+  complianceCase(CCTS_CASES.STATE_VALUES_RECORD_TYPING, "state-and-computed", "values(Record<string, T>) preserves typed collection flow semantics."),
+  complianceCase(CCTS_CASES.STATE_ARG_SELECTION_COVERAGE, "state-and-computed", "argmax/argmin keep nullable labels only when candidate eligibility is not exhaustively covered."),
 
   complianceCase(CCTS_CASES.ACTIONS_GUARDED_BODY, "actions-and-control", "Action mutations remain guarded."),
   complianceCase(CCTS_CASES.ACTIONS_ONCE_DESUGARING, "actions-and-control", "once() desugars to intent-guarded marker writes."),
@@ -171,6 +179,10 @@ export const COMPILER_RULE_COVERAGE: readonly CompilerComplianceCoverageEntry[] 
   ...coverMany(["STATE-INIT-2", "STATE-INIT-3", "E040", "E041", "E042"], [CCTS_CASES.STATE_SCHEMA_REFS]),
   ...coverMany(["COMP-DEP-1", "COMP-DEP-2", "COMP-DEP-3", "COMP-DEP-4", "COMP-DEP-5", "COMP-DEP-6"], [CCTS_CASES.STATE_COMPUTED_DEPS, CCTS_CASES.STATE_SCHEMA_REFS]),
   ...coverMany(["TYPE-LOWER-6", "TYPE-LOWER-7", "TYPE-LOWER-8", "TYPE-LOWER-9", "E043", "E044"], [CCTS_CASES.STATE_UNSUPPORTED_TYPES]),
+  ...coverMany(["PATCH-MERGE-1"], [CCTS_CASES.STATE_PATCH_MERGE]),
+  ...coverMany(["COALESCE-1"], [CCTS_CASES.STATE_COALESCE_NARROWING]),
+  ...coverMany(["COLLECT-VALUES-1"], [CCTS_CASES.STATE_VALUES_RECORD_TYPING]),
+  ...coverMany(["MEL-SUGAR-4"], [CCTS_CASES.IR_ARG_SELECTION_SUGAR, CCTS_CASES.STATE_ARG_SELECTION_COVERAGE]),
 
   ...coverMany(["COMPILER-MEL-1"], [CCTS_CASES.ACTIONS_ONCE_INTENT_DESUGARING]),
   ...coverMany(["COMPILER-MEL-3"], [CCTS_CASES.GRAMMAR_ONCE_INTENT_CONTEXTUAL]),

--- a/packages/compiler/src/__tests__/compliance/ccts-rules.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-rules.ts
@@ -42,6 +42,7 @@ export const COMPILER_COMPLIANCE_RULES: readonly CompilerComplianceRule[] = [
   ...registryMany(["COMP-DEP-5", "COMP-DEP-6"], "blocking"),
   ...registryMany(["TYPE-LOWER-1", "TYPE-LOWER-2", "TYPE-LOWER-3", "TYPE-LOWER-4", "TYPE-LOWER-5"], "blocking"),
   ...registryMany(["TYPE-LOWER-6", "TYPE-LOWER-7", "TYPE-LOWER-8", "TYPE-LOWER-9"], "blocking"),
+  ...registryMany(["PATCH-MERGE-1", "COALESCE-1", "COLLECT-VALUES-1"], "blocking"),
   ...registryMany(["SGRAPH-1", "SGRAPH-2", "SGRAPH-3", "SGRAPH-4", "SGRAPH-5", "SGRAPH-6", "SGRAPH-7", "SGRAPH-8", "SGRAPH-9", "SGRAPH-10", "SGRAPH-11", "SGRAPH-12", "SGRAPH-13", "SGRAPH-14", "SGRAPH-15"], "blocking"),
 
   ...registryMany(["ENTITY-1", "ENTITY-2", "ENTITY-2a", "ENTITY-2b", "ENTITY-3", "ENTITY-4", "ENTITY-5", "ENTITY-7", "ENTITY-8", "ENTITY-9"], "blocking"),

--- a/packages/compiler/src/__tests__/compliance/ccts-spec-inventory.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-spec-inventory.ts
@@ -78,6 +78,9 @@ export const COMPILER_SPEC_INVENTORY: readonly CompilerComplianceInventoryItem[]
     notes: "Record schema-position types MUST lower through compatibility FieldSpec plus precise TypeDefinition.",
   }),
   ...inventoryMany(["TYPE-LOWER-8", "TYPE-LOWER-9"], "§5.6.2", "MUST", "state-and-computed"),
+  inventory("PATCH-MERGE-1", "docs/mel/REFERENCE.md `patch merge` / docs/mel/SYNTAX.md `patch path merge expr`", "MUST", "state-and-computed"),
+  inventory("COALESCE-1", "docs/mel/REFERENCE.md `coalesce(a, b, ...)`", "MUST", "state-and-computed"),
+  inventory("COLLECT-VALUES-1", "docs/mel/REFERENCE.md `values(obj)` / docs/mel/SYNTAX.md computed examples", "MUST", "state-and-computed"),
   ...inventoryMany(["SGRAPH-1", "SGRAPH-2", "SGRAPH-3", "SGRAPH-4", "SGRAPH-5", "SGRAPH-6", "SGRAPH-7", "SGRAPH-8", "SGRAPH-9", "SGRAPH-10", "SGRAPH-11", "SGRAPH-12", "SGRAPH-13", "SGRAPH-14"], "SPEC v0.8.0 §6/§7/§8", "MUST", "introspection"),
   inventory("SGRAPH-15", "SPEC v0.8.0 §6", "SHOULD", "introspection"),
 

--- a/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
@@ -707,9 +707,31 @@ describe("CCTS State and Computed Suite", () => {
         }
       }
     `);
+    const optionalPathResult = adapter.compile(`
+      domain Demo {
+        type Selection = { mode?: "ship" | "pickup" }
+
+        state {
+          selection: Selection = {}
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["pickup", eq(selection.mode, "pickup"), 100],
+          ["ship", eq(selection.mode, "ship"), 80],
+          "first"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
 
     expectAllCompliance([
-      evaluateRule(getRuleOrThrow("MEL-SUGAR-4"), coveredResult.success && coveredMinResult.success && hasDiagnosticCode(uncoveredResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(literalGapResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(nullablePathResult.errors, "E_TYPE_MISMATCH"), {
+      evaluateRule(getRuleOrThrow("MEL-SUGAR-4"), coveredResult.success && coveredMinResult.success && hasDiagnosticCode(uncoveredResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(literalGapResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(nullablePathResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(optionalPathResult.errors, "E_TYPE_MISMATCH"), {
         passMessage: "argmax()/argmin() preserve non-null label typing only when candidate eligibility coverage is statically exhaustive.",
         failMessage: "argmax()/argmin() nullability narrowing is either too weak for exhaustive coverage or too loose for uncovered cases.",
         evidence: [
@@ -718,6 +740,7 @@ describe("CCTS State and Computed Suite", () => {
           ...diagnosticEvidence(uncoveredResult.errors),
           ...diagnosticEvidence(literalGapResult.errors),
           ...diagnosticEvidence(nullablePathResult.errors),
+          ...diagnosticEvidence(optionalPathResult.errors),
         ],
       }),
     ]);

--- a/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
@@ -729,9 +729,31 @@ describe("CCTS State and Computed Suite", () => {
         }
       }
     `);
+    const indexPathResult = adapter.compile(`
+      domain Demo {
+        type Entry = { mode: "ship" | "pickup" }
+
+        state {
+          entries: Record<string, Entry> = {}
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["pickup", eq(entries["active"].mode, "pickup"), 100],
+          ["ship", eq(entries["active"].mode, "ship"), 80],
+          "first"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
 
     expectAllCompliance([
-      evaluateRule(getRuleOrThrow("MEL-SUGAR-4"), coveredResult.success && coveredMinResult.success && hasDiagnosticCode(uncoveredResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(literalGapResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(nullablePathResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(optionalPathResult.errors, "E_TYPE_MISMATCH"), {
+      evaluateRule(getRuleOrThrow("MEL-SUGAR-4"), coveredResult.success && coveredMinResult.success && hasDiagnosticCode(uncoveredResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(literalGapResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(nullablePathResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(optionalPathResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(indexPathResult.errors, "E_TYPE_MISMATCH"), {
         passMessage: "argmax()/argmin() preserve non-null label typing only when candidate eligibility coverage is statically exhaustive.",
         failMessage: "argmax()/argmin() nullability narrowing is either too weak for exhaustive coverage or too loose for uncovered cases.",
         evidence: [
@@ -741,6 +763,7 @@ describe("CCTS State and Computed Suite", () => {
           ...diagnosticEvidence(literalGapResult.errors),
           ...diagnosticEvidence(nullablePathResult.errors),
           ...diagnosticEvidence(optionalPathResult.errors),
+          ...diagnosticEvidence(indexPathResult.errors),
         ],
       }),
     ]);

--- a/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
@@ -400,4 +400,282 @@ describe("CCTS State and Computed Suite", () => {
       }),
     ]);
   });
+
+  it(caseTitle(CCTS_CASES.STATE_PATCH_MERGE, "(PATCH-MERGE-1) patch merge remains a shallow partial-object operation"), () => {
+    const partialResult = adapter.compile(`
+      domain Demo {
+        type User = { name: string, age: number }
+
+        state {
+          user: User = { name: "a", age: 1 }
+        }
+
+        action rename() {
+          when true {
+            patch user merge { name: "b" }
+          }
+        }
+      }
+    `);
+    const invalidResult = adapter.compile(`
+      domain Demo {
+        type User = { name: string, age: number }
+
+        state {
+          user: User = { name: "a", age: 1 }
+        }
+
+        action rename() {
+          when true {
+            patch user merge { age: "oops" }
+          }
+        }
+      }
+    `);
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("PATCH-MERGE-1"), partialResult.success && hasDiagnosticCode(invalidResult.errors, "E_TYPE_MISMATCH"), {
+        passMessage: "patch merge accepts partial object payloads while preserving field-level type checks.",
+        failMessage: "patch merge no longer behaves as a shallow partial-object operation.",
+        evidence: [
+          ...diagnosticEvidence(partialResult.errors),
+          ...diagnosticEvidence(invalidResult.errors),
+        ],
+      }),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.STATE_COALESCE_NARROWING, "(COALESCE-1) coalesce narrows compatible nullable branches for downstream typing"), () => {
+    const numericResult = adapter.compile(`
+      domain Demo {
+        state { count: number = 1 }
+        computed maybe = idiv(count, 2)
+        computed safe = clamp(coalesce(maybe, 0), 0, 10)
+      }
+    `);
+    const selectorResult = adapter.compile(`
+      domain Demo {
+        state { mode: "ship" | "pickup" = "ship" }
+
+        computed carrier = argmax(
+          ["pickup", eq(mode, "pickup"), 100],
+          ["ship", eq(mode, "ship"), 80],
+          "first"
+        )
+
+        computed tier = match(
+          coalesce(carrier, "manual"),
+          ["pickup", "pickup"],
+          ["ship", "ship"],
+          "manual"
+        )
+      }
+    `);
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("COALESCE-1"), numericResult.success && selectorResult.success, {
+        passMessage: "coalesce provides non-null downstream typing for compatible fallback branches.",
+        failMessage: "coalesce still leaks nullable result types into downstream numeric or selector checks.",
+        evidence: [
+          ...diagnosticEvidence(numericResult.errors),
+          ...diagnosticEvidence(selectorResult.errors),
+        ],
+      }),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.STATE_VALUES_RECORD_TYPING, "(COLLECT-VALUES-1) values(record) preserves typed collection flows"), () => {
+    const typedResult = adapter.compile(`
+      domain Demo {
+        type Item = { id: string, qty: number }
+        type Line = { id: string, qty: number }
+
+        state {
+          items: Record<string, Item> = {}
+          lines: Array<Line> = []
+        }
+
+        action copy() {
+          when true {
+            patch lines = map(values(items), { id: $item.id, qty: $item.qty })
+          }
+        }
+      }
+    `);
+    const invalidResult = adapter.compile(`
+      domain Demo {
+        type Item = { id: string, qty: number }
+        type Line = { id: string, qty: number }
+
+        state {
+          items: Record<string, Item> = {}
+          lines: Array<Line> = []
+        }
+
+        action copy() {
+          when true {
+            patch lines = map(values(items), { id: 1, qty: "x" })
+          }
+        }
+      }
+    `);
+    const nestedResult = adapter.compile(`
+      domain Demo {
+        type Item = { id: string, qty: number }
+        type Line = { id: string, qty: number }
+        type Order = { id: string, lines: Array<Line> }
+
+        state {
+          items: Record<string, Item> = {}
+          orders: Record<string, Order> = {}
+        }
+
+        action submit(orderId: string) {
+          when true {
+            patch orders[orderId] = {
+              id: orderId,
+              lines: map(values(items), { id: $item.id, qty: $item.qty })
+            }
+          }
+        }
+      }
+    `);
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("COLLECT-VALUES-1"), typedResult.success && nestedResult.success && hasDiagnosticCode(invalidResult.errors, "E_TYPE_MISMATCH"), {
+        passMessage: "values(record) keeps typed collection flows visible to semantic checking.",
+        failMessage: "values(record) still loses typing or bypasses downstream validation.",
+        evidence: [
+          ...diagnosticEvidence(typedResult.errors),
+          ...diagnosticEvidence(invalidResult.errors),
+          ...diagnosticEvidence(nestedResult.errors),
+          noteEvidence("Observed nested order field", nestedResult.value?.state.fields["orders"]),
+        ],
+      }),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.STATE_ARG_SELECTION_COVERAGE, "(MEL-SUGAR-4) argmax()/argmin() narrow away null only when eligibility is exhaustively covered"), () => {
+    const coveredResult = adapter.compile(`
+      domain Demo {
+        state {
+          mode: "ship" | "pickup" = "ship"
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["pickup", eq(mode, "pickup"), 100],
+          ["ship", eq(mode, "ship"), 80],
+          "first"
+        )
+
+        computed tier = match(
+          carrier,
+          ["pickup", "pickup"],
+          ["ship", "ship"],
+          "manual"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+    const coveredMinResult = adapter.compile(`
+      domain Demo {
+        state {
+          mode: "ship" | "pickup" = "ship"
+          note: string = ""
+        }
+
+        computed carrier = argmin(
+          ["pickup", eq(mode, "pickup"), 100],
+          ["ship", eq(mode, "ship"), 80],
+          "first"
+        )
+
+        computed tier = match(
+          carrier,
+          ["pickup", "pickup"],
+          ["ship", "ship"],
+          "manual"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+    const uncoveredResult = adapter.compile(`
+      domain Demo {
+        state {
+          flag: boolean = false
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["a", flag, 1],
+          ["b", false, 0],
+          "first"
+        )
+
+        computed tier = match(
+          carrier,
+          ["a", "A"],
+          ["b", "B"],
+          "manual"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+    const literalGapResult = adapter.compile(`
+      domain Demo {
+        state {
+          mode: "ship" | "pickup" | "digital" = "ship"
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["pickup", eq(mode, "pickup"), 100],
+          ["ship", eq(mode, "ship"), 80],
+          "first"
+        )
+
+        computed tier = match(
+          carrier,
+          ["pickup", "pickup"],
+          ["ship", "ship"],
+          "manual"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("MEL-SUGAR-4"), coveredResult.success && coveredMinResult.success && hasDiagnosticCode(uncoveredResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(literalGapResult.errors, "E_TYPE_MISMATCH"), {
+        passMessage: "argmax()/argmin() preserve non-null label typing only when candidate eligibility coverage is statically exhaustive.",
+        failMessage: "argmax()/argmin() nullability narrowing is either too weak for exhaustive coverage or too loose for uncovered cases.",
+        evidence: [
+          ...diagnosticEvidence(coveredResult.errors),
+          ...diagnosticEvidence(coveredMinResult.errors),
+          ...diagnosticEvidence(uncoveredResult.errors),
+          ...diagnosticEvidence(literalGapResult.errors),
+        ],
+      }),
+    ]);
+  });
 });

--- a/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
@@ -471,14 +471,35 @@ describe("CCTS State and Computed Suite", () => {
         )
       }
     `);
+    const invalidResult = adapter.compile(`
+      domain Demo {
+        state {
+          primary: string | null = null
+          secondary: string | null = null
+          chosen: string = ""
+        }
+
+        action copy() {
+          when true {
+            patch chosen = coalesce(primary, secondary)
+          }
+        }
+      }
+    `);
 
     expectAllCompliance([
-      evaluateRule(getRuleOrThrow("COALESCE-1"), numericResult.success && selectorResult.success, {
-        passMessage: "coalesce provides non-null downstream typing for compatible fallback branches.",
-        failMessage: "coalesce still leaks nullable result types into downstream numeric or selector checks.",
+      evaluateRule(
+        getRuleOrThrow("COALESCE-1"),
+        numericResult.success
+          && selectorResult.success
+          && hasDiagnosticCode(invalidResult.errors, "E_TYPE_MISMATCH"),
+        {
+        passMessage: "coalesce narrows only when a non-null fallback is guaranteed and preserves nullable results otherwise.",
+        failMessage: "coalesce still leaks nullable result types into guaranteed fallback paths or over-narrows all-nullable paths.",
         evidence: [
           ...diagnosticEvidence(numericResult.errors),
           ...diagnosticEvidence(selectorResult.errors),
+          ...diagnosticEvidence(invalidResult.errors),
         ],
       }),
     ]);

--- a/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
@@ -685,9 +685,31 @@ describe("CCTS State and Computed Suite", () => {
         }
       }
     `);
+    const nullablePathResult = adapter.compile(`
+      domain Demo {
+        type Selection = { mode: "ship" | "pickup" }
+
+        state {
+          selection: Selection | null = null
+          note: string = ""
+        }
+
+        computed carrier = argmax(
+          ["pickup", eq(selection.mode, "pickup"), 100],
+          ["ship", eq(selection.mode, "ship"), 80],
+          "first"
+        )
+
+        action remember() {
+          when true {
+            patch note = carrier
+          }
+        }
+      }
+    `);
 
     expectAllCompliance([
-      evaluateRule(getRuleOrThrow("MEL-SUGAR-4"), coveredResult.success && coveredMinResult.success && hasDiagnosticCode(uncoveredResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(literalGapResult.errors, "E_TYPE_MISMATCH"), {
+      evaluateRule(getRuleOrThrow("MEL-SUGAR-4"), coveredResult.success && coveredMinResult.success && hasDiagnosticCode(uncoveredResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(literalGapResult.errors, "E_TYPE_MISMATCH") && hasDiagnosticCode(nullablePathResult.errors, "E_TYPE_MISMATCH"), {
         passMessage: "argmax()/argmin() preserve non-null label typing only when candidate eligibility coverage is statically exhaustive.",
         failMessage: "argmax()/argmin() nullability narrowing is either too weak for exhaustive coverage or too loose for uncovered cases.",
         evidence: [
@@ -695,6 +717,7 @@ describe("CCTS State and Computed Suite", () => {
           ...diagnosticEvidence(coveredMinResult.errors),
           ...diagnosticEvidence(uncoveredResult.errors),
           ...diagnosticEvidence(literalGapResult.errors),
+          ...diagnosticEvidence(nullablePathResult.errors),
         ],
       }),
     ]);

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -631,10 +631,7 @@ function inferFunctionCallType(
   }
 
   if (expr.name === "coalesce") {
-    return joinTypeCandidates(
-      expr.args.map((arg) => inferExprType(arg, env, symbols)),
-      expr.location
-    );
+    return inferCoalesceType(expr, env, symbols);
   }
 
   if (expr.name === "match") {
@@ -663,6 +660,10 @@ function inferFunctionCallType(
       elementType: simpleType("string", expr.location),
       location: expr.location,
     };
+  }
+
+  if (expr.name === "values" && expr.args.length >= 1) {
+    return inferValuesType(expr, env, symbols);
   }
 
   return null;
@@ -761,7 +762,572 @@ function inferArgSelectionType(
     return null;
   }
 
+  if (hasExhaustiveArgSelectionCoverage(expr, env, symbols)) {
+    return labelType;
+  }
+
   return joinTypeCandidates([labelType, simpleType("null", expr.location)], expr.location);
+}
+
+const OTHER_STRING = Symbol("arg-selection:other-string");
+const OTHER_NUMBER = Symbol("arg-selection:other-number");
+
+type AbstractPrimitiveValue = string | number | boolean | null | typeof OTHER_STRING | typeof OTHER_NUMBER;
+
+interface EligibilityAtom {
+  key: string;
+  typeExpr: TypeExprNode;
+  comparedLiterals: Array<string | number | boolean | null>;
+}
+
+// Conservatively prove that at least one arg-selection candidate is eligible for every
+// abstract assignment of the boolean/comparable atoms referenced by candidate predicates.
+// If the proof cannot be completed cheaply, we keep the existing nullable result surface.
+function hasExhaustiveArgSelectionCoverage(
+  expr: Extract<ExprNode, { kind: "functionCall" }>,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols
+): boolean {
+  const eligibleExprs: ExprNode[] = [];
+  for (let index = 0; index < expr.args.length - 1; index += 1) {
+    const candidate = expr.args[index];
+    if (candidate.kind !== "arrayLiteral" || candidate.elements.length !== 3) {
+      return false;
+    }
+    eligibleExprs.push(candidate.elements[1]);
+  }
+
+  const atoms = new Map<string, EligibilityAtom>();
+  for (const eligibleExpr of eligibleExprs) {
+    if (!collectEligibilityAtoms(eligibleExpr, env, symbols, atoms)) {
+      return false;
+    }
+  }
+
+  const domains = [...atoms.values()].map((atom) => ({
+    key: atom.key,
+    values: buildEligibilityAtomDomain(atom, symbols),
+  }));
+  if (domains.some((entry) => entry.values === null || entry.values.length === 0)) {
+    return false;
+  }
+
+  let combinationCount = 1;
+  for (const entry of domains) {
+    combinationCount *= entry.values!.length;
+    if (combinationCount > 256) {
+      // Keep compile-time proof bounded; larger domains remain conservatively nullable.
+      return false;
+    }
+  }
+
+  const assignment = new Map<string, AbstractPrimitiveValue>();
+  return enumerateEligibilityAssignments(domains as Array<{ key: string; values: AbstractPrimitiveValue[] }>, 0, assignment, () =>
+    eligibleExprs.some((eligibleExpr) => evaluateEligibilityExpr(eligibleExpr, assignment) === true)
+  );
+}
+
+function enumerateEligibilityAssignments(
+  domains: Array<{ key: string; values: AbstractPrimitiveValue[] }>,
+  index: number,
+  assignment: Map<string, AbstractPrimitiveValue>,
+  predicate: () => boolean
+): boolean {
+  if (index >= domains.length) {
+    return predicate();
+  }
+
+  const domain = domains[index]!;
+  for (const value of domain.values) {
+    assignment.set(domain.key, value);
+    if (!enumerateEligibilityAssignments(domains, index + 1, assignment, predicate)) {
+      assignment.delete(domain.key);
+      return false;
+    }
+  }
+
+  assignment.delete(domain.key);
+  return true;
+}
+
+function collectEligibilityAtoms(
+  expr: ExprNode,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols,
+  atoms: Map<string, EligibilityAtom>
+): boolean {
+  switch (expr.kind) {
+    case "literal":
+      return expr.literalType === "boolean";
+
+    case "identifier":
+    case "iterationVar":
+    case "propertyAccess":
+    case "indexAccess":
+      return registerBooleanEligibilityAtom(expr, env, symbols, atoms);
+
+    case "unary":
+      return expr.operator === "!" && collectEligibilityAtoms(expr.operand, env, symbols, atoms);
+
+    case "binary":
+      if (expr.operator === "&&" || expr.operator === "||") {
+        return collectEligibilityAtoms(expr.left, env, symbols, atoms)
+          && collectEligibilityAtoms(expr.right, env, symbols, atoms);
+      }
+      if (expr.operator === "==" || expr.operator === "!=") {
+        return registerComparisonEligibilityAtoms(expr.left, expr.right, env, symbols, atoms);
+      }
+      return false;
+
+    case "functionCall":
+      switch (expr.name) {
+        case "and":
+        case "or":
+          return expr.args.every((arg) => collectEligibilityAtoms(arg, env, symbols, atoms));
+        case "not":
+          return expr.args.length === 1 && collectEligibilityAtoms(expr.args[0], env, symbols, atoms);
+        case "eq":
+        case "neq":
+          return expr.args.length === 2
+            && registerComparisonEligibilityAtoms(expr.args[0], expr.args[1], env, symbols, atoms);
+        case "isNull":
+        case "isNotNull":
+          return expr.args.length === 1 && registerComparableEligibilityAtom(expr.args[0], env, symbols, atoms, null);
+        default:
+          return false;
+      }
+
+    default:
+      return false;
+  }
+}
+
+function registerBooleanEligibilityAtom(
+  expr: ExprNode,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols,
+  atoms: Map<string, EligibilityAtom>
+): boolean {
+  const key = getEligibilityAtomKey(expr);
+  const typeExpr = inferExprType(expr, env, symbols);
+  if (!key || !typeExpr || !isStrictBooleanType(typeExpr, symbols)) {
+    return false;
+  }
+
+  const existing = atoms.get(key);
+  if (existing) {
+    return true;
+  }
+
+  atoms.set(key, {
+    key,
+    typeExpr,
+    comparedLiterals: [],
+  });
+  return true;
+}
+
+function registerComparisonEligibilityAtoms(
+  left: ExprNode,
+  right: ExprNode,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols,
+  atoms: Map<string, EligibilityAtom>
+): boolean {
+  const leftLiteral = getLiteralPrimitiveValue(left);
+  const rightLiteral = getLiteralPrimitiveValue(right);
+
+  if (leftLiteral !== undefined && rightLiteral !== undefined) {
+    return true;
+  }
+
+  if (rightLiteral !== undefined) {
+    return registerComparableEligibilityAtom(left, env, symbols, atoms, rightLiteral);
+  }
+  if (leftLiteral !== undefined) {
+    return registerComparableEligibilityAtom(right, env, symbols, atoms, leftLiteral);
+  }
+
+  return false;
+}
+
+function registerComparableEligibilityAtom(
+  expr: ExprNode,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols,
+  atoms: Map<string, EligibilityAtom>,
+  comparedLiteral: string | number | boolean | null
+): boolean {
+  const key = getEligibilityAtomKey(expr);
+  const typeExpr = inferExprType(expr, env, symbols);
+  if (!key || !typeExpr || !isPrimitiveComparableType(typeExpr, symbols)) {
+    return false;
+  }
+
+  const existing = atoms.get(key);
+  if (existing) {
+    if (!existing.comparedLiterals.some((candidate) => Object.is(candidate, comparedLiteral))) {
+      existing.comparedLiterals.push(comparedLiteral);
+    }
+    return true;
+  }
+
+  atoms.set(key, {
+    key,
+    typeExpr,
+    comparedLiterals: [comparedLiteral],
+  });
+  return true;
+}
+
+function buildEligibilityAtomDomain(
+  atom: EligibilityAtom,
+  symbols: DomainTypeSymbols
+): AbstractPrimitiveValue[] | null {
+  const values: AbstractPrimitiveValue[] = [];
+  let invalid = false;
+
+  const addValue = (value: AbstractPrimitiveValue) => {
+    if (!values.some((candidate) => Object.is(candidate, value))) {
+      values.push(value);
+    }
+  };
+
+  const visit = (typeExpr: TypeExprNode | null) => {
+    const resolved = resolveType(typeExpr, symbols);
+    if (!resolved || invalid) {
+      invalid = true;
+      return;
+    }
+
+    switch (resolved.kind) {
+      case "literalType":
+        addValue(resolved.value);
+        return;
+
+      case "simpleType":
+        switch (resolved.name) {
+          case "boolean":
+            addValue(true);
+            addValue(false);
+            return;
+          case "string":
+            for (const literal of atom.comparedLiterals) {
+              if (typeof literal === "string") {
+                addValue(literal);
+              }
+            }
+            addValue(OTHER_STRING);
+            return;
+          case "number":
+            for (const literal of atom.comparedLiterals) {
+              if (typeof literal === "number") {
+                addValue(literal);
+              }
+            }
+            addValue(OTHER_NUMBER);
+            return;
+          case "null":
+            addValue(null);
+            return;
+          default:
+            invalid = true;
+            return;
+        }
+
+      case "unionType":
+        for (const member of resolved.types) {
+          visit(member);
+        }
+        return;
+
+      default:
+        invalid = true;
+    }
+  };
+
+  visit(atom.typeExpr);
+  if (invalid || values.length === 0) {
+    return null;
+  }
+
+  return values;
+}
+
+function evaluateEligibilityExpr(
+  expr: ExprNode,
+  assignment: Map<string, AbstractPrimitiveValue>
+): string | number | boolean | null | undefined {
+  switch (expr.kind) {
+    case "literal":
+      return expr.literalType === "null"
+        ? null
+        : typeof expr.value === "string" || typeof expr.value === "number" || typeof expr.value === "boolean"
+        ? expr.value
+        : undefined;
+
+    case "identifier":
+    case "iterationVar":
+    case "propertyAccess":
+    case "indexAccess": {
+      const key = getEligibilityAtomKey(expr);
+      return key ? assignment.get(key) : undefined;
+    }
+
+    case "unary": {
+      const operand = evaluateEligibilityExpr(expr.operand, assignment);
+      return expr.operator === "!" && typeof operand === "boolean" ? !operand : undefined;
+    }
+
+    case "binary": {
+      const left = evaluateEligibilityExpr(expr.left, assignment);
+      const right = evaluateEligibilityExpr(expr.right, assignment);
+      switch (expr.operator) {
+        case "&&":
+          return typeof left === "boolean" && typeof right === "boolean" ? left && right : undefined;
+        case "||":
+          return typeof left === "boolean" && typeof right === "boolean" ? left || right : undefined;
+        case "==":
+          return left !== undefined && right !== undefined ? Object.is(left, right) : undefined;
+        case "!=":
+          return left !== undefined && right !== undefined ? !Object.is(left, right) : undefined;
+        default:
+          return undefined;
+      }
+    }
+
+    case "functionCall":
+      switch (expr.name) {
+        case "and": {
+          const values = expr.args.map((arg) => evaluateEligibilityExpr(arg, assignment));
+          return values.every((value) => typeof value === "boolean")
+            ? (values as boolean[]).every(Boolean)
+            : undefined;
+        }
+        case "or": {
+          const values = expr.args.map((arg) => evaluateEligibilityExpr(arg, assignment));
+          return values.every((value) => typeof value === "boolean")
+            ? (values as boolean[]).some(Boolean)
+            : undefined;
+        }
+        case "not": {
+          const value = expr.args.length === 1 ? evaluateEligibilityExpr(expr.args[0], assignment) : undefined;
+          return typeof value === "boolean" ? !value : undefined;
+        }
+        case "eq":
+        case "neq": {
+          if (expr.args.length !== 2) {
+            return undefined;
+          }
+          const left = evaluateEligibilityExpr(expr.args[0], assignment);
+          const right = evaluateEligibilityExpr(expr.args[1], assignment);
+          if (left === undefined || right === undefined) {
+            return undefined;
+          }
+          return expr.name === "eq" ? Object.is(left, right) : !Object.is(left, right);
+        }
+        case "isNull": {
+          if (expr.args.length !== 1) {
+            return undefined;
+          }
+          const value = evaluateEligibilityExpr(expr.args[0], assignment);
+          return value === undefined ? undefined : value === null;
+        }
+        case "isNotNull": {
+          if (expr.args.length !== 1) {
+            return undefined;
+          }
+          const value = evaluateEligibilityExpr(expr.args[0], assignment);
+          return value === undefined ? undefined : value !== null;
+        }
+        case "cond":
+        case "if": {
+          if (expr.args.length !== 3) {
+            return undefined;
+          }
+          const condition = evaluateEligibilityExpr(expr.args[0], assignment);
+          if (typeof condition !== "boolean") {
+            return undefined;
+          }
+          return evaluateEligibilityExpr(condition ? expr.args[1] : expr.args[2], assignment);
+        }
+        default:
+          return undefined;
+      }
+
+    default:
+      return undefined;
+  }
+}
+
+function getEligibilityAtomKey(expr: ExprNode): string | null {
+  switch (expr.kind) {
+    case "identifier":
+      return `id:${expr.name}`;
+    case "iterationVar":
+      return "$item";
+    case "propertyAccess": {
+      const parent = getEligibilityAtomKey(expr.object);
+      return parent ? `${parent}.${expr.property}` : null;
+    }
+    case "indexAccess": {
+      const parent = getEligibilityAtomKey(expr.object);
+      const index = getLiteralPrimitiveValue(expr.index);
+      return parent && index !== undefined ? `${parent}[${JSON.stringify(index)}]` : null;
+    }
+    default:
+      return null;
+  }
+}
+
+function isStrictBooleanType(typeExpr: TypeExprNode | null, symbols: DomainTypeSymbols): boolean {
+  const resolved = resolveType(typeExpr, symbols);
+  if (!resolved) {
+    return false;
+  }
+
+  switch (resolved.kind) {
+    case "simpleType":
+      return resolved.name === "boolean";
+    case "literalType":
+      return typeof resolved.value === "boolean";
+    case "unionType":
+      return resolved.types.length > 0 && resolved.types.every((member) => isStrictBooleanType(member, symbols));
+    default:
+      return false;
+  }
+}
+
+function isPrimitiveComparableType(typeExpr: TypeExprNode | null, symbols: DomainTypeSymbols): boolean {
+  const resolved = resolveType(typeExpr, symbols);
+  if (!resolved) {
+    return false;
+  }
+
+  switch (resolved.kind) {
+    case "simpleType":
+      return resolved.name === "string"
+        || resolved.name === "number"
+        || resolved.name === "boolean"
+        || resolved.name === "null";
+    case "literalType":
+      return typeof resolved.value === "string"
+        || typeof resolved.value === "number"
+        || typeof resolved.value === "boolean"
+        || resolved.value === null;
+    case "unionType":
+      return resolved.types.length > 0 && resolved.types.every((member) => isPrimitiveComparableType(member, symbols));
+    default:
+      return false;
+  }
+}
+
+function getLiteralPrimitiveValue(expr: ExprNode): string | number | boolean | null | undefined {
+  if (expr.kind !== "literal") {
+    return undefined;
+  }
+  if (expr.literalType === "null") {
+    return null;
+  }
+  return typeof expr.value === "string" || typeof expr.value === "number" || typeof expr.value === "boolean"
+    ? expr.value
+    : undefined;
+}
+
+function inferCoalesceType(
+  expr: Extract<ExprNode, { kind: "functionCall" }>,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols
+): TypeExprNode | null {
+  const argTypes = expr.args.map((arg) => inferExprType(arg, env, symbols));
+  if (argTypes.some((typeExpr) => typeExpr === null)) {
+    return joinTypeCandidates(argTypes, expr.location);
+  }
+
+  const nonNullCandidates = argTypes
+    .map((typeExpr) => stripNullBranches(typeExpr, symbols))
+    .filter((typeExpr): typeExpr is TypeExprNode => typeExpr !== null);
+
+  if (nonNullCandidates.length === 0) {
+    return joinTypeCandidates(argTypes, expr.location);
+  }
+
+  return joinTypeCandidates(nonNullCandidates, expr.location);
+}
+
+function inferValuesType(
+  expr: Extract<ExprNode, { kind: "functionCall" }>,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols
+): TypeExprNode | null {
+  if (expr.args.length < 1) {
+    return null;
+  }
+
+  const elementType = getValuesElementType(inferExprType(expr.args[0], env, symbols), symbols);
+  if (!elementType) {
+    return null;
+  }
+
+  return {
+    kind: "arrayType",
+    elementType,
+    location: expr.location,
+  };
+}
+
+function getValuesElementType(
+  typeExpr: TypeExprNode | null,
+  symbols: DomainTypeSymbols
+): TypeExprNode | null {
+  const resolved = resolveType(typeExpr, symbols);
+  if (!resolved) {
+    return null;
+  }
+
+  if (resolved.kind === "recordType") {
+    return resolved.valueType;
+  }
+
+  if (resolved.kind === "objectType") {
+    return joinTypeCandidates(
+      resolved.fields.map((field) => field.typeExpr),
+      resolved.location
+    );
+  }
+
+  if (resolved.kind === "unionType") {
+    return joinTypeCandidates(
+      resolved.types
+        .filter((member) => !isNullType(member))
+        .map((member) => getValuesElementType(member, symbols)),
+      resolved.location
+    );
+  }
+
+  return null;
+}
+
+function stripNullBranches(
+  typeExpr: TypeExprNode | null,
+  symbols: DomainTypeSymbols
+): TypeExprNode | null {
+  const resolved = resolveType(typeExpr, symbols);
+  if (!resolved || isNullType(resolved)) {
+    return null;
+  }
+
+  if (resolved.kind !== "unionType") {
+    return resolved;
+  }
+
+  const members = resolved.types
+    .map((member) => stripNullBranches(member, symbols))
+    .filter((member): member is TypeExprNode => member !== null);
+  if (members.length === 0) {
+    return null;
+  }
+  return joinTypeCandidates(members, resolved.location);
 }
 
 function literalTypeFromValue(

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -1192,8 +1192,7 @@ function hasNullableEligibilityPath(
         || hasNullableEligibilityPath(expr.object, env, symbols);
 
     case "indexAccess":
-      return canTypeIncludeNull(inferExprType(expr.object, env, symbols), symbols)
-        || hasNullableEligibilityPath(expr.object, env, symbols);
+      return true;
 
     default:
       return false;

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -1252,7 +1252,12 @@ function inferCoalesceType(
     return joinTypeCandidates(argTypes, expr.location);
   }
 
-  return joinTypeCandidates(nonNullCandidates, expr.location);
+  const resultCandidates: Array<TypeExprNode | null> = [...nonNullCandidates];
+  if (argTypes.every((typeExpr) => typeExpr !== null && canTypeIncludeNull(typeExpr, symbols))) {
+    resultCandidates.push(simpleType("null", expr.location));
+  }
+
+  return joinTypeCandidates(resultCandidates, expr.location);
 }
 
 function inferValuesType(
@@ -1328,6 +1333,26 @@ function stripNullBranches(
     return null;
   }
   return joinTypeCandidates(members, resolved.location);
+}
+
+function canTypeIncludeNull(
+  typeExpr: TypeExprNode | null,
+  symbols: DomainTypeSymbols
+): boolean {
+  const resolved = resolveType(typeExpr, symbols);
+  if (!resolved) {
+    return true;
+  }
+
+  if (isNullType(resolved)) {
+    return true;
+  }
+
+  if (resolved.kind !== "unionType") {
+    return false;
+  }
+
+  return resolved.types.some((member) => canTypeIncludeNull(member, symbols));
 }
 
 function literalTypeFromValue(

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -910,7 +910,7 @@ function registerBooleanEligibilityAtom(
 ): boolean {
   const key = getEligibilityAtomKey(expr);
   const typeExpr = inferExprType(expr, env, symbols);
-  if (!key || !typeExpr || !isStrictBooleanType(typeExpr, symbols)) {
+  if (!key || !typeExpr || !isStrictBooleanType(typeExpr, symbols) || hasNullableEligibilityPath(expr, env, symbols)) {
     return false;
   }
 
@@ -960,7 +960,7 @@ function registerComparableEligibilityAtom(
 ): boolean {
   const key = getEligibilityAtomKey(expr);
   const typeExpr = inferExprType(expr, env, symbols);
-  if (!key || !typeExpr || !isPrimitiveComparableType(typeExpr, symbols)) {
+  if (!key || !typeExpr || !isPrimitiveComparableType(typeExpr, symbols) || hasNullableEligibilityPath(expr, env, symbols)) {
     return false;
   }
 
@@ -1177,6 +1177,25 @@ function getEligibilityAtomKey(expr: ExprNode): string | null {
     }
     default:
       return null;
+  }
+}
+
+function hasNullableEligibilityPath(
+  expr: ExprNode,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols
+): boolean {
+  switch (expr.kind) {
+    case "propertyAccess":
+      return canTypeIncludeNull(inferExprType(expr.object, env, symbols), symbols)
+        || hasNullableEligibilityPath(expr.object, env, symbols);
+
+    case "indexAccess":
+      return canTypeIncludeNull(inferExprType(expr.object, env, symbols), symbols)
+        || hasNullableEligibilityPath(expr.object, env, symbols);
+
+    default:
+      return false;
   }
 }
 

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -1188,6 +1188,7 @@ function hasNullableEligibilityPath(
   switch (expr.kind) {
     case "propertyAccess":
       return canTypeIncludeNull(inferExprType(expr.object, env, symbols), symbols)
+        || canPropertyAccessBeMissing(expr.object, expr.property, env, symbols)
         || hasNullableEligibilityPath(expr.object, env, symbols);
 
     case "indexAccess":
@@ -1197,6 +1198,38 @@ function hasNullableEligibilityPath(
     default:
       return false;
   }
+}
+
+function canPropertyAccessBeMissing(
+  objectExpr: ExprNode,
+  property: string,
+  env: TypeEnv,
+  symbols: DomainTypeSymbols
+): boolean {
+  return canPropertyTypeBeMissing(inferExprType(objectExpr, env, symbols), property, symbols);
+}
+
+function canPropertyTypeBeMissing(
+  typeExpr: TypeExprNode | null,
+  property: string,
+  symbols: DomainTypeSymbols
+): boolean {
+  const resolved = resolveType(typeExpr, symbols);
+  if (!resolved) {
+    return true;
+  }
+
+  if (resolved.kind === "objectType") {
+    const field = resolved.fields.find((candidate) => candidate.name === property);
+    return !field || field.optional;
+  }
+
+  if (resolved.kind === "unionType") {
+    const members = resolved.types.filter((member) => !isNullType(member));
+    return members.length === 0 || members.some((member) => canPropertyTypeBeMissing(member, property, symbols));
+  }
+
+  return true;
 }
 
 function isStrictBooleanType(typeExpr: TypeExprNode | null, symbols: DomainTypeSymbols): boolean {

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -1057,7 +1057,7 @@ function buildEligibilityAtomDomain(
 function evaluateEligibilityExpr(
   expr: ExprNode,
   assignment: Map<string, AbstractPrimitiveValue>
-): string | number | boolean | null | undefined {
+): AbstractPrimitiveValue | undefined {
   switch (expr.kind) {
     case "literal":
       return expr.literalType === "null"

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -307,17 +307,29 @@ function stripNullType(typeExpr: TypeExprNode | null, symbols: DomainTypeSymbols
     return resolved;
   }
 
-  const members = resolved.types.filter((member) => !isNullType(member));
+  const members = resolved.types
+    .map((member) => stripNullType(member, symbols))
+    .filter((member): member is TypeExprNode => member !== null);
   if (members.length === 0) {
     return null;
   }
-  if (members.length === 1) {
-    return members[0];
+  const deduped: TypeExprNode[] = [];
+  const seen = new Set<string>();
+  for (const member of members) {
+    const key = JSON.stringify(member);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(member);
+  }
+  if (deduped.length === 1) {
+    return deduped[0];
   }
 
   return {
     kind: "unionType",
-    types: members,
+    types: deduped,
     location: resolved.location,
   };
 }
@@ -351,6 +363,71 @@ function areTypesCompatible(
   }
 
   return null;
+}
+
+function isMergeAssignableType(
+  sourceType: TypeExprNode,
+  targetType: TypeExprNode,
+  symbols: DomainTypeSymbols
+): boolean | null {
+  const resolvedSource = resolveType(sourceType, symbols);
+  const resolvedTarget = resolveType(targetType, symbols);
+  if (!resolvedSource || !resolvedTarget) {
+    return null;
+  }
+
+  if (resolvedTarget.kind === "unionType") {
+    let sawUnknown = false;
+    for (const member of resolvedTarget.types) {
+      if (isNullType(member)) {
+        continue;
+      }
+      const outcome = isMergeAssignableType(resolvedSource, member, symbols);
+      if (outcome === true) {
+        return true;
+      }
+      if (outcome === null) {
+        sawUnknown = true;
+      }
+    }
+    return sawUnknown ? null : false;
+  }
+
+  if (resolvedSource.kind === "unionType") {
+    let sawUnknown = false;
+    for (const member of resolvedSource.types) {
+      const outcome = isMergeAssignableType(member, resolvedTarget, symbols);
+      if (outcome === false) {
+        return false;
+      }
+      if (outcome === null) {
+        sawUnknown = true;
+      }
+    }
+    return sawUnknown ? null : true;
+  }
+
+  if (resolvedTarget.kind !== "objectType") {
+    return false;
+  }
+
+  if (resolvedSource.kind !== "objectType") {
+    return false;
+  }
+
+  for (const sourceField of resolvedSource.fields) {
+    const targetField = resolvedTarget.fields.find((candidate) => candidate.name === sourceField.name);
+    if (!targetField) {
+      return false;
+    }
+
+    const fieldAssignable = isAssignableType(sourceField.typeExpr, targetField.typeExpr, symbols);
+    if (fieldAssignable !== true) {
+      return fieldAssignable;
+    }
+  }
+
+  return true;
 }
 
 function classifyArrayOperand(
@@ -1033,7 +1110,9 @@ export class SemanticValidator {
         return;
       }
 
-      const assignable = isAssignableType(valueType, targetType, this.symbols);
+      const assignable = stmt.op === "merge"
+        ? isMergeAssignableType(valueType, targetType, this.symbols)
+        : isAssignableType(valueType, targetType, this.symbols);
       if (assignable === false) {
         this.error(
           `Patch value for '${renderPath(stmt.path)}' must be assignable to ${describeTypeExpr(targetType, this.symbols)}, got ${describeTypeExpr(valueType, this.symbols)}`,

--- a/packages/compiler/src/generator/ir.ts
+++ b/packages/compiler/src/generator/ir.ts
@@ -641,6 +641,48 @@ function resolveTypeDefinitionWithCtx(
   return resolveTypeDefinitionWithCtx(next, ctx, [...seenRefs, definition.name]);
 }
 
+function isNullTypeDefinition(definition: TypeDefinition | null): boolean {
+  return (definition?.kind === "primitive" && definition.type === "null")
+    || (definition?.kind === "literal" && definition.value === null);
+}
+
+function getSingleNonNullUnionBranch(
+  definition: TypeDefinition,
+  ctx: GeneratorContext,
+): TypeDefinition | null {
+  const resolved = resolveTypeDefinitionWithCtx(definition, ctx);
+  if (!resolved || resolved.kind !== "union") {
+    return null;
+  }
+
+  const nonNullTypes = resolved.types.filter((candidate) => {
+    const next = resolveTypeDefinitionWithCtx(candidate, ctx);
+    return !isNullTypeDefinition(next);
+  });
+
+  return nonNullTypes.length === 1 ? nonNullTypes[0] : null;
+}
+
+function getPatchLiteralValidationTargetType(
+  targetType: TypeDefinition,
+  literalValue: unknown,
+  ctx: GeneratorContext,
+): TypeDefinition {
+  if (literalValue === null || Array.isArray(literalValue) || typeof literalValue !== "object") {
+    return targetType;
+  }
+
+  const nonNullBranch = getSingleNonNullUnionBranch(targetType, ctx);
+  if (!nonNullBranch) {
+    return targetType;
+  }
+
+  const resolvedNonNullBranch = resolveTypeDefinitionWithCtx(nonNullBranch, ctx);
+  return resolvedNonNullBranch?.kind === "object"
+    ? nonNullBranch
+    : targetType;
+}
+
 function describeTypeDefinition(definition: TypeDefinition): string {
   switch (definition.kind) {
     case "primitive":
@@ -1427,19 +1469,12 @@ function generatePatch(stmt: PatchStmtNode, ctx: GeneratorContext): CompilerFlow
               break;
             }
             if (resolved.kind === "union") {
-              const nonNullTypes: TypeDefinition[] = resolved.types.filter((candidate: TypeDefinition) => {
-                const next = resolveTypeDefinitionWithCtx(candidate, ctx);
-                return !(
-                  next?.kind === "primitive" && next.type === "null"
-                ) && !(
-                  next?.kind === "literal" && next.value === null
-                );
-              });
-              if (nonNullTypes.length !== 1) {
+              const nonNullType = getSingleNonNullUnionBranch(targetType, ctx);
+              if (!nonNullType) {
                 targetType = null;
                 break;
               }
-              targetType = nonNullTypes[0];
+              targetType = nonNullType;
               i -= 1;
               continue;
             }
@@ -1462,7 +1497,18 @@ function generatePatch(stmt: PatchStmtNode, ctx: GeneratorContext): CompilerFlow
               const fieldName = stmt.path.segments.map(s =>
                 s.kind === "propertySegment" ? s.name : "[*]"
               ).join(".");
-              validateLiteralAgainstTypeDefinition(literalValue, targetType, fieldName, stmt.location, ctx);
+              const validationTargetType = getPatchLiteralValidationTargetType(
+                targetType,
+                literalValue,
+                ctx,
+              );
+              validateLiteralAgainstTypeDefinition(
+                literalValue,
+                validationTargetType,
+                fieldName,
+                stmt.location,
+                ctx,
+              );
             }
           }
         }


### PR DESCRIPTION
## Summary
- fix nullable object patch literal validation for named and nullable object targets
- fix `patch ... merge` typing so shallow partial-object payloads are accepted and still type-checked
- fix `coalesce(...)` null-elimination inference for downstream numeric and selector typing
- fix typed `values(Record<string, T>)` collection flows so `map(values(record), ...)` stays type-safe in direct and nested assignments
- narrow `argmax()` / `argmin()` away from `null` only when candidate eligibility is statically exhaustive
- strengthen compiler CCTS coverage and regression tests for all of the above

## Why
The compiler had several semantic typing gaps that surfaced under realistic MEL authoring:

- merge patches were validated like full-object `set` assignments
- `coalesce(...)` preserved nested nullable branches in inferred result types
- `values(record)` could lose element typing, allowing false negatives and misleading downstream diagnostics
- `argmax()` / `argmin()` always surfaced a nullable label result even when candidate predicates exhaustively covered all static cases

Together these issues caused valid domains such as `CommerceFulfillmentEngine` to fail compilation despite matching the current MEL contract.

## Impact
- valid MEL domains now compile without requiring defensive rewrites around merge, coalesce, record-value mapping, or exhaustive arg-selection patterns
- the compiler remains conservative when static proof cannot be completed
- compliance coverage is stronger and the matrix now tracks the newly enforced semantics explicitly

## Validation
- `pnpm --filter @manifesto-ai/compiler exec vitest run`
- `node --import tsx --input-type=module` compile check for the `CommerceFulfillmentEngine` repro
