### PR TITLE
feat(compiler): add MEL object spread sugar

### DIFF
--- a/docs/api/compiler.md
+++ b/docs/api/compiler.md
@@ -8,7 +8,7 @@
 
 `@manifesto-ai/compiler` provides the MEL compilation seams used by runtime creation, tooling, and bundler integration.
 
-The current canonical compiler contract is documented in the [current SPEC index](../internals/spec/index.md), with the compiler pinned to `SPEC-v1.1.0`.
+The current canonical compiler contract is documented in the [current SPEC index](../internals/spec/index.md), with the compiler pinned to `SPEC-v1.2.0`.
 
 Current compiler responsibilities include:
 - schema-only compilation through `compileMelDomain()`
@@ -18,6 +18,12 @@ Current compiler responsibilities include:
 - declaration-level source locations as an out-of-schema `SourceMapIndex` sidecar
 - intent-level dispatchability via `dispatchable when`
 - MEL patch lowering through `compileMelPatch()`
+
+Current MEL v1.2 compiler highlights include:
+- object-literal spread as the sole bounded parser-level shorthand
+- canonical lowering of spread through `merge(...)`
+- presence-aware object typing shared by spread and direct `merge()`
+- optional spread-result reads observed as `T | null`, requiring explicit normalization before non-null sinks
 
 ## Main Entry Points
 

--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -236,8 +236,10 @@ _Source: `packages/compiler/src/index.ts`_
 - `MelSystemPath`
 - `MelTypeExpr`
 - `MelTypeField`
+- `ObjectLiteralEntryNode`
 - `ObjectLiteralExprNode`
 - `ObjectPropertyNode`
+- `ObjectSpreadNode`
 - `ObjectTypeNode`
 - `OnceIntentStmtNode`
 - `OnceStmtNode`

--- a/docs/guide/essentials/effects.md
+++ b/docs/guide/essentials/effects.md
@@ -74,7 +74,7 @@ action completeTodo(id: string) {
   onceIntent {
     effect array.map({
       source: todos,
-      select: if(eq($item.id, id), merge($item, { completed: true }), $item),
+      select: eq($item.id, id) ? { ...$item, completed: true } : $item,
       into: todos
     })
   }

--- a/docs/internals/adr/002-dx-improvement-mel-namespace-onceIntent.md
+++ b/docs/internals/adr/002-dx-improvement-mel-namespace-onceIntent.md
@@ -10,7 +10,7 @@
 - **Date:** 2026-01-27
 - **Status:** Implemented
 - **Implemented-by:**
-  - [Compiler current contract (SPEC-v1.1.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)
+  - [Compiler current contract (SPEC-v1.2.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md)
   - historical SDK v1.0.0 contract (removed from the working tree; see Git history)
   - `packages/compiler/src/parser/parser.ts`, `packages/compiler/src/api/compile-mel-patch-collector.ts`, `packages/compiler/src/__tests__/once-intent.test.ts`, `packages/sdk/src/create-manifesto.ts`
 - **Owners:** 정성우

--- a/docs/internals/adr/009-structured-patch-path.md
+++ b/docs/internals/adr/009-structured-patch-path.md
@@ -6,7 +6,7 @@
 > **Scope:** Core, Compiler, Host, Runtime, World
 > **Resolves:** [#108](https://github.com/manifesto-ai/core/issues/108), [#189](https://github.com/manifesto-ai/core/issues/189)
 > **Supersedes:** None
-> **Implemented-by:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler current contract (SPEC-v1.1.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md), [host-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC.md), and concrete code in `packages/core/src/schema/patch.ts`, `packages/core/src/core/apply.ts`, `packages/compiler/src/lowering/lower-runtime-patch.ts`, plus historical pre-split world/store code paths
+> **Implemented-by:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler current contract (SPEC-v1.2.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md), [host-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC.md), and concrete code in `packages/core/src/schema/patch.ts`, `packages/core/src/core/apply.ts`, `packages/compiler/src/lowering/lower-runtime-patch.ts`, plus historical pre-split world/store code paths
 > **Strengthens:** FDR-015 (Static Patch Paths), FDR-MEL-032 (Dynamic Path Segments)
 > **Breaking:** Yes — Major version bump required for Core, Compiler
 

--- a/docs/internals/adr/012-remove-computed-prefix.md
+++ b/docs/internals/adr/012-remove-computed-prefix.md
@@ -5,7 +5,7 @@
 > **Deciders:** Manifesto Core/Compiler Design Group
 > **Scope:** Core, Compiler, Host, SDK, Docs
 > **Breaking:** Yes
-> **Implemented-by:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler current contract (SPEC-v1.1.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md), and concrete code in `packages/core/src/evaluator/expr.ts`, `packages/core/src/core/explain.ts`
+> **Implemented-by:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [Compiler current contract (SPEC-v1.2.0)](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md), and concrete code in `packages/core/src/evaluator/expr.ts`, `packages/core/src/core/explain.ts`
 > **Related:** ADR-001 (Layer Separation), ADR-006 (Canonical rules), ADR-009 (Structured PatchPath), ADR-011 (Boundary contract)
 > **Reason for change:** Developer Ergonomics / API consistency
 

--- a/docs/internals/adr/013a-mel-statement-composition-flow-and-include.md
+++ b/docs/internals/adr/013a-mel-statement-composition-flow-and-include.md
@@ -9,7 +9,7 @@
 > **Related:** ADR-013b (Entity Collection Primitives — separate approval gate)
 > **Supersedes:** ADR-013 (Withdrawn — mixed three independent decisions)
 > **Breaking:** No — additive syntax via contextual keywords; runtime layers unchanged
-> **Implemented In:** Compiler current contract ([SPEC-v1.1.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)), `packages/compiler/src/analyzer/flow-composition.ts`, analyzer/generator/integration/compliance test suites
+> **Implemented In:** Compiler current contract ([SPEC-v1.2.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md)), `packages/compiler/src/analyzer/flow-composition.ts`, analyzer/generator/integration/compliance test suites
 
 ---
 

--- a/docs/internals/adr/013b-entity-collection-primitives.md
+++ b/docs/internals/adr/013b-entity-collection-primitives.md
@@ -10,7 +10,7 @@
 > **Supersedes:** ADR-013 (Withdrawn — mixed three independent decisions)
 > **Breaking:** No — additive builtin functions only; existing syntax unaffected; Core IR unchanged; runtime layers unchanged
 > **Internal Structure:** §4 Query Primitives (013b-1) and §5 Transform Primitives (013b-2) have **separate acceptance criteria** and may be approved independently.
-> **Implemented In:** Compiler current contract ([SPEC-v1.1.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)), entity primitive lowering/analyzer paths, generator/integration/compliance test suites
+> **Implemented In:** Compiler current contract ([SPEC-v1.2.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md)), entity primitive lowering/analyzer paths, generator/integration/compliance test suites
 
 ---
 

--- a/docs/internals/adr/020-intent-level-dispatchability.md
+++ b/docs/internals/adr/020-intent-level-dispatchability.md
@@ -5,7 +5,7 @@
 > **Deciders:** 정성우 (Architect), Manifesto Architecture Team
 > **Scope:** Compiler, Core, SDK, Studio/Introspection, Docs
 > **Related ADRs:** ADR-017 (Capability Decorator Pattern), ADR-018 (Public Snapshot Boundary)
-> **Related SPECs:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), [SPEC-v1.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)
+> **Related SPECs:** [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), [SPEC-v1.2.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md)
 
 > **Current Contract Authority:** This ADR is implemented. The current behavior now lives in the owning package specs and current MEL docs. This document remains the architectural decision record and original design rationale.
 

--- a/docs/internals/adr/023-object-spread-sugar-in-mel.md
+++ b/docs/internals/adr/023-object-spread-sugar-in-mel.md
@@ -1,0 +1,663 @@
+# ADR-023: Object Spread Sugar in MEL
+
+> **Status:** Accepted
+> **Date:** 2026-04-23
+> **Deciders:** Manifesto Architecture Team
+> **Scope:** `@manifesto-ai/compiler` (MEL surface form)
+> **Affected Packages:** `@manifesto-ai/compiler` (MEL parser, type checker, lowering)
+> **Current Normative Source:** Compiler SPEC v1.2.0 §5, MEL Reference §5.7, MEL LLM Context
+> **Supersedes:** None
+> **Breaking:** No runtime/Core breaking — additive syntax only. Compiler type inference for existing `merge()` calls MAY be tightened where current behavior was unsound around nullable or presence-aware object operands. No change to `DomainSchema` hash, `SchemaGraph`, Core IR, runtime semantics, or any existing non-typing contract.
+
+This ADR is the accepted decision record for object-literal spread in MEL. The current normative wording now lives in `packages/compiler/docs/SPEC-v1.2.0.md` and the maintained MEL docs. Parser, lowering, analyzer, and compiler compliance coverage landed on 2026-04-23; this ADR now remains as rationale and acceptance history.
+
+---
+
+## Review History
+
+| Round | Reviewer | Finding | Resolution Version |
+|-------|----------|---------|-------------------|
+| 1 | Independent (GPT) | (a) patch-form Core IR equivalence overreach; (b) nullable vs optional conflation; (c) empty object grammar breakage | v2 |
+| 2 | Independent (GPT) | Conditional contributor model incomplete (reverse direction / fallback-before-nullable-spread) | v3 |
+| 3 | Independent (GPT) | Operand-level contributor classification breaks compositional closure; incompatible union unhandled | v4 |
+| 4 | Independent (GPT) | Optional field consumption rule undefined; `merge()` type inference consistency implicit | v5 |
+| 4 (minor) | Independent (GPT) | Breaking clause precision (type inference tightening on existing `merge()`) | v5 (header) |
+| 5 | Independent (GPT) | **GO** for ADR acceptance and SPEC patch planning, conditional on §7.8 Implementation Cost Validation gate | v5 |
+
+---
+
+## Revision History
+
+### v5 (2026-04-23) — Round 4 Review Fixes + Minor Header Precision
+
+- §4.5 Presence-Aware Field Consumption (SPREAD-CONSUME-1 through -5): optional field read → `T | null` at boundary, aligned with MEL's `at()`/`first()`/`last()` idiom; preserves optional ≠ nullable distinction in the type system, converges only at read boundary
+- §4.6 `merge()` Type Inference Extension (SPREAD-MERGE-TYPE-1): explicit consistency between direct `merge(presence-aware, ...)` and spread-form lowering
+- Cases J, K, L, M added to §7.4 for consumption and merge-form parity guards
+- Open Question 9 dissolved into §4.5 (normative); narrower Open Question 10 added for diagnostic quality
+- Header `Breaking` clause clarified to note possible compiler type-inference tightening for existing `merge()` call sites that had unsound nullable-operand behavior
+
+### v4 (2026-04-23) — Round 3 Review Fixes
+
+Field-level contributor classification (operand-level was insufficient for compositional closure); union normalization rules (SPREAD-PRES-UNION-1/2); Cases F/G/H/I added.
+
+### v3 (2026-04-23) — Round 2 Review Fixes
+
+Presence-aware contributor model for nullable spread (SPREAD-PRES framework); object-only union closure (SPREAD-OP-5); Case D added.
+
+### v2 (2026-04-23) — Round 1 Review Fixes
+
+Patch-layer equivalence scoping (v1 falsely claimed byte-identical Core IR between `patch = spread` and `patch merge`); nullable-vs-optional distinction per MEL §3.3; empty-object grammar `{}` restored.
+
+### v1 (2026-04-23) — Initial Draft
+
+Original proposal. Superseded.
+
+---
+
+## 1. Context
+
+### 1.1 The Problem
+
+Manifesto domains require composing objects with field overrides as a first-class authoring pattern. The canonical expressions are `merge()` at the expression layer and `patch path merge expr` at the patch layer:
+
+```mel
+computed enriched = merge(item, { status: "active", ts: $meta.timestamp })
+
+effect array.map({
+  source: items,
+  select: merge($item, { processed: true, source: "api" }),
+  into: result
+})
+
+patch draft merge {
+  submissionState: "submitted"
+}
+```
+
+These forms are semantically sufficient. They are not sufficient for authoring comfort, per evidence in §1.2.
+
+### 1.2 Evidence
+
+**Manifesto designer (self-authored).** Repeated reports that `merge(...)` bracket nesting creates a reading and writing barrier.
+
+Stimulus:
+
+```mel
+type CheckoutDraft = {
+  customerId: string,
+  appliedCouponId: string | null,
+  submissionState: "idle" | "ready" | "submitted"
+}
+
+// Sanctioned form:
+patch draft merge {
+  submissionState: "submitted"
+}
+
+// Hand-reached-for form:
+patch draft = {
+  ...draft,
+  submissionState: "submitted"
+}
+```
+
+**Agent collaborators (independent evidence).** Multiple LLM collaborator sessions have independently flagged the same friction point.
+
+Triangulation: both channels independently indicate real friction, not a single-channel artifact.
+
+### 1.3 The Constraint
+
+Manifesto's architecture enforces strict surface boundaries:
+
+- MEL is not Turing-complete (structural property)
+- MEL is **not a subset of JavaScript** — declines JS features deliberately
+- Harness principle: safety through structural impossibility, not behavioral prohibition
+
+This ADR proposes a bounded, named exception with explicit defense against generalization.
+
+### 1.4 Contract Position at Proposal Time
+
+Compiler SPEC v1.1.0 §5.1:
+
+> Only ordinary function-call forms are part of this contract. No new arm syntax, named arguments, or parser-only shorthand is implied here.
+
+Object spread is **parser-only shorthand**. This ADR explicitly amends §5.1 to admit object-literal spread as the sole parser-level surface extension.
+
+### 1.5 Prior Withdrawal Lineage (ADR-005)
+
+| Ground | ADR-005 | ADR-023 |
+|---|---|---|
+| §6.1 Zero String Paths | Violated | N/A |
+| §2 Priority 8 (Simplicity) | Overhead exceeded alternative | Pure `merge()` equivalence; no new IR |
+| Alternative exists | Yes, deployed | Yes (`merge()`), insufficient per evidence |
+| Motivation | Future v3 coordinates | Current triangulated friction |
+| §8.2 | "Future requirements not specified" | Present, documented, reproducible |
+
+---
+
+## 2. Decision
+
+### 2.1 Grammar Admission
+
+```ebnf
+ObjectLiteral ::= "{" [ ObjectEntry ( "," ObjectEntry )* ","? ] "}"
+
+ObjectEntry   ::= NamedField
+               | SpreadEntry
+
+NamedField    ::= Identifier ":" Expression
+SpreadEntry   ::= "..." Expression
+```
+
+The outer bracket `[ ... ]` preserves empty-object parsing (`{}`).
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-1 | MUST | Accept `"..." Expression` as valid `ObjectEntry` inside object literals |
+| SPREAD-2 | MUST | Spread entries MAY appear at any position |
+| SPREAD-3 | MUST | An object literal MAY contain multiple spread entries, or zero entries (`{}`) |
+| SPREAD-4 | MUST NOT | Spread MUST NOT be admitted outside object literal expressions |
+| SPREAD-5 | MUST | Spread entry AST MUST be structurally distinct from named-field entries |
+
+### 2.2 Operand Shape
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-OP-1 | MUST | Each spread operand's static type MUST resolve to an object-shaped type or `T \| null` where `T` is object-shaped |
+| SPREAD-OP-2 | MUST | `Record<string, T>` operands MUST be rejected in v1 |
+| SPREAD-OP-3 | MUST | Primitive, array, or union-including-non-object-non-null-branch types MUST be rejected |
+| SPREAD-OP-4 | MUST | `T \| null` (object-shaped `T`) operands MUST be accepted under SPREAD-PRES rules (§4.2) |
+| SPREAD-OP-5 | MUST NOT | Object-only union operands MUST NOT be admitted in v1. Only `T \| null` is admissible |
+
+### 2.3 Same-Key Conflict Resolution
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-KEY-1 | MUST | When multiple entries contribute the same key, source-order determines contributor precedence |
+| SPREAD-KEY-2 | MUST | Named fields and spread entries compete on source order alone |
+| SPREAD-KEY-3 | MUST | Simple last-wins type narrowing applies only to unconditional **field contributors** (per §4.2). Conditional field contributors follow SPREAD-PRES |
+
+---
+
+## 3. Lowering
+
+### 3.1 Expression-Level Lowering
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-LOWER-1 | MUST | Lower object-spread literals (as expressions) to `merge()` expressions with argument order preserved |
+| SPREAD-LOWER-2 | MUST | Consecutive named-field entries between spread entries MUST group into a single object-literal argument |
+| SPREAD-LOWER-3 | MUST | Lowered Core Runtime IR MUST use existing expression kinds only |
+| SPREAD-LOWER-4 | MUST | No new `ExprNode` kind is introduced |
+
+Canonical lowering:
+
+```
+{ f1: v1, ...a, f2: v2, f3: v3, ...b, f4: v4 }
+  ↓
+merge({ f1: v1 }, a, { f2: v2, f3: v3 }, b, { f4: v4 })
+```
+
+### 3.2 Patch-Layer Behavior
+
+**Spread is an expression-level sugar.** When used as `patch path = expr` RHS, the statement is a `set` patch whose value is the lowered `merge()`. **Distinct** from `patch path merge expr`.
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-PATCH-LOWER-1 | MUST | `patch path = <object-spread>` MUST lower to `set` patch with lowered `merge(...)` value |
+| SPREAD-PATCH-LOWER-2 | MUST | `patch path merge expr` preserved unchanged; no patch-layer grammar change |
+| SPREAD-PATCH-LOWER-3 | MUST | `set` and `merge` are distinct patch operations and MAY differ at edge cases (Open Question 5) |
+
+### 3.3 Semantic Equivalence Requirement
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-EQ-1 | MUST | Spread-involving **expression** IR MUST be byte-identical to canonical `merge()` rewrite's expression IR |
+| SPREAD-EQ-2 | MUST | `compute()` output MUST be byte-identical for contexts admitting both forms |
+| SPREAD-EQ-3 | MUST NOT | MUST NOT claim equivalence between `patch path = <spread>` and `patch path merge <object>` |
+
+---
+
+## 4. Type System Impact
+
+### 4.1 Presence-Tracking Object Type
+
+Each field in a presence-tracking object type carries:
+
+- `type` — value type
+- `presence` — one of `{required, optional}`
+
+Orthogonal to nullability. Valid combinations: `required: T`, `required: T | null`, `optional: T`, `optional: T | null`.
+
+**Closure property.** Presence propagates across spread composition (see §4.2) and consumption (see §4.5). N-level chained spreads preserve presence soundness by induction.
+
+**Implementation note.** This ADR assumes compiler `TypeDefinition` supports both type and presence flag on object fields. Phase 2 MUST verify against `@manifesto-ai/compiler` source.
+
+### 4.2 Field-Level Contributor Classification and Presence-Aware Typing
+
+Contributor classification is **per-field**, not per-operand.
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-PRES-1 | MUST | Spread-involving literal result type MUST be computed as presence-tracking object type |
+| SPREAD-PRES-2 | MUST | **Field-level classification:** **(a)** Named field → unconditional. **(b)** Non-nullable operand: required field → unconditional; optional field → conditional. **(c)** `T \| null` operand: every field of `T` → conditional, regardless of declared presence inside `T` |
+| SPREAD-PRES-3 | MUST | **Unconditional contributor effect:** overwrites prior state; result becomes `{presence: required, type: <declared type>}` |
+| SPREAD-PRES-4 | MUST | **Conditional contributor effect:** combines with prior state: **(a)** no prior → `{optional, <declared type>}`; **(b)** prior optional (type `T_prev`) → `{optional, T_prev ∪ <declared type>}`; **(c)** prior required (type `T_prev`) → `{required, T_prev ∪ <declared type>}`. Union per SPREAD-PRES-UNION |
+| SPREAD-PRES-5 | MUST | Optional fields MUST NOT satisfy required fields of assignment target; compiler MUST require explicit unconditional contribution |
+| SPREAD-PRES-6 | MAY | Implementations MAY warn when optional field is never promoted to required |
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-PRES-UNION-1 | MUST | Normalize value-type unions using existing MEL type-unification rules (e.g., literal-subtype absorption, nullable absorption) |
+| SPREAD-PRES-UNION-2 | MUST | Reject spread expression with diagnostic if resulting union cannot be represented in MEL's current type system |
+
+### 4.3 Record Spread Deferred
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-REC-1 | MUST NOT | `Record<string, T>` operands MUST be rejected in v1 |
+
+### 4.4 Patch RHS Assignability
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-PATCH-1 | MUST | `patch path = <object-spread>` undergoes standard assignability check |
+| SPREAD-PATCH-2 | MUST | Fields not declared on target MUST be rejected at compile time |
+| SPREAD-PATCH-3 | MUST NOT | MUST NOT silently drop extra fields at runtime |
+| SPREAD-PATCH-4 | MUST | Optional fields MUST NOT satisfy required fields on target |
+| SPREAD-PATCH-5 | MUST | Existing `patch path merge expr` form remains unchanged |
+
+### 4.5 Presence-Aware Field Consumption
+
+Presence information, once introduced by spread, MUST have a defined observation rule wherever a presence-aware object is consumed.
+
+MEL's existing absence-observation idiom (`at(arr, i) → T | null`, `first(arr) → T | null`, `last(arr) → T | null`, `coalesce()` for explicit normalization) is the pattern this ADR aligns with: **absence is observed as `null` at the read boundary, and explicit normalization is the author's responsibility when a required `T` is needed.**
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-CONSUME-1 | MUST | Presence-aware object types MAY flow into computed expressions, action bodies, effect arguments, and other expression contexts |
+| SPREAD-CONSUME-2 | MUST | **Direct field access on an optional field MUST have value type `T \| null`**, where `T` is the field's present-value type. An absent optional field is observed as `null` at the expression read boundary |
+| SPREAD-CONSUME-3 | MUST | A value read from an optional field MUST NOT satisfy a non-null required argument or target type unless explicitly normalized (`coalesce(...)`, a later unconditional object contribution, or a structural override) |
+| SPREAD-CONSUME-4 | MUST | Spread re-use and dot access MUST agree on presence: if spreading preserves a field as optional (per SPREAD-PRES-2), dot access MUST also treat it as optional |
+| SPREAD-CONSUME-5 | MUST | If the current Core expression evaluator cannot faithfully observe missing object fields as `null` at runtime, direct optional-field access MUST be rejected at compile time in v1 with a diagnostic directing the author toward `coalesce()` or explicit normalization. Phase 2 MUST verify Core behavior before relaxing |
+
+**Rationale for SPREAD-CONSUME-2 direction.** MEL already treats "absence" as observable `null` in collection and record access. Optional-field dot access aligns with this idiom. Banning dot access on optional fields would make spread results effectively dead-end for consumption, undermining the proposal's motivation.
+
+**Important distinction — optional vs nullable.** SPREAD-CONSUME-2 does not collapse the optional/nullable distinction. The distinction is preserved in the **type system** (assignability, contributor classification, patch target checking) and merges only at the **read boundary** (field value observation):
+
+- Optional field `customerId?: string` cannot satisfy a target field declared `customerId: string` (SPREAD-PRES-5, SPREAD-CONSUME-3)
+- But reading `partialDraft.customerId` produces `string | null`, flowing into expression contexts as any other nullable value would
+
+This two-layer model — orthogonal in types, convergent at reads — keeps presence-aware typing sound without requiring new operators for the nullable-vs-optional distinction.
+
+**Illustration:**
+
+```mel
+// draft: Draft | null
+computed partialDraft = { ...draft }
+
+computed maybeCustomerId = partialDraft.customerId
+// maybeCustomerId: string | null (SPREAD-CONSUME-2)
+
+computed label = concat("customer=", partialDraft.customerId)
+// COMPILE ERROR: concat arg requires string, got string | null (SPREAD-CONSUME-3)
+
+computed label = concat("customer=", coalesce(partialDraft.customerId, "unknown"))
+// OK: explicit normalization
+```
+
+### 4.6 `merge()` Type Inference Extension
+
+Since spread lowers to `merge()` (SPREAD-LOWER-1) and spread inputs may be presence-aware (§4.2), `merge()` type inference MUST recognize presence on inputs consistently, whether called via spread sugar or directly.
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-MERGE-TYPE-1 | MUST | `merge()` type inference MUST handle presence-aware input types per SPREAD-PRES-2/3/4 rules. A direct call `merge(partialDraft, { x: 1 })` MUST produce a result type identical to the lowered form of `{ ...partialDraft, x: 1 }` |
+
+Rationale. Without SPREAD-MERGE-TYPE-1, `{ ...partialDraft }` and its lowered `merge(partialDraft)` could produce different result types, violating SPREAD-EQ-1. This rule makes the implication explicit.
+
+**Non-goal.** Runtime semantics of `merge()` are unchanged: non-object arguments skipped, later keys override. Extension is purely at the type-inference layer.
+
+**Compatibility note.** Per the `Breaking` clause, this type-inference tightening MAY cause existing `merge()` call sites that previously compiled to emit new diagnostics where their nullable-operand handling was unsound. This is a soundness improvement, not a semantic change; affected sites were already producing runtime-surprising values and are now caught at compile time.
+
+---
+
+## 5. Identity and Boundary Preservation
+
+### 5.1 Amendment to "Not a Subset of JavaScript"
+
+The following MUST be incorporated into `docs/mel/LLM-CONTEXT.md`:
+
+> **MEL is not a subset of JavaScript.** Object-literal spread is admitted exclusively as an authoring-ergonomics sugar that lowers to `merge()`. All other JavaScript syntactic forms — array spread, rest destructuring, computed keys, optional chaining, method call syntax, template literals, truthiness coercion — remain unsupported.
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SPREAD-BDRY-1 | MUST | `LLM-CONTEXT.md` and MEL reference docs MUST carry the amendment text |
+| SPREAD-BDRY-2 | MUST | This ADR's admission MUST NOT be cited as precedent for other JS syntactic forms |
+| SPREAD-BDRY-3 | MUST | Compiler MUST emit specific diagnostics for forbidden adjacent forms referencing this ADR's scope boundary |
+
+### 5.2 Patch Layer Untouched
+
+Existing forms preserved: `patch path = expr`, `patch path merge expr`, `patch path unset`, `patch path[key] = expr`, `patch path[key] unset`. The two forms `patch draft = { ...draft, x: v }` and `patch draft merge { x: v }` may be runtime-equivalent under narrow conditions but are not guaranteed byte-identical Core IR.
+
+### 5.3 Harness Surface Accounting
+
+Object-spread admission expands syntactic surface only; action surface is untouched. Presence-aware typing expands the type system surface (§4.1); consumption boundary (§4.5) closes this expansion against silent unsoundness. Agents may continue generating `merge()` forms with identical expression IR.
+
+---
+
+## 6. Considered and Resolved
+
+### 6.1–6.5 (v1) — Unchanged
+
+Identity, contract amendment, ADR-005 precedent, slope risk, harness surface accounting.
+
+### 6.6–6.8 (v2) — Unchanged
+
+Patch IR overreach, nullable-vs-optional conflation, empty-object grammar.
+
+### 6.9–6.10 (v3) — Unchanged
+
+Conditional contributor modeling gap, object-only union closure.
+
+### 6.11–6.12 (v4) — Unchanged
+
+Operand-level classification breaking compositional closure (resolved by field-level classification), value-type union representability.
+
+### 6.13 (v5) — Consumption Boundary Gap
+
+**Concern.** v4 introduced optional presence via SPREAD-PRES but deferred the read-side observation rule to Open Question 9 ("follow-up if unexpected behavior"). This incorrectly categorized consumption rules as peripheral: optional presence is a type-system concept that immediately affects every context where spread results are consumed.
+
+**Resolution.** v5 adds §4.5 defining SPREAD-CONSUME-1 through SPREAD-CONSUME-5. Optional read → `T | null` aligns with MEL's existing "absence as null" idiom. Type-system distinction between optional and nullable is preserved; convergence only at the read boundary.
+
+### 6.14 (v5) — `merge()` Type Inference Consistency
+
+**Concern.** SPREAD-LOWER-1 lowers `{ ...partialDraft }` to `merge(partialDraft)`. Without extending `merge()` type inference to presence-aware inputs, the lowered form could produce a different result type than the spread form, violating SPREAD-EQ-1.
+
+**Resolution.** v5 adds SPREAD-MERGE-TYPE-1 making the extension explicit. Runtime semantics of `merge()` unchanged. Header `Breaking` clause updated to note possible type-inference tightening for existing call sites.
+
+---
+
+## 7. Acceptance Criteria
+
+Implementation landed on 2026-04-23. This checklist is preserved as closure evidence; checked items reflect the current implemented/compiler-covered state.
+
+### 7.1 Semantic Equivalence (Expression Layer Only)
+
+- [x] Spread-involving expression IR byte-identical to canonical `merge()` rewrite
+- [x] `compute()` output byte-identical for contexts admitting both forms
+- [x] Acceptance suite MUST NOT claim byte-identical Core IR between `patch p = <spread>` and `patch p merge <expr>`
+- [x] No new `ExprNode` kind in Core IR
+
+### 7.2 Grammar and Parsing
+
+- [x] `ObjectEntry` admits both named-field and spread forms
+- [x] Empty `{}` parses correctly
+- [x] Spread entries at leading, trailing, interleaved positions parse
+- [x] Multiple spread entries within a single literal parse
+- [x] Array spread, rest, computed keys each rejected with diagnostic
+
+### 7.3 Type System
+
+- [x] SPREAD-PRES-2 field-level classification (a)(b)(c) all covered
+- [x] SPREAD-PRES-3 unconditional effect
+- [x] SPREAD-PRES-4 conditional effect (a)(b)(c) all covered
+- [x] SPREAD-PRES-5 optional cannot satisfy required target
+- [x] SPREAD-PRES-UNION-1/2 union normalization and rejection
+- [x] SPREAD-CONSUME-2 optional field read → `T | null`
+- [x] SPREAD-CONSUME-3 normalization required for non-null target
+- [x] SPREAD-MERGE-TYPE-1 direct `merge()` with presence-aware input equals spread form
+- [x] `Record<string, T>` rejected
+- [x] Multi-branch object union `A | B` rejected
+- [x] Primitive/array/non-object-union rejected
+
+### 7.4 Patch Integration and Consumption — Mandated Test Cases
+
+Test setup:
+
+```mel
+type Draft = {
+  customerId: string,
+  appliedCouponId: string | null,
+  submissionState: "idle" | "ready" | "submitted"
+}
+
+state { draft: Draft | null = null }
+```
+
+**Case A (negative) — nullable spread alone cannot satisfy required target:**
+
+```mel
+action bad() {
+  onceIntent {
+    patch draft = { ...draft, submissionState: "submitted" }
+    // EXPECTED: compile error
+  }
+}
+```
+
+**Case B (positive) — explicit override after nullable spread:**
+
+```mel
+action goodAfter(customerId: string) {
+  onceIntent {
+    patch draft = {
+      ...draft,
+      customerId: customerId,
+      appliedCouponId: null,
+      submissionState: "submitted"
+    }
+  }
+}
+```
+
+**Case C (positive) — non-nullable base, spread alone sufficient:**
+
+```mel
+type Order = { orderId: string, status: "pending" | "shipped" }
+state { order: Order = { orderId: "o1", status: "pending" } }
+
+action updateOrder() {
+  onceIntent {
+    patch order = { ...order, status: "shipped" }
+  }
+}
+```
+
+**Case D (positive) — required fallback before nullable spread:**
+
+```mel
+action goodBefore(customerId: string) {
+  onceIntent {
+    patch draft = {
+      customerId: customerId,
+      appliedCouponId: null,
+      ...draft,
+      submissionState: "submitted"
+    }
+  }
+}
+```
+
+**Case E (computed regression) — defaults-then-override:**
+
+```mel
+type UserPrefs = { theme: string, locale: string }
+state { prefs: UserPrefs | null = null }
+
+computed effectiveConfig = {
+  theme: "light",
+  locale: "en",
+  ...prefs
+}
+// EXPECTED: both fields required, types normalized
+```
+
+**Case F — optional preserved through re-spread:**
+
+```mel
+computed partialDraft = { ...draft }
+computed copiedDraft = { ...partialDraft }
+// EXPECTED: all optional preserved
+```
+
+**Case G (negative) — optional from non-null re-spread cannot satisfy required target:**
+
+```mel
+computed partialDraft = { ...draft }
+
+action badCopy() {
+  onceIntent {
+    patch draft = { ...partialDraft }
+    // EXPECTED: compile error
+  }
+}
+```
+
+**Case H (positive) — fallback before optional-field spread preserves required:**
+
+```mel
+computed partialDraft = { ...draft }
+
+action goodCopy(customerId: string) {
+  onceIntent {
+    patch draft = {
+      customerId: customerId,
+      appliedCouponId: null,
+      submissionState: "idle",
+      ...partialDraft
+    }
+  }
+}
+```
+
+**Case I (negative) — incompatible union rejected:**
+
+```mel
+type Weird = { amount: string }
+state { weird: Weird | null = null }
+
+computed x = { amount: 0, ...weird }
+// EXPECTED: compile error
+```
+
+**Case J — optional field read becomes nullable value:**
+
+```mel
+computed partialDraft = { ...draft }
+computed maybeCustomerId = partialDraft.customerId
+// EXPECTED: maybeCustomerId : string | null
+```
+
+**Case K (negative) — optional field value cannot satisfy required without normalization:**
+
+```mel
+type CustomerRef = { customerId: string }
+state { ref: CustomerRef | null = null }
+
+computed partialDraft = { ...draft }
+
+action badRef() {
+  onceIntent {
+    patch ref = { customerId: partialDraft.customerId }
+    // EXPECTED: compile error
+  }
+}
+```
+
+**Case L (positive) — explicit normalization succeeds:**
+
+```mel
+action goodRef() {
+  onceIntent {
+    patch ref = {
+      customerId: coalesce(partialDraft.customerId, "unknown")
+    }
+  }
+}
+```
+
+**Case M — direct `merge()` with presence-aware input matches spread form:**
+
+```mel
+computed partialDraft = { ...draft }
+
+computed viaSpread = { ...partialDraft, submissionState: "submitted" }
+computed viaMerge  = merge(partialDraft, { submissionState: "submitted" })
+
+// EXPECTED: byte-identical result types and expression IR
+```
+
+### 7.5 Evidence Preservation
+
+- [ ] §1.2 MUST cite at least one designer-authored scenario and one agent-collaborator feedback instance
+- [ ] §6 (including v2, v3, v4, v5 additions 6.6–6.14) MUST be preserved intact
+
+### 7.6 Documentation
+
+- [x] `docs/mel/LLM-CONTEXT.md` amended per §5.1
+- [x] `docs/mel/REFERENCE.md` §5.7 adds spread sugar section with patch-layer distinction note and consumption-rule reference
+- [x] `docs/mel/SYNTAX.md` updated with object-literal grammar
+- [x] `docs/mel/ERROR-GUIDE.md` adds entries for SPREAD-BDRY-3, SPREAD-PRES-5, SPREAD-PRES-UNION-2, SPREAD-OP-5, SPREAD-CONSUME-3, SPREAD-CONSUME-5 diagnostics
+
+### 7.7 Non-Regression
+
+- [ ] All existing MEL test fixtures compile unchanged **except** where v5 Breaking note applies (existing `merge()` calls with previously-unsound nullable-operand handling MAY emit new diagnostics; each such case MUST be reviewed as a soundness fix, not a regression)
+- [x] Empty object literal usage unchanged
+- [x] CCTS extended with spread coverage while preserving existing rule modes
+- [x] Existing `merge()` test coverage passes under unchanged runtime semantics
+
+### 7.8 Implementation Cost Validation (Historical Gate, Closed)
+
+The pre-implementation gate is now closed. The implementation validated the Core/runtime assumptions that mattered for landing:
+
+- Core expression evaluation already observed missing object fields as `null`, so optional spread-result reads could remain admitted as `T | null`.
+- Unary `merge()` lowering proved viable, so `{ ...a }` could lower directly through `merge(a)` without extra empty-object scaffolding.
+- Presence-aware typing landed in the compiler analyzer/CCTS layer without changing the public `DomainSchema` / `TypeDefinition` wire contract.
+- The implementation stayed inside compiler/docs/CCTS scope; no Core IR or runtime contract expansion was required.
+
+---
+
+## 8. Open Questions
+
+1. **Record spread admission timing.** Entry criteria: `record.*` effects insufficient for use case, plus value-type-preserving typing model.
+
+2. **Multi-branch object union spread admission timing.** Entry criteria: concrete authoring pattern plus per-branch presence model.
+
+3. **`self` keyword consideration.** `patch draft = { ...draft, x: v }` restates target. Declined; may revisit with post-adoption evidence.
+
+4. **Array spread status.** Explicit resolution of "permanently out of scope" vs. "not currently proposed" prevents ambiguity.
+
+5. **Patch `set`-with-`merge()` vs patch `merge` operation edge cases.** Core SPEC should document divergence surface.
+
+6. **Optional field diagnostic presentation.** Phase 2 decision for author-actionable form.
+
+7. **Tooling normalization.** Studio, linter, formatter display-form choices out of scope.
+
+8. **Agent generation parity.** Post-adoption measurement.
+
+9. ~~Presence-aware typing propagation beyond spread.~~ **Resolved in v5 §4.5.**
+
+10. **Optional-field diagnostic precision in SPREAD-CONSUME-3 errors.** Distinguish spread-consumption errors from plain `T | null` argument errors (coalesce hint vs isNotNull branching hint). Phase 2.
+
+11. **Co-occurring presence propagation beyond this ADR.** If presence-aware typing is adopted elsewhere (action parameter defaults, partial update patterns), these rules SHOULD be the foundation. Unification opportunity.
+
+---
+
+## 9. References
+
+- Compiler SPEC v1.1.0 §5 (Pure Collection Builtins), §5.1 (Additional Explicit MEL Surface Forms)
+- MEL Reference §3.3 (Nullable as Present-or-Null), §5.7 (Object functions, `merge()` semantics)
+- MEL Reference §5.5 (`coalesce`, `isNull`, `isNotNull`), §5.6 (`at` — absence-as-null idiom) — convergence points for SPREAD-CONSUME
+- ADR-005 (Withdrawn) — lineage contrast §1.5
+- ADR-013b — precedent for surface extension
+- ADR-021 — precedent for bounded addition
+- ADR-022a — source map implications
+- `docs/mel/LLM-CONTEXT.md` — amendment target per §5.1
+- Core SPEC — `merge()` expression semantics, `set`/`merge`/`unset` patch operations (Open Question 5 target)
+- Manifesto Constitution §6.1 (Zero String Paths), §2 Priority 8 (Simplicity), §8.2 (Valid Refactoring Motivation)
+- Manifesto Design Principle — "Separation by evidence, not by speculation"
+
+---
+
+*End of ADR-023*

--- a/docs/internals/adr/index.md
+++ b/docs/internals/adr/index.md
@@ -53,6 +53,7 @@ These ADRs affect multiple packages across the monorepo:
 | [ADR-020](./020-intent-level-dispatchability) | Intent-Level Dispatchability — `dispatchable when` Clause | Implemented | 2026-04-07 | Compiler, Core, SDK, Studio/Introspection, Docs |
 | [ADR-021](./021-mel-structural-annotation-system-meta-sidecar) | MEL Structural Annotation System — `@meta` Sidecar | Accepted | 2026-04-15 | Compiler, Tooling, Docs |
 | [ADR-022](./022-compiler-owned-source-location-sidecar-source-map-index) | Compiler-Owned Source Location Sidecar (`SourceMapIndex`) | Accepted | 2026-04-16 | Compiler, Tooling, Docs |
+| [ADR-023](./023-object-spread-sugar-in-mel) | Object Spread Sugar in MEL | Accepted | 2026-04-23 | Compiler, Docs |
 
 ### ADR-006 Companion Evidence (Non-Normative)
 
@@ -97,7 +98,7 @@ These ADRs affect multiple packages across the monorepo:
 
 - There is no standalone `ADR-013` file in the repository.
 - The original mixed ADR-013 draft was withdrawn and split into `ADR-013a` (`flow`/`include`) and `ADR-013b` (entity collection primitives).
-- Both split tracks are now implemented in the compiler current contract, reflected in [SPEC-v1.1.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md), and covered by the compiler compliance suites.
+- Both split tracks are now implemented in the compiler current contract, reflected in [SPEC-v1.2.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md), and covered by the compiler compliance suites.
 
 ### ADR-014 Companion Notes
 
@@ -128,7 +129,7 @@ These ADRs affect multiple packages across the monorepo:
 ### ADR-020 Companion Notes
 
 - ADR-020 is implemented in the current compiler, core, and SDK contracts.
-- The current behavior now lives in [SPEC-v1.1.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md), [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), and the maintained MEL docs.
+- The current behavior now lives in [SPEC-v1.2.0](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md), [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md), [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md), and the maintained MEL docs.
 - This ADR remains the architectural rationale for `dispatchable when`; the owning package specs define the current runtime and compiler behavior.
 
 ### ADR-021 Companion Notes

--- a/docs/internals/spec/current-contract.md
+++ b/docs/internals/spec/current-contract.md
@@ -1,7 +1,7 @@
 # Current Contract
 
 > **Status:** Living Document
-> **Last Updated:** 2026-04-16
+> **Last Updated:** 2026-04-23
 > **Purpose:** Single-source current contract for external consumers, canonical-doc exports, and current-surface onboarding
 
 This document is the current-only contract summary for the active Manifesto workspace.
@@ -38,7 +38,7 @@ This is the canonical entry story for new integrations.
 | `@manifesto-ai/core` | [core-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/core/docs/core-SPEC.md) (current through v4.2.0) | Pure semantic runtime, schema validation, patch/apply semantics |
 | `@manifesto-ai/host` | [host-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/host/docs/host-SPEC.md) (current through v4.0.0) | Effect execution, compute loop orchestration, canonical snapshot substrate |
 | `@manifesto-ai/sdk` | [sdk-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/sdk-SPEC.md) (current v3.x surface) | Activation-first application surface, intent creation/dispatch, additive base write reports, simulation, projected introspection |
-| `@manifesto-ai/compiler` | [SPEC-v1.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md) | Full current MEL compiler contract |
+| `@manifesto-ai/compiler` | [SPEC-v1.2.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md) | Full current MEL compiler contract |
 | `@manifesto-ai/lineage` | [lineage-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/lineage/docs/lineage-SPEC.md) (current v3.x decorator surface) | Seal-aware continuity, additive lineage write reports, canonical snapshot persistence, restore |
 | `@manifesto-ai/governance` | [governance-SPEC.md](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/governance-SPEC.md) (current v3.x decorator surface) | Proposal legitimacy, governed runtime gate over lineage-composed manifesto, settlement observation and settlement reports |
 
@@ -104,7 +104,7 @@ Current extension seam:
 
 `@manifesto-ai/compiler` is now described by one current full contract:
 
-- [SPEC-v1.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)
+- [SPEC-v1.2.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md)
 
 Current MEL/compiler highlights:
 
@@ -117,6 +117,9 @@ Current MEL/compiler highlights:
 - The compiler preserves precise type information through `TypeDefinition`.
 - `state.fields` / `action.input` remain compatibility surfaces.
 - `state.fieldTypes` / `action.inputType` / `action.params` are the authoritative emitted typing seams for current consumers.
+- object-literal spread is the sole bounded parser-level shorthand in current MEL
+- spread results and direct `merge()` now share a presence-aware object typing model
+- optional fields introduced through spread are observed as `T | null` at the read boundary and require explicit normalization for non-null sinks
 
 Current expression support includes:
 
@@ -135,6 +138,7 @@ Current bounded sugar support includes:
 - `match(key, [k, v], ..., default)` in parser-free function form
 - `argmax([label, eligible, score], ..., "first" | "last")`
 - `argmin([label, eligible, score], ..., "first" | "last")`
+- `{ ...obj, key: value }` object-literal spread, lowered through canonical `merge(...)`
 
 Current schema-position support includes:
 

--- a/docs/internals/spec/index.md
+++ b/docs/internals/spec/index.md
@@ -7,7 +7,7 @@ If you need a single current-surface document without version-history context, s
 :::
 
 ::: tip Single Source of Truth
-Specifications are maintained in canonical package docs with version indexes. The current hard-cut surface is: `@manifesto-ai/core` v4.2.0, `@manifesto-ai/host` v4.0.0, `@manifesto-ai/sdk` v3.5.0 activation-first plus `sdk/extensions`, and `@manifesto-ai/compiler` v1.1.0 as the rolled-up MEL compiler contract, with `@manifesto-ai/lineage` / `@manifesto-ai/governance` as the governed decorator packages. Draft package work that is not yet implemented is listed separately below.
+Specifications are maintained in canonical package docs with version indexes. The current hard-cut surface is: `@manifesto-ai/core` v4.2.0, `@manifesto-ai/host` v4.0.0, `@manifesto-ai/sdk` v3.5.0 activation-first plus `sdk/extensions`, and `@manifesto-ai/compiler` v1.2.0 as the rolled-up MEL compiler contract, with `@manifesto-ai/lineage` / `@manifesto-ai/governance` as the governed decorator packages. Draft package work that is not yet implemented is listed separately below.
 :::
 
 If you want the governing documentation rules, see [Documentation Governance](../documentation-governance.md).
@@ -39,7 +39,7 @@ If an older ADR conflicts with a current package SPEC on runtime surface details
 | **@manifesto-ai/governance** | [Living Document](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/governance-SPEC.md) (v3.x surface) | Normative (decorator legitimacy package + additive `waitForProposal()` settlement observer + additive `waitForProposalWithReport()` settlement-report helper) | [VERSION-INDEX](https://github.com/manifesto-ai/core/blob/main/packages/governance/docs/VERSION-INDEX.md) |
 | **@manifesto-ai/runtime** | Retired | Superseded (ADR-010, no successor) — package removed from workspace | — |
 | **App facade (retired)** | Removed (R2) | Historical reference only | [Retired Page](/internals/retired/app) |
-| **@manifesto-ai/compiler** | [SPEC-v1.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md) | Normative full MEL compiler contract | [VERSION-INDEX](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/VERSION-INDEX.md) |
+| **@manifesto-ai/compiler** | [SPEC-v1.2.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md) | Normative full MEL compiler contract | [VERSION-INDEX](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/VERSION-INDEX.md) |
 
 > **Current Governed Direction:** `createManifesto() -> withLineage() -> withGovernance() -> activate()`
 
@@ -94,9 +94,9 @@ The `@manifesto-ai/runtime` package is **retired**. Its responsibilities are abs
 
 ### Compiler (MEL)
 
-- **Compiler SPEC v1.1.0** (Current Full)
-  - [SPEC-v1.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.1.0.md)
-  - Rolls up `SchemaGraph`, `dispatchable when`, `TypeDefinition`-backed schema-position lowering, and pure collection builtins into the current MEL compiler contract
+- **Compiler SPEC v1.2.0** (Current Full)
+  - [SPEC-v1.2.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md)
+  - Rolls up `SchemaGraph`, `dispatchable when`, `TypeDefinition`-backed schema-position lowering, pure collection builtins, and object-literal spread with presence-aware object typing into the current MEL compiler contract
 
 ---
 
@@ -120,6 +120,7 @@ The `@manifesto-ai/runtime` package is **retired**. Its responsibilities are abs
 
 | Date | Package | Version | Change |
 |------|---------|---------|--------|
+| 04-23 | Compiler | v1.2.0 | Current full compiler spec admits object-literal spread as bounded source sugar and defines presence-aware object typing / direct `merge()` parity |
 | 04-08 | Compiler | v1.1.0 | Current full compiler spec rolls up v0.7.0 + addenda and lands `TypeDefinition`-backed nullable/record schema-position lowering plus expression-level collection builtins |
 | 04-08 | Core | v4.2.0 | Living Core spec now treats `state.fieldTypes` / `action.inputType` as the normative runtime typing seam while keeping `FieldSpec` as the compatibility surface |
 | 04-07 | Core | v4.1.0 | Living Core spec adds `ActionSpec.dispatchable` and the pure `isIntentDispatchable()` query without changing `available` semantics |

--- a/docs/mel/ERROR-GUIDE.md
+++ b/docs/mel/ERROR-GUIDE.md
@@ -477,6 +477,94 @@ when eq(len(taskIds), 0) { ... }         // Check key count
 
 ---
 
+### Error: Invalid spread operand
+
+```mel
+// ❌ BROKEN
+computed badArray = { ...items }
+computed badRecord = { ...tasks }
+computed badNumber = { ...count }
+```
+
+**Error:** `SemanticError: Object spread operands must be object-shaped or T | null where T is object-shaped.`
+
+**Rule violated:** Current MEL admits object-literal spread only for object operands. Arrays, records, primitives, and unsupported object-only unions are outside the current contract.
+
+```mel
+// ✅ FIXED: Spread only objects, or stay in canonical merge()/patch forms
+computed fullProfile = { ...profile, status: "active" }
+
+action markDone(id: string) {
+  when true {
+    patch tasks[id] merge { done: true }
+  }
+}
+```
+
+---
+
+### Error: Nullable or optional spread result used as required target
+
+```mel
+// ❌ BROKEN
+type Draft = {
+  customerId: string,
+  appliedCouponId: string | null,
+  submissionState: "idle" | "submitted"
+}
+
+state { draft: Draft | null = null }
+
+action bad(customerId: string) {
+  onceIntent {
+    patch draft = {
+      ...draft,
+      submissionState: "submitted"
+    }
+  }
+}
+```
+
+**Error:** `SemanticError: Optional spread contributors cannot satisfy required target fields without an unconditional contribution.`
+
+**Rule violated:** If a field comes only from a nullable spread operand or optional source field, it remains optional until later contributed unconditionally.
+
+```mel
+// ✅ FIXED: Contribute required fields explicitly
+action good(customerId: string) {
+  onceIntent {
+    patch draft = {
+      ...draft,
+      customerId: customerId,
+      appliedCouponId: null,
+      submissionState: "submitted"
+    }
+  }
+}
+```
+
+---
+
+### Error: Optional spread-result field used without normalization
+
+```mel
+// ❌ BROKEN
+computed partialDraft = { ...draft }
+computed label = concat("customer=", partialDraft.customerId)
+```
+
+**Error:** `SemanticError: Optional spread-result field reads behave as T | null and must be normalized before a non-null sink.`
+
+**Rule violated:** Optional fields introduced by spread are observed as nullable at the read boundary.
+
+```mel
+// ✅ FIXED: Normalize explicitly
+computed partialDraft = { ...draft }
+computed label = concat("customer=", coalesce(partialDraft.customerId, "unknown"))
+```
+
+---
+
 ### Error: Method call
 
 ```mel
@@ -869,6 +957,28 @@ action processAll() {
     })
   }
 }
+```
+
+---
+
+### Error: Adjacent JavaScript forms around object spread
+
+```mel
+// ❌ BROKEN
+computed copy = [...items]
+computed keyed = { [name]: value }
+computed maybeName = profile?.name
+```
+
+**Error:** `SyntaxError: Object spread is the only bounded JavaScript-like sugar admitted in current MEL.`
+
+**Rule violated:** MEL admits object-literal spread only. Array spread, computed keys, rest patterns, and optional chaining remain unsupported.
+
+```mel
+// ✅ FIXED: Stay inside current MEL surface
+computed copied = append([], at(items, 0), at(items, 1))
+computed explicit = { name: value }
+computed safeName = coalesce(profile.name, "unknown")
 ```
 
 ---

--- a/docs/mel/LLM-CONTEXT.md
+++ b/docs/mel/LLM-CONTEXT.md
@@ -14,6 +14,10 @@ MEL (Manifesto Expression Language) is a **declarative domain language** for def
 - Turing-complete
 - A subset of JavaScript
 
+> **MEL is not a subset of JavaScript.** Object-literal spread is admitted exclusively as an authoring-ergonomics sugar that lowers to `merge()`. Array spread, rest destructuring, computed keys, optional chaining, method-call syntax, template literals, and truthiness coercion remain unsupported.
+>
+> **Compatibility note:** If you need code that also compiles on older pre-v1.2 compiler branches, prefer `merge(...)` and `patch path merge expr` as the fallback forms. On current v1.2 compilers, object-literal spread is part of the normal surface.
+
 **MEL expresses:**
 - Facts (computed)
 - Conditions (when, available when)
@@ -56,6 +60,9 @@ MEL (Manifesto Expression Language) is a **declarative domain language** for def
 8. `argmax()` / `argmin()` only accept inline `[label, eligible, score]` candidates plus a literal `"first"` or `"last"` tie-break
 9. `absDiff`, `clamp`, `idiv`, and `streak` are lowering-only sugar over existing arithmetic and conditional builtins
 10. Complex object types in state must be named (`type X = { ... }`)
+11. Object-literal spread `{ ...obj, key: value }` is the sole parser-level shorthand in current MEL
+12. Spread operands must be object-shaped or `T | null`; arrays, records, computed keys, rest patterns, and object-only multi-branch unions are not part of the current contract
+13. Optional fields produced by spread or spread-equivalent `merge()` reads are observed as `T | null` and usually require `coalesce(...)` before a non-null sink
 
 ---
 
@@ -151,13 +158,15 @@ computed bestKind = argmax(
 )
 
 // Object functions
-computed withDefaults = merge(config, { theme: "light" })  // Shallow merge (later wins)
+computed withDefaults = { theme: "light", ...config }      // Spread-first composition
+computed effectiveConfig = { theme: "light", locale: "en", ...userPrefs }
+computed mergedConfig = merge(defaults, config)             // Direct merge() still available
 computed taskIds = keys(tasks)                              // Object keys
 computed taskList = values(tasks)                           // Object values
 computed taskPairs = entries(tasks)                         // Key-value pairs
 ```
 
-> **`merge()` vs `patch merge`:** `merge(a, b)` is a pure expression returning a new object. `patch path merge expr` is a state operation. They are different constructs.
+> **`merge()` vs `patch merge` vs spread-set:** `merge(a, b)` is a pure expression returning a new object. `patch path merge expr` is a patch operation. `patch path = { ...obj, key: value }` is still a set patch whose value lowers through `merge(...)`.
 
 **Forbidden in computed:**
 ```mel
@@ -175,6 +184,11 @@ computed label = match(status, "open" => "Open", _ => "Unknown")
 
 // ❌ Runtime-array argmax/argmin forms are not supported
 computed best = argmax(candidates, "first")
+
+// ❌ Adjacent JS forms remain unsupported
+computed copy = [...items]
+computed keyed = { [name]: value }
+computed maybeName = profile?.name
 ```
 
 ---
@@ -262,6 +276,14 @@ patch tasks[id] unset
 
 // Shallow merge
 patch settings merge { theme: "dark" }
+
+// Set patch with object spread sugar
+patch draft = {
+  ...draft,
+  customerId: customerId,
+  appliedCouponId: null,
+  submissionState: "submitted"
+}
 ```
 
 ---
@@ -483,16 +505,16 @@ action loadData() {
 }
 ```
 
-### Merge to Enrich/Override Fields
+### Object Composition to Enrich/Override Fields
 
 ```mel
-// In computed — combine with defaults
-computed enriched = merge(item, { status: "active", source: "api" })
+// In computed — spread-first override
+computed enriched = { ...item, status: "active", source: "api" }
 
 // In map — override fields without enumerating all
 effect array.map({
   source: items,
-  select: merge($item, { processed: true }),
+  select: { ...$item, processed: true },
   into: processedItems
 })
 ```

--- a/docs/mel/REFERENCE.md
+++ b/docs/mel/REFERENCE.md
@@ -2,7 +2,7 @@
 
 > **Purpose:** The single document a user reads to learn and use MEL. Covers every function, construct, and pattern with examples.
 > **Audience:** Developers writing MEL domains. Both beginners and experienced users.
-> **Normative sources:** SPEC-v1.1.0.md (current full compiler contract), validator.ts (function signatures), lower-expr.ts (supported functions).
+> **Normative sources:** SPEC-v1.2.0.md (current full compiler contract), validator.ts (function signatures), lower-expr.ts (supported functions).
 
 ---
 
@@ -51,6 +51,10 @@ MEL source -> @manifesto-ai/compiler -> DomainSchema -> Core -> Host
 MEL is a **source format**. It does not execute. It produces data that Core computes on.
 
 The builtin meanings documented in this reference are the current MEL surface. If the compiler later admits extra source-level sugar, it must do so explicitly and lower through the existing MEL → Core boundary without silently changing the meaning of the builtins documented here.
+
+Current bounded exception: object-literal spread is part of the current MEL surface, but only inside object literals and only as a sugar that lowers through `merge(...)`.
+
+Compatibility note: if you still need code that compiles on older pre-v1.2 compiler branches, keep using `merge(...)` and `patch path merge expr`. Current v1.2 compilers accept object-literal spread directly.
 
 ### What MEL is NOT
 
@@ -339,8 +343,8 @@ computed taskIds = keys(tasks)
 computed taskList = values(tasks)
 computed taskPairs = entries(tasks)
 
-// Merge with defaults
-computed withDefaults = merge(config, { theme: "light", lang: "en" })
+// Object composition
+computed withDefaults = { theme: "light", lang: "en", ...config }
 ```
 
 ### Forbidden Computed Patterns
@@ -461,7 +465,7 @@ computed inRange = and(gte(value, min), lte(value, max))
 | `and(a, b, ...)` | `(...boolean) → boolean` | Logical AND. All arguments must be boolean. Variadic. |
 | `or(a, b, ...)` | `(...boolean) → boolean` | Logical OR. All arguments must be boolean. Variadic. |
 | `not(a)` | `boolean → boolean` | Logical NOT. |
-| `cond(c, t, e)` | `(boolean, T, T) → T` | Conditional. Returns `t` if `c` is true, otherwise `e`. Alias: `if`. |
+| `cond(c, t, e)` | `(boolean, T, T) → T` | Conditional. Returns `t` if `c` is true, otherwise `e`. |
 | `match(key, [k, v], ..., default)` | Function-form only | Finite branch sugar. Each arm is an inline `[key, value]` pair and the last argument is the default value. |
 | `argmax([label, eligible, score], ..., tieBreak)` | Function-form only | Deterministic fixed-candidate max selection. `tieBreak` must be `"first"` or `"last"`. Returns `null` if no candidate is eligible. |
 | `argmin([label, eligible, score], ..., tieBreak)` | Function-form only | Deterministic fixed-candidate min selection. `tieBreak` must be `"first"` or `"last"`. Returns `null` if no candidate is eligible. |
@@ -646,37 +650,83 @@ computed allMembers = flat(teamMemberArrays)
 | `values(obj)` | `Object → Array<unknown>` | Object values in key order. Returns `[]` for null or non-objects. |
 | `entries(obj)` | `Object → Array<[string, unknown]>` | Key-value pairs in key order. Returns `[]` for null or non-objects. |
 
+**Object spread (current surface):**
+
+```mel
+computed effectiveConfig = {
+  theme: "light",
+  locale: "en",
+  ...userPrefs
+}
+
+computed shippedOrder = { ...order, status: "shipped" }
+
+action submitDraft(customerId: string) {
+  onceIntent {
+    patch draft = {
+      ...draft,
+      customerId: customerId,
+      appliedCouponId: null,
+      submissionState: "submitted"
+    }
+  }
+}
+```
+
+Current rules:
+
+- Object-literal spread `{ ...expr, key: value }` is the sole parser-level shorthand admitted in MEL.
+- It is valid only inside object literals.
+- It lowers to canonical `merge(...)` with source order preserved.
+- Array spread, rest destructuring, computed keys, and optional chaining are not part of MEL.
+- Spread operands must be object-shaped or `T | null` where `T` is object-shaped.
+- `Record<string, T>`, arrays, primitives, and object-only multi-branch unions are not valid spread operands in the current contract.
+
 **Examples:**
 
 ```mel
-// Merge with defaults (later wins)
-computed withDefaults = merge(defaults, config)
-computed withOverride = merge(config, { theme: "light" })
-computed fullProfile = merge(base, userPrefs, { lastSeen: $meta.timestamp })
+// Spread-first object composition (later contributors win)
+computed withDefaults = { theme: "light", locale: "en", ...defaults }
+computed withOverride = { ...config, theme: "light" }
+computed fullProfile = { ...base, ...userPrefs, lastSeen: $meta.timestamp }
+
+// Direct merge() remains available and follows the same typing rules
+computed mergedSettings = merge(defaults, config)
 
 // Decompose objects
 computed taskIds = keys(tasks)
 computed taskList = values(tasks)
 computed taskPairs = entries(tasks)
 
-// In actions: update a field without enumerating all fields
-action markDone(id: string) {
-  when isNotNull(at(tasks, id)) {
-    patch tasks[id] = merge(at(tasks, id), { done: true })
+// Patch-layer merge remains distinct from spread sugar
+action updateTheme() {
+  when true {
+    patch settings merge { theme: "light" }
   }
 }
 ```
 
-> **`merge()` expression vs `patch merge` operation — these are different constructs.**
+> **`merge()` expression vs `patch merge` operation vs `patch = { ...spread }` — these are different constructs.**
 >
 > | Construct | Level | What it does |
 > |-----------|-------|-------------|
 > | `merge(a, b)` | Expression | Returns a new merged object. Pure, does not modify state. |
+> | `patch path = { ...expr, key: value }` | Set patch | Computes a new object value, then replaces state at `path`. |
 > | `patch path merge expr` | Patch operation | Shallow-merges `expr` into existing state at `path`. |
 >
-> Both perform shallow merge. `merge()` computes a value; `patch merge` changes state.
+> All three preserve shallow-merge semantics, but they are not the same operation. `merge()` computes a value, `patch = { ...spread }` is still a `set`, and `patch merge` changes state by patch operation.
 
-> **`field(obj, "prop")` is compiler-internal.** You do not call `field()` directly. When you write `at(tasks, id).title`, the compiler generates `field(at(tasks, id), "title")` automatically. See §5.6.
+> **Presence-aware typing applies to spread and direct `merge()`.** If a field comes only from a nullable spread operand or an optional source field, it remains optional in the result until a later unconditional contributor makes it required.
+
+```mel
+computed partialDraft = { ...draft }
+computed maybeCustomerId = partialDraft.customerId
+computed label = concat("customer=", coalesce(partialDraft.customerId, "unknown"))
+```
+
+> Reads from optional spread-result fields are observed as `T | null`. Normalize explicitly with `coalesce(...)` or provide a later unconditional object contribution before using the value in a non-null sink.
+
+> **`field(obj, "prop")` is compiler-internal.** You do not call `field()` directly. When you write `at(tasks, id).title`, the compiler generates `field(at(tasks, id), "title")` automatically. Missing fields are observed as `null`, which is why optional spread-result reads behave as `T | null`.
 
 ---
 
@@ -1823,4 +1873,4 @@ domain Toggles {
 
 ---
 
-*Authoritative sources: SPEC-v1.1.0.md, packages/compiler/src/analyzer/validator.ts, packages/compiler/src/lowering/lower-expr.ts.*
+*Authoritative sources: SPEC-v1.2.0.md, packages/compiler/src/analyzer/validator.ts, packages/compiler/src/lowering/lower-expr.ts.*

--- a/docs/mel/SYNTAX.md
+++ b/docs/mel/SYNTAX.md
@@ -213,25 +213,47 @@ computed display = eq(status, "loading") ? "Please wait..." : result
 Object expression functions operate on objects and return new values — they do NOT modify state.
 
 ```mel
-// Merge: combine objects (later wins)
-computed withDefaults = merge(config, { theme: "light", lang: "en" })
-computed fullProfile = merge(baseProfile, userOverrides, { lastSeen: $meta.timestamp })
+// Spread-first composition (later contributors win)
+computed withDefaults = { theme: "light", lang: "en", ...config }
+computed fullProfile = { ...baseProfile, ...userOverrides, lastSeen: $meta.timestamp }
 
 // Decompose objects
 computed taskIds = keys(tasks)
 computed taskList = values(tasks)
 computed taskPairs = entries(tasks)
 
-// Key use case: merge inside map to override fields without enumerating all
-// Without merge — must list EVERY field:
+// Key use case: override fields without enumerating all
+// Without object composition — must list EVERY field:
 //   effect array.map({ source: items, select: { id: $item.id, name: $item.name, ... }, into: result })
-// With merge — only specify overrides:
+// With spread — only specify overrides:
 effect array.map({
   source: items,
-  select: merge($item, { status: "active" }),
+  select: { ...$item, status: "active" },
   into: processedItems
 })
 ```
+
+Object spread is also part of the current MEL surface, but only inside object literals:
+
+```mel
+computed effectiveConfig = {
+  theme: "light",
+  locale: "en",
+  ...userPrefs
+}
+
+computed shippedOrder = { ...order, status: "shipped" }
+```
+
+Compatibility note: keep using `merge(...)` and `patch path merge expr` only when you need syntax that compiles across older pre-v1.2 compiler branches.
+
+Rules:
+- `{ ...expr, key: value }` is the sole parser-level shorthand admitted in MEL.
+- It lowers through `merge(...)`; it does not add a new runtime IR kind.
+- It is only valid inside object literals.
+- Array spread, rest destructuring, computed keys, and optional chaining are not part of MEL.
+- Spread operands must be object-shaped or `T | null` where `T` is object-shaped.
+- Direct reads from optional spread-result fields behave like nullable values and usually need `coalesce(...)` before a non-null sink.
 
 ### Aggregation Functions
 
@@ -460,9 +482,17 @@ patch tasks[completedId] unset
 // Merge: Shallow merge into state at path
 patch user merge { name: "Bob" }
 patch settings merge $input.partialSettings
+
+// Set patch with object spread sugar
+patch draft = {
+  ...draft,
+  customerId: customerId,
+  appliedCouponId: null,
+  submissionState: "submitted"
+}
 ```
 
-> **`patch merge` vs `merge()` expression:** `patch path merge expr` is a flow-level state operation that shallow-merges into state at `path`. `merge(a, b)` is a pure expression function that returns a new merged object without modifying state. See [Object Functions](#object-functions) below.
+> **`patch merge` vs `merge()` expression vs `patch = { ...spread }`:** `patch path merge expr` is a flow-level state operation that shallow-merges into state at `path`. `merge(a, b)` is a pure expression function that returns a new merged object. `patch path = { ...spread }` is still a set patch whose value is the lowered `merge(...)`. See [Object Functions](#object-functions) above.
 
 ### System Values
 
@@ -862,6 +892,8 @@ action process() {
 | `keys(obj)` | `Object → Array<string>` | Object keys |
 | `values(obj)` | `Object → Array<unknown>` | Object values |
 | `entries(obj)` | `Object → Array<[string, unknown]>` | Key-value pairs |
+
+> **Object spread is syntax, not a builtin.** `{ ...base, status: "active" }` is the current bounded object-literal sugar and lowers through `merge(...)`.
 
 **Property Access vs. Dynamic Lookup:**
 

--- a/docs/mel/examples/computed/object.mel
+++ b/docs/mel/examples/computed/object.mel
@@ -1,6 +1,6 @@
 // ============================================
 // Title: Object Functions
-// Description: merge, keys, values, entries
+// Description: object spread, merge, keys, values, entries
 // Prerequisites: basic.mel
 // ============================================
 
@@ -17,19 +17,22 @@ domain ObjectFunctions {
     tasks: Record<string, Item> = {}
   }
 
-  // --- merge: Shallow merge objects (later wins) ---
+  // --- Object composition: later contributors win ---
 
-  // Merge two objects — later overrides earlier
-  computed merged = merge(defaults, config)
+  // Spread-first composition — later overrides earlier
+  computed merged = { ...defaults, ...config }
   // If config = { theme: "dark", lang: "en", fontSize: 14 }
   // Result: { theme: "dark", lang: "en", fontSize: 14 }
 
-  // Merge with literal override
-  computed withOverride = merge(config, { theme: "light" })
+  // Spread with literal override
+  computed withOverride = { ...config, theme: "light" }
   // Result: { theme: "light", lang: "en", fontSize: 14 }
 
-  // Variadic: merge 3+ objects
-  computed full = merge(defaults, config, { fontSize: 20 })
+  // Spread multiple contributors
+  computed full = { ...defaults, ...config, fontSize: 20 }
+
+  // Direct merge() remains available and follows the same typing rules
+  computed mergedViaFunction = merge(defaults, config)
 
   // --- keys, values, entries ---
 
@@ -43,12 +46,12 @@ domain ObjectFunctions {
   // Extract key-value pairs
   computed taskPairs = entries(tasks)
 
-  // --- merge in actions (key use case: enrich without enumerating all fields) ---
+  // --- merge in actions (useful when you already have an object expression) ---
 
   action markActive(id: string) {
     when isNotNull(at(tasks, $input.id)) {
       // Instead of: patch tasks[$input.id] = { id: ..., name: ..., status: "active" }
-      // Use merge to only override status:
+      // Use merge to only override status on the fetched record object:
       patch tasks[$input.id] = merge(at(tasks, $input.id), { status: "active" })
     }
   }

--- a/docs/tutorial/02-actions-and-state.md
+++ b/docs/tutorial/02-actions-and-state.md
@@ -54,7 +54,7 @@ domain TodoList {
     onceIntent {
       effect array.map({
         source: todos,
-        select: if(eq($item.id, id), merge($item, { completed: not($item.completed) }), $item),
+        select: eq($item.id, id) ? { ...$item, completed: not($item.completed) } : $item,
         into: todos
       })
     }

--- a/docs/tutorial/04-todo-app.md
+++ b/docs/tutorial/04-todo-app.md
@@ -54,7 +54,7 @@ domain TodoApp {
     onceIntent {
       effect array.map({
         source: todos,
-        select: if(eq($item.id, id), merge($item, { completed: not($item.completed) }), $item),
+        select: eq($item.id, id) ? { ...$item, completed: not($item.completed) } : $item,
         into: todos
       })
     }

--- a/packages/compiler/__tests__/analyzer/flow-composition.test.ts
+++ b/packages/compiler/__tests__/analyzer/flow-composition.test.ts
@@ -101,6 +101,35 @@ describe("flow composition", () => {
     expect(codes).toContain("E024");
   });
 
+  it("keeps include argument diagnostics stable across union member order", () => {
+    const compile = (union: string) => transform(`
+      domain Demo {
+        type A = { value: string }
+        type B = { value: number }
+
+        state {
+          current: ${union} = { value: 1 }
+        }
+
+        flow helper(input: number) {
+          when true {
+            stop "ok"
+          }
+        }
+
+        action test() {
+          include helper(current.value)
+        }
+      }
+    `);
+
+    const aThenB = compile("A | B");
+    const bThenA = compile("B | A");
+
+    expect(aThenB.diagnostics.map((diagnostic) => diagnostic.code)).toContain("E024");
+    expect(bThenA.diagnostics.map((diagnostic) => diagnostic.code)).toContain("E024");
+  });
+
   it("diagnoses invalid include positions and forbidden flow constructs", () => {
     const result = transform(`
       domain Demo {

--- a/packages/compiler/__tests__/generator/generator.test.ts
+++ b/packages/compiler/__tests__/generator/generator.test.ts
@@ -324,6 +324,26 @@ describe("IR Generator", () => {
       }
     });
 
+    it("generates object spread through merge lowering", () => {
+      const expr = compileExpr('{ ...{ base: 1 }, name: "Grace" }');
+      expect(expr?.kind).toBe("merge");
+      if (expr?.kind === "merge") {
+        expect(expr.objects).toHaveLength(2);
+        expect(expr.objects[0]).toEqual({
+          kind: "object",
+          fields: {
+            base: { kind: "lit", value: 1 },
+          },
+        });
+        expect(expr.objects[1]).toEqual({
+          kind: "object",
+          fields: {
+            name: { kind: "lit", value: "Grace" },
+          },
+        });
+      }
+    });
+
     it("generates array literal", () => {
       const expr = compileExpr("[1, 2, 3]");
       expect(expr?.kind).toBe("lit");
@@ -353,6 +373,23 @@ describe("IR Generator", () => {
         path: [
           { kind: "prop", name: "user" },
           { kind: "prop", name: "name" },
+        ],
+      });
+    });
+
+    it("canonicalizes object spread through merge()", () => {
+      const expr = compileCanonicalExpr('{ ...user, name: "Grace" }');
+      expect(expr).toEqual({
+        kind: "call",
+        fn: "merge",
+        args: [
+          { kind: "get", path: [{ kind: "prop", name: "user" }] },
+          {
+            kind: "obj",
+            fields: [
+              { key: "name", value: { kind: "lit", value: "Grace" } },
+            ],
+          },
         ],
       });
     });

--- a/packages/compiler/__tests__/lexer/lexer.test.ts
+++ b/packages/compiler/__tests__/lexer/lexer.test.ts
@@ -74,6 +74,20 @@ describe("Lexer", () => {
         "COMMA", "SEMICOLON", "DOT", "EOF"
       ]);
     });
+
+    it("tokenizes ellipsis for object spread", () => {
+      const { tokens } = tokenize("... .");
+      expect(tokens.map((t) => t.kind)).toEqual([
+        "ELLIPSIS", "DOT", "EOF"
+      ]);
+    });
+
+    it("does not collapse invalid double-dot into a single token", () => {
+      const { tokens } = tokenize(".. a..b");
+      expect(tokens.map((t) => t.kind)).toEqual([
+        "DOT", "DOT", "IDENTIFIER", "DOT", "DOT", "IDENTIFIER", "EOF"
+      ]);
+    });
   });
 
   describe("literals", () => {

--- a/packages/compiler/__tests__/parser/parser.test.ts
+++ b/packages/compiler/__tests__/parser/parser.test.ts
@@ -285,12 +285,83 @@ describe("Parser", () => {
       }
     });
 
+    it("parses object literals with spread entries", () => {
+      const expr = parseExpr('{ ...user, name: "Grace" }');
+      expect(expr?.kind).toBe("objectLiteral");
+      if (expr?.kind === "objectLiteral") {
+        expect(expr.properties).toHaveLength(2);
+        expect(expr.properties[0]?.kind).toBe("objectSpread");
+        expect(expr.properties[1]?.kind).toBe("objectProperty");
+      }
+    });
+
     it("parses array literals", () => {
       const expr = parseExpr("[1, 2, 3]");
       expect(expr?.kind).toBe("arrayLiteral");
       if (expr?.kind === "arrayLiteral") {
         expect(expr.elements).toHaveLength(3);
       }
+    });
+
+    it("reports a boundary diagnostic for array spread", () => {
+      const { diagnostics } = parseSource(`
+        domain Demo {
+          computed copy = [...items]
+        }
+      `);
+
+      expect(diagnostics.some((diagnostic) =>
+        diagnostic.message.includes("Object spread is the only bounded JavaScript-like sugar admitted in current MEL.")
+          && diagnostic.message.includes("Array spread is not supported.")
+      )).toBe(true);
+    });
+
+    it("reports a boundary diagnostic for computed object keys", () => {
+      const { diagnostics } = parseSource(`
+        domain Demo {
+          state {
+            name: string = ""
+          }
+
+          computed keyed = { [name]: 1 }
+        }
+      `);
+
+      expect(diagnostics.some((diagnostic) =>
+        diagnostic.message.includes("Object spread is the only bounded JavaScript-like sugar admitted in current MEL.")
+          && diagnostic.message.includes("Computed object keys are not supported.")
+      )).toBe(true);
+    });
+
+    it("reports a boundary diagnostic for optional chaining", () => {
+      const { diagnostics } = parseSource(`
+        domain Demo {
+          type Profile = { name: string }
+
+          state {
+            profile: Profile = { name: "" }
+          }
+
+          computed maybeName = profile?.name
+        }
+      `);
+
+      expect(diagnostics.some((diagnostic) =>
+        diagnostic.message.includes("Object spread is the only bounded JavaScript-like sugar admitted in current MEL.")
+          && diagnostic.message.includes("Optional chaining is not supported.")
+      )).toBe(true);
+    });
+
+    it("reports a parse diagnostic for invalid double-dot access", () => {
+      const { diagnostics } = parseSource(`
+        domain Demo {
+          computed broken = user..name
+        }
+      `);
+
+      expect(diagnostics.some((diagnostic) =>
+        diagnostic.message.includes("Expected property name after '.'")
+      )).toBe(true);
     });
 
     it("parses system identifiers", () => {

--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -771,10 +771,38 @@ describe("Expression type checking", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts non-null state coalesce object spread operands with unreachable array fallbacks", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Profile = { id: string }
+        state {
+          profile: Profile = { id: "x" }
+        }
+        computed draft = { ...coalesce(profile, []) }
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
   it("accepts object-first coalesce merge operands with unreachable array fallbacks", () => {
     const result = compileSource(`
       domain Demo {
         computed draft = merge(coalesce(merge({ id: "x" }), []))
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts non-null state coalesce merge operands with unreachable array fallbacks", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Profile = { id: string }
+        state {
+          profile: Profile = { id: "x" }
+        }
+        computed draft = merge(coalesce(profile, []))
       }
     `);
 

--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -338,6 +338,28 @@ describe("Expression type checking", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts nullable object spread operands through null aliases", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Nil = null
+        type User = {
+          id: string,
+          name: string
+        }
+        type MaybeUser = User | Nil
+
+        state {
+          maybeUser: MaybeUser = null
+        }
+
+        computed partialUser = { ...maybeUser }
+        computed safeName = coalesce(partialUser.name, "guest")
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
   it("rejects invalid object spread operands", () => {
     const result = compileSource(`
       domain Demo {
@@ -368,6 +390,28 @@ describe("Expression type checking", () => {
 
         computed partialDraft = merge(draft)
         computed safeCustomerId = coalesce(partialDraft.customerId, "guest")
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts direct merge operands through null aliases", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Nil = null
+        type User = {
+          id: string,
+          name: string
+        }
+        type MaybeUser = User | Nil
+
+        state {
+          maybeUser: MaybeUser = null
+        }
+
+        computed partialUser = merge(maybeUser)
+        computed safeName = coalesce(partialUser.name, "guest")
       }
     `);
 

--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -738,4 +738,26 @@ describe("Expression type checking", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("rejects array-first coalesce object spread operands", () => {
+    const result = compileSource(`
+      domain Demo {
+        computed draft = { ...coalesce([], { id: "x" }) }
+      }
+    `);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
+
+  it("rejects array-first coalesce merge operands", () => {
+    const result = compileSource(`
+      domain Demo {
+        computed draft = merge(coalesce([], { id: "x" }))
+      }
+    `);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
 });

--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -375,6 +375,24 @@ describe("Expression type checking", () => {
     expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
   });
 
+  it("rejects object spread operands that deterministically yield arrays", () => {
+    const spreadResult = compileSource(`
+      domain Demo {
+        computed bad = { ...coalesce([], []) }
+      }
+    `);
+    const mergeResult = compileSource(`
+      domain Demo {
+        computed bad = merge(cond(true, [], []))
+      }
+    `);
+
+    expect(spreadResult.success).toBe(false);
+    expect(spreadResult.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+    expect(mergeResult.success).toBe(false);
+    expect(mergeResult.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
+
   it("accepts direct merge typing parity for nullable object operands", () => {
     const result = compileSource(`
       domain Demo {

--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -760,4 +760,24 @@ describe("Expression type checking", () => {
     expect(result.success).toBe(false);
     expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
   });
+
+  it("accepts object-first coalesce object spread operands with unreachable array fallbacks", () => {
+    const result = compileSource(`
+      domain Demo {
+        computed draft = { ...coalesce(merge({ id: "x" }), []) }
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts object-first coalesce merge operands with unreachable array fallbacks", () => {
+    const result = compileSource(`
+      domain Demo {
+        computed draft = merge(coalesce(merge({ id: "x" }), []))
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/expression-type-check.test.ts
@@ -317,6 +317,117 @@ describe("Expression type checking", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts optional spread-result reads when normalized explicitly", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Draft = {
+          customerId: string,
+          appliedCouponId: string | null,
+          submissionState: "idle" | "submitted"
+        }
+
+        state {
+          draft: Draft | null = null
+        }
+
+        computed partialDraft = { ...draft }
+        computed safeCustomerId = coalesce(partialDraft.customerId, "guest")
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid object spread operands", () => {
+    const result = compileSource(`
+      domain Demo {
+        state {
+          items: Array<string> = []
+        }
+
+        computed bad = { ...items }
+      }
+    `);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
+  });
+
+  it("accepts direct merge typing parity for nullable object operands", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Draft = {
+          customerId: string,
+          appliedCouponId: string | null,
+          submissionState: "idle" | "submitted"
+        }
+
+        state {
+          draft: Draft | null = null
+        }
+
+        computed partialDraft = merge(draft)
+        computed safeCustomerId = coalesce(partialDraft.customerId, "guest")
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("narrows later unconditional spread contributors to the overriding field type", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Draft = {
+          submissionState: "idle" | "submitted"
+        }
+
+        state {
+          draft: Draft = {
+            submissionState: "idle"
+          }
+          status: "submitted" = "submitted"
+        }
+
+        computed submitted = { ...draft, submissionState: "submitted" }
+
+        action remember() {
+          when true {
+            patch status = submitted.submissionState
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("narrows later unconditional merge contributors to the overriding field type", () => {
+    const result = compileSource(`
+      domain Demo {
+        type Draft = {
+          submissionState: "idle" | "submitted"
+        }
+
+        state {
+          draft: Draft = {
+            submissionState: "idle"
+          }
+          status: "submitted" = "submitted"
+        }
+
+        computed submitted = merge(draft, { submissionState: "submitted" })
+
+        action remember() {
+          when true {
+            patch status = submitted.submissionState
+          }
+        }
+      }
+    `);
+
+    expect(result.success).toBe(true);
+  });
+
   it("accepts argmax results as non-null when candidate eligibility is exhaustively covered", () => {
     const result = compileSource(`
       domain Demo {

--- a/packages/compiler/__tests__/type-checking/literal-type-check.test.ts
+++ b/packages/compiler/__tests__/type-checking/literal-type-check.test.ts
@@ -106,6 +106,51 @@ describe("Literal type checking", () => {
     });
   });
 
+  describe("object spread state initializers", () => {
+    it("accepts compile-time constant object spread operands", () => {
+      const result = compileSource(`
+        domain Demo {
+          type Config = {
+            theme: string,
+            locale: string
+          }
+
+          state {
+            cfg: Config = {
+              ...{ theme: "light" },
+              locale: "ko-KR"
+            }
+          }
+        }
+      `);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects invalid spread operands in state initializers", () => {
+      const result = compileSource(`
+        domain Demo {
+          type Config = {
+            theme: string
+          }
+
+          state {
+            cfg: Config = {
+              ...1,
+              theme: "light"
+            }
+          }
+        }
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.some((diagnostic) =>
+        diagnostic.code === "E_TYPE_MISMATCH"
+          && diagnostic.message.includes("Object spread operands must be object-shaped")
+      )).toBe(true);
+    });
+  });
+
   describe("enum type mismatch", () => {
     it("rejects value not in enum", () => {
       const result = compileSource(`
@@ -398,6 +443,65 @@ describe("Literal type checking", () => {
         }
       `);
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("object spread patch literals", () => {
+    it("accepts spread-backed object literals when required fields are reintroduced unconditionally", () => {
+      const result = compileSource(`
+        domain Demo {
+          type Draft = {
+            customerId: string,
+            appliedCouponId: string | null,
+            submissionState: "idle" | "submitted"
+          }
+
+          state {
+            draft: Draft | null = null
+          }
+
+          action submit(customerId: string) {
+            onceIntent {
+              patch draft = {
+                ...draft,
+                customerId: customerId,
+                appliedCouponId: null,
+                submissionState: "submitted"
+              }
+            }
+          }
+        }
+      `);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects spread-backed object literals when required fields stay conditional", () => {
+      const result = compileSource(`
+        domain Demo {
+          type Draft = {
+            customerId: string,
+            appliedCouponId: string | null,
+            submissionState: "idle" | "submitted"
+          }
+
+          state {
+            draft: Draft | null = null
+          }
+
+          action submit() {
+            onceIntent {
+              patch draft = {
+                ...draft,
+                submissionState: "submitted"
+              }
+            }
+          }
+        }
+      `);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.some((diagnostic) => diagnostic.code === "E_TYPE_MISMATCH")).toBe(true);
     });
   });
 

--- a/packages/compiler/docs/SPEC-v1.2.0.md
+++ b/packages/compiler/docs/SPEC-v1.2.0.md
@@ -1,0 +1,728 @@
+# MEL Compiler SPEC v1.2.0
+
+> **Version:** 1.2.0
+> **Type:** Full
+> **Status:** Normative
+> **Date:** 2026-04-23
+> **Replaces:** v1.1.0 as the current full compiler contract
+> **Compatible with:** Core SPEC v4.2.0, current SDK activation-first contract
+
+---
+
+## Changelog
+
+### v1.2.0
+
+- admit object-literal spread as the sole bounded parser-level shorthand in current MEL
+- define spread operand admissibility, canonical `merge(...)` lowering, and patch-layer distinction from `patch path merge expr`
+- define presence-aware object typing for spread results and direct `merge()` parity
+- define optional-field read contract as `T | null` at the expression boundary
+- add diagnostic expectations for forbidden adjacent JS-like forms and presence-aware normalization failures
+
+### v1.1.0
+
+- add `SourceMapIndex` as a compiler-owned, tooling-only declaration-level source location sidecar on `DomainModule`
+- add `SourceMapEmissionContext` as the explicit emission-context contract for deterministic source-map extraction
+- split sidecar cache identity by artifact class while preserving the existing runtime-facing `DomainSchema` contract
+- reaffirm that action-level trace replay is the current stable join scope for source-map consumers
+
+---
+
+## 1. Purpose
+
+This document is the **current full MEL compiler contract**.
+
+It consolidates the landed compiler surface into one current contract, including:
+
+- the active full MEL/compiler baseline
+- `SchemaGraph` extraction
+- structural annotations via `@meta` with a tooling-only sidecar
+- compiler-owned declaration-level source locations via `SourceMapIndex`
+- `dispatchable when`
+- current landed compiler/runtime alignment for `Record<string, T>` and `T | null` in schema positions
+- current landed support for pure collection builtins in expression contexts
+- current clarification that additive MEL surface forms must preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary
+- object-literal spread as the sole bounded parser-level shorthand in current MEL
+- presence-aware object typing and direct `merge()` typing parity for spread-admitted object composition
+
+Historical compiler docs remain useful for archaeology, but **this file is the current truth**.
+
+---
+
+## 2. Current Output Contract
+
+The current compiler contract defines four distinct artifacts:
+
+- `DomainSchema` as the semantic runtime artifact returned by existing schema-only compile entrypoints
+- `SchemaGraph` as the projected static dependency artifact
+- `AnnotationIndex` as the tooling-only structural sidecar
+- `SourceMapIndex` as the tooling-only declaration-level source location sidecar
+
+Additive compiler/tooling entrypoints MAY expose those artifacts together through a module envelope:
+
+```typescript
+type DomainModule = {
+  readonly schema: DomainSchema;
+  readonly graph: SchemaGraph;
+  readonly annotations: AnnotationIndex;
+  readonly sourceMap: SourceMapIndex;
+};
+```
+
+Within `DomainSchema`, the compiler emits three distinct type-carrying seams:
+
+```typescript
+type DomainSchema = {
+  readonly types: Record<string, TypeSpec>;
+  readonly state: StateSpec;
+  readonly actions: Record<string, ActionSpec>;
+  // ...
+};
+
+type StateSpec = {
+  readonly fields: Record<string, FieldSpec>;
+  readonly fieldTypes?: Record<string, TypeDefinition>;
+};
+
+type ActionSpec = {
+  readonly flow: FlowNode;
+  readonly input?: FieldSpec;
+  readonly inputType?: TypeDefinition;
+  readonly params?: readonly string[];
+  readonly available?: ExprNode;
+  readonly dispatchable?: ExprNode;
+  readonly description?: string;
+};
+```
+
+Normative meaning:
+
+- `schema` is the semantic runtime artifact. Core, Host, and SDK runtime entrypoints remain `DomainSchema`-only.
+- `graph` is the projected static dependency artifact extracted from `schema` alone.
+- `annotations` is a tooling-only structural sidecar and MUST remain out-of-schema.
+- `sourceMap` is a tooling-only declaration-level source location sidecar and MUST remain out-of-schema.
+- schema-only compiler entrypoints MAY continue to expose `DomainSchema` without wrapping it in `DomainModule`.
+- `types` preserves named MEL type declarations losslessly.
+- `state.fields` and `action.input` are the **compatibility / coarse introspection seam**.
+- `state.fieldTypes` and `action.inputType` are the **normative runtime typing seam** when present.
+- `action.params` is the normative parameter-order seam.
+
+The compiler MUST preserve precise type information in `fieldTypes` / `inputType` whenever the source schema uses shapes that are wider than `FieldSpec`.
+
+---
+
+## 3. Type Lowering
+
+### 3.1 Lossless Type Preservation
+
+The compiler MUST preserve full MEL type information in `DomainSchema.types` using `TypeDefinition`.
+
+```typescript
+type TypeDefinition =
+  | { kind: "primitive"; type: string }
+  | { kind: "array"; element: TypeDefinition }
+  | { kind: "record"; key: TypeDefinition; value: TypeDefinition }
+  | { kind: "object"; fields: Record<string, { type: TypeDefinition; optional: boolean }> }
+  | { kind: "union"; types: TypeDefinition[] }
+  | { kind: "literal"; value: string | number | boolean | null }
+  | { kind: "ref"; name: string };
+```
+
+### 3.2 Compatibility FieldSpec Lowering
+
+`FieldSpec` is still emitted, but it is no longer the sole normative runtime boundary.
+
+The compiler MUST lower schema-position types according to the following table:
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| TYPE-LOWER-1 | MUST | Action parameters MUST lower to `ActionSpec.input` as a compatibility `FieldSpec` object with named fields |
+| TYPE-LOWER-2 | MUST | Named object types MUST inline into compatibility `FieldSpec.fields` when representable |
+| TYPE-LOWER-3 | MUST | `Array<T>` MUST lower to `FieldSpec { type: "array", items: ... }` when `T` is compatibility-representable |
+| TYPE-LOWER-4 | MUST | Literal-only unions MUST lower to enum `FieldSpec` where sound |
+| TYPE-LOWER-5 | MUST | Inline object types in schema positions MUST remain visible to users through diagnostics/introspection |
+| TYPE-LOWER-6 | MUST | `T \| null` in state/action-input positions MUST compile and preserve precise nullability through `fieldTypes` / `inputType` |
+| TYPE-LOWER-7 | MUST | `Record<string, T>` in state/action-input positions MUST compile and preserve precise value typing through `fieldTypes` / `inputType` |
+| TYPE-LOWER-8 | MUST | Non-trivial unions that are not nullable or literal-enum compatible MUST remain compile errors (`E043`) |
+| TYPE-LOWER-9 | MUST | Recursive schema-position refs that cannot be soundly lowered for runtime validation MUST remain compile errors (`E044`) |
+
+### 3.3 Nullable Types
+
+`T | null` is supported in state fields and action input positions.
+
+Normative rules:
+
+- nullable lowering MUST preserve the exact branch structure in `fieldTypes` / `inputType`
+- compatibility `FieldSpec` MAY degrade to the non-null branch for coarse shape/tooling
+- runtime validation MUST distinguish:
+  - missing field
+  - explicit `null`
+  - non-null value of type `T`
+
+`nullable` means **present-or-null**, not “optional by another name.”
+
+### 3.4 Record Types
+
+`Record<string, T>` is supported in state fields and action input positions.
+
+Normative rules:
+
+- record keys remain string-keyed only
+- `fieldTypes` / `inputType` MUST preserve the declared record value type
+- compatibility `FieldSpec` MAY degrade records to coarse `{ type: "object" }`
+- runtime validation MUST validate each record entry value against `T`
+
+### 3.5 Action Input Lowering
+
+For actions with declared parameters, the compiler MUST emit:
+
+- `action.params` in declared source order
+- `action.inputType` as an object-shaped `TypeDefinition`
+- `action.input` as the compatibility/coarse `FieldSpec` seam
+
+This split is normative. Consumers that need exact typing MUST prefer `params` plus `inputType`.
+
+---
+
+## 4. State Initializers and Literal Checking
+
+The compiler MUST evaluate state initializer expressions to concrete JSON values where the source expression is statically literal.
+
+When a concrete literal value is available:
+
+- compatibility checks MAY use `FieldSpec`
+- precise checks MUST use `TypeDefinition` when available
+
+Static literal mismatch diagnostics MUST continue to point at nested locations such as:
+
+- `current.id`
+- `current.done`
+- `nums[1]`
+
+---
+
+## 5. Pure Collection Builtins
+
+The current compiler surface supports the following collection builtins in expression contexts:
+
+- `filter(arr, pred)`
+- `map(arr, expr)`
+- `find(arr, pred)`
+- `every(arr, pred)`
+- `some(arr, pred)`
+
+Normative rules:
+
+- these functions are expression-level builtins, not effects
+- `$item` is valid only inside the predicate/mapper expression they introduce
+- hidden accumulation remains forbidden
+- aggregation composition rules remain unchanged: `sum()`, `min()`, and `max()` require a direct state/computed reference, not an inline transformed expression
+
+Examples:
+
+```mel
+computed active = filter(items, eq($item.active, true))
+computed firstOpen = find(items, eq($item.status, "open"))
+computed allDone = every(tasks, eq($item.done, true))
+
+// still forbidden
+computed bad = sum(filter(prices, gt($item, 0)))
+```
+
+### 5.1 Additional Explicit MEL Surface Forms
+
+The builtin and collection surface defined in this spec is the **current** MEL source contract.
+
+Any additive MEL surface form beyond the builtin set explicitly defined here MUST satisfy all of the following:
+
+- it MUST be admitted explicitly at the MEL source level rather than appearing as an undocumented parser or lowering convenience
+- it MUST preserve the current meanings of existing builtin names such as `floor`, `ceil`, `min`, `max`, `filter`, `map`, `find`, `every`, and `some`
+- it MUST remain representable as an explicit MEL canonical expression or flow form through validation and type checking
+- lowering to Core Runtime IR MUST occur only at the existing MEL → Core lowering boundary
+- the lowered result MUST use existing Core/runtime expression and flow kinds only
+- user-defined accumulation, runtime-shaped iteration, dynamic dispatch, and other general-computation constructs remain forbidden
+
+Entity primitives are the current precedent for this pattern: they remain explicit MEL surface forms until the lowering boundary and then lower into existing Core/runtime kinds without changing the underlying runtime model.
+
+Ordinary function-call forms remain the baseline contract. The sole admitted parser-level shorthand is object-literal spread inside object literals. No new arm syntax, named arguments, or other parser-only shorthand is implied here.
+
+The following bounded function forms are admitted under that rule:
+
+#### `absDiff(a, b)`
+
+- signature: `(number, number) -> number`
+- lowering: `abs(sub(a, b))`
+- both arguments MUST be numbers
+
+#### `clamp(x, lo, hi)`
+
+- signature: `(number, number, number) -> number`
+- lowering: `min(max(x, lo), hi)`
+- all arguments MUST be numbers
+- bounds MUST NOT be reordered implicitly
+- when both bounds are statically literal numbers and `lo > hi`, the compiler MUST reject the call
+- this does NOT change the existing meanings of unary `floor()` or `ceil()`
+
+#### `idiv(a, b)`
+
+- signature: `(number, number) -> number | null`
+- lowering: `floor(div(a, b))`
+- both arguments MUST be numbers
+- negative results MUST follow mathematical floor semantics, not truncation toward zero
+- zero-divisor behavior MUST inherit existing `div()` semantics, including `null` on zero
+
+#### `streak(prev, cond)`
+
+- signature: `(number, boolean) -> number`
+- lowering: `cond(cond, add(prev, 1), 0)`
+- `prev` MUST be a number
+- `cond` MUST be a boolean
+
+#### `match(key, [k1, v1], [k2, v2], ..., defaultValue)`
+
+- source form example: `match(status, ["open", 1], ["closed", 0], -1)`
+- the call MUST contain at least one arm and one default value
+- each arm MUST be an inline 2-item array literal `[matchKey, value]`
+- each `matchKey` MUST be a literal `string`, `number`, or `boolean`
+- the final positional argument MUST be the default value
+- `key` and every `matchKey` MUST have the same comparable primitive type: `string`, `number`, or `boolean`
+- duplicate literal arm keys MUST be rejected
+- all arm values and the default value MUST unify to one result type
+- lowering: nested `cond(eq(key, kN), vN, ...)` in source order
+
+#### `argmax([label, eligible, score], ..., tieBreak)`
+
+- source form example: `argmax(["a", aOk, aScore], ["b", bOk, bScore], "first")`
+- the call MUST contain at least one candidate and one tie-break literal
+- each candidate MUST be an inline 3-item array literal `[label, eligible, score]`
+- `eligible` MUST be boolean
+- `score` MUST be number
+- all labels MUST unify to one primitive scalar type: `string`, `number`, or `boolean`
+- the final positional argument MUST be the literal `"first"` or `"last"`
+- runtime-array forms such as `argmax(items, "first")` are NOT part of this contract
+- if no candidate is eligible, the result MUST be `null`
+- `"first"` MUST select the earliest source-order candidate among equal eligible maxima
+- `"last"` MUST select the latest source-order candidate among equal eligible maxima
+- lowering MUST use only existing conditional and comparison structure; tie-break determinism MUST be expressed through `gt`/`gte` selection order
+
+#### `argmin([label, eligible, score], ..., tieBreak)`
+
+- source form example: `argmin(["a", aOk, aScore], ["b", bOk, bScore], "last")`
+- candidate shape, label rules, and tie-break rules are identical to `argmax`
+- runtime-array forms are NOT part of this contract
+- if no candidate is eligible, the result MUST be `null`
+- `"first"` MUST select the earliest source-order candidate among equal eligible minima
+- `"last"` MUST select the latest source-order candidate among equal eligible minima
+- lowering MUST use only existing conditional and comparison structure; tie-break determinism MUST be expressed through `lt`/`lte` selection order
+
+Non-goals of this admission rule:
+
+- no `match(expr, "k" => v)` arrow-arm syntax
+- no `tieBreak: "first"` named-argument syntax
+- no runtime-array `argmax(items, scoreFn)` or `argmin(items, scoreFn)`
+- no reinterpretation of existing builtin meanings such as `floor`, `ceil`, `min`, `max`, `filter`, `map`, `find`, `every`, or `some`
+
+### 5.2 Object-Literal Spread
+
+Object-literal spread is part of the current MEL surface as a bounded source-level sugar:
+
+```mel
+computed shippedOrder = { ...order, status: "shipped" }
+
+action submit(customerId: string) {
+  onceIntent {
+    patch draft = {
+      ...draft,
+      customerId: customerId,
+      appliedCouponId: null,
+      submissionState: "submitted"
+    }
+  }
+}
+```
+
+Normative rules:
+
+- spread entries are admitted only inside object literals: `{ ...expr, key: value }`
+- spread is source-order sensitive; named fields and spread contributors compete by source order alone
+- spread operands MUST be object-shaped, or `T | null` where `T` is object-shaped
+- `Record<string, T>` spread operands are not part of the current v1.2 contract
+- primitive, array, and object-only multi-branch union spread operands are not part of the current v1.2 contract
+- object-literal spread MUST lower to canonical `merge(...)` expressions with source order preserved
+- consecutive named fields between spread contributors MUST group into one object-literal `merge(...)` argument
+- `patch path = { ...expr, key: value }` remains a `set` patch whose value is the lowered `merge(...)`
+- `patch path merge expr` remains a distinct patch operation and is not interchangeable with `patch path = <spread>`
+- lowering MUST continue to use existing MEL canonical expression shapes and existing Core/runtime expression kinds only
+
+Typing rules:
+
+- spread result typing is presence-aware at the field level
+- a required field contributed unconditionally remains required
+- a field contributed only through a nullable spread or an optional source field remains optional until later unconditionally contributed
+- optional result fields MUST NOT satisfy required assignment targets without a later unconditional contribution
+- direct reads from optional result fields are observed as `T | null` at the expression boundary
+- values read from optional spread-result fields MUST be explicitly normalized before they satisfy a non-null required sink
+- direct `merge()` typing MUST follow the same presence-aware rules as the lowered spread form
+
+Compatibility note:
+
+- current runtime semantics of `merge()` are unchanged
+- current compile-time typing MAY tighten existing `merge()` call sites that previously relied on unsound nullable/object-presence behavior
+- this tightening is part of the v1.2 current contract, not a runtime change
+
+---
+
+## 6. Intent Dispatchability
+
+`available when` remains the coarse action-family gate.
+
+`dispatchable when` is part of the current full compiler contract:
+
+- it MAY reference state, computed values, and bare action parameter names
+- it MUST NOT allow direct `$input.*` syntax in source
+- it MUST NOT allow `$meta.*`, `$system.*`, or effects
+- it MUST lower to `ActionSpec.dispatchable`
+
+If both clauses are present, ordering is fixed:
+
+```ebnf
+ActionDecl ::= 'action' Identifier '(' Params? ')' AvailableClause? DispatchableClause? '{' ActionBody '}'
+```
+
+---
+
+## 7. SchemaGraph
+
+`SchemaGraph` is part of the current compiler contract.
+
+The compiler MUST continue to extract the projected static graph with:
+
+- nodes: `state`, `computed`, `action`
+- edges: `feeds`, `mutates`, `unlocks`
+
+`dispatchable when` is input-bound and MUST NOT be projected into `SchemaGraph`.
+`unlocks` remains derived from `available when` only.
+Structural annotations and source-map sidecars MUST NOT alter graph nodes, graph edges, or graph derivation.
+
+---
+
+## 8. Tooling Sidecars
+
+### 8.1 Surface and Target Model
+
+`@meta` is part of the current MEL surface as a structural annotation form.
+
+Source form:
+
+```mel
+@meta("namespace:kind")
+@meta("namespace:kind", { key: "value", enabled: true })
+```
+
+Normative rules:
+
+- `@meta` uses prefix syntax and attaches to the immediately following construct.
+- Multiple annotations MAY stack on the same target.
+- The compiler MUST treat the tag string as opaque. Namespace or kind semantics are consumer-owned.
+- Current v1 attachable targets are:
+  - `domain`
+  - `type`
+  - `type_field`
+  - `state_field`
+  - `computed`
+  - `action`
+- For `type_field` and `state_field`, the same prefix form appears immediately above the field declaration inside the enclosing block.
+- `action_param` annotations are deferred from the current v1 contract and are NOT part of current MEL syntax.
+
+Examples:
+
+```mel
+@meta("doc:summary", { area: "tasks" })
+domain TaskBoard {
+  @meta("doc:entity")
+  type Task = {
+    id: string,
+    @meta("ui:hidden")
+    internalNote: string | null
+  }
+
+  state {
+    @meta("analytics:track")
+    lastArchivedId: string | null = null
+  }
+
+  @meta("ui:primary-list")
+  computed hasArchivedTask = isNotNull(lastArchivedId)
+
+  @meta("ui:button", { variant: "secondary" })
+  action archive(id: string) {
+    when true {
+      patch lastArchivedId = id
+    }
+  }
+}
+```
+
+### 8.2 Sidecar Types and Boundaries
+
+Annotations compile into a tooling-only sidecar. They MUST NOT appear inside `DomainSchema` or `SchemaGraph`.
+
+```typescript
+type AnnotationIndex = {
+  readonly schemaHash: string;
+  readonly entries: Record<LocalTargetKey, readonly Annotation[]>;
+};
+
+type LocalTargetKey = string;
+
+type Annotation = {
+  readonly tag: string;
+  readonly payload?: JsonLiteral;
+};
+
+type JsonLiteral =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonLiteral[]
+  | { readonly [key: string]: JsonLiteral };
+```
+
+Current v1 `LocalTargetKey` forms are:
+
+```text
+domain:<DomainName>
+type:<TypeName>
+type_field:<TypeName>.<FieldName>
+state_field:<FieldName>
+computed:<ComputedName>
+action:<ActionName>
+```
+
+Current v1 emission rules:
+
+- `schemaHash` MUST equal `hash` on the emitted `DomainSchema`.
+- `entries` MUST include only targets that carry at least one annotation.
+- `entries` MUST NOT contain empty annotation arrays.
+- stacked annotations on the same target MUST preserve source order.
+- repeated tags on the same target MUST NOT be deduplicated by the compiler.
+- sidecar emission order MUST be deterministic for a fixed source input.
+
+Normative rules:
+
+- `schemaHash` scopes the entire annotation sidecar to one emitted semantic schema.
+- Every emitted `LocalTargetKey` MUST map to an existing construct in the emitted `DomainSchema`.
+- Child targets use exactly one dotted segment (`Parent.Child`) in the current contract.
+- The sidecar MAY be exposed only by additive compiler/tooling entrypoints. It MUST NOT become a runtime input artifact.
+
+### 8.3 Payload Model
+
+Payloads are JSON-like literals only.
+
+Permitted payload values:
+
+- strings
+- numbers
+- booleans
+- `null`
+- arrays of JSON-like literals
+- objects whose values are JSON-like literals
+
+Current v1 payload restrictions:
+
+- payload is optional
+- maximum nesting depth is 2
+- MEL expressions are forbidden
+- semantic references are forbidden
+- guard references or runtime predicates are forbidden
+
+Examples:
+
+```mel
+// valid
+@meta("ui:button", { variant: "primary", size: "lg" })
+@meta("doc:priority", 3)
+
+// invalid: MEL expression in payload
+@meta("ui:button", { disabled: eq(len(items), 0) })
+
+// invalid: depth > 2
+@meta("ui:card", { config: { pricing: { free: "$0" } } })
+```
+
+### 8.4 Annotation Rules and Invariants
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| META-1 | MUST | The compiler MUST remain namespace-blind for annotation tags and payload meaning |
+| META-2 | MUST | Annotations MUST exist only in `AnnotationIndex`, never in `DomainSchema` or `SchemaGraph` |
+| META-3 | MUST | Annotation presence or absence MUST NOT affect schema hash, `compute()`, availability, dispatchability, or other runtime semantics |
+| META-4 | MUST | Runtime entrypoints MUST continue to accept `DomainSchema` only, not `DomainModule` |
+| META-5 | MUST | The compiler MUST validate emitted annotation targets against the emitted `DomainSchema` structure |
+| META-6 | MUST | Payloads MUST be JSON-like literals only, with current v1 nesting depth capped at 2 |
+| META-7 | MUST | Semantic validation of namespace-specific annotation meaning MUST remain consumer-owned |
+| META-8 | MUST | Stacked annotations on the same target MUST preserve source order and repeated tags MUST NOT be deduplicated |
+| META-9 | MUST | `AnnotationIndex.schemaHash` MUST equal `hash` on the emitted `DomainSchema` |
+| META-10 | MUST | `AnnotationIndex.entries` MUST omit unannotated targets and empty arrays, and emission order MUST be deterministic |
+
+Current invariants:
+
+| Invariant | Meaning |
+|-----------|---------|
+| INV-META-1 | Removing all `@meta` from MEL source MUST leave emitted `DomainSchema` byte-identical |
+| INV-META-2 | Removing all `@meta` from MEL source MUST leave emitted `SchemaGraph` identical |
+| INV-META-3 | For any snapshot and intent, `compute()` results MUST remain identical regardless of annotation presence |
+| INV-META-4 | For any snapshot, `getAvailableActions()` MUST remain identical regardless of annotation presence |
+| INV-META-5 | For any snapshot and intent, `isIntentDispatchable()` MUST remain identical regardless of annotation presence |
+| INV-META-6 | Tooling-only `DomainModule` artifacts MUST remain outside runtime schema-input seams |
+
+### 8.5 Compiler-Owned Source Location Sidecar
+
+`SourceMapIndex` is a compiler-owned sibling sidecar to `AnnotationIndex`. It records declaration-level MEL source spans for tooling and inspection consumers.
+
+It MUST remain outside `DomainSchema`, `SchemaGraph`, and runtime entrypoint contracts.
+
+```typescript
+type SourceMapIndex = {
+  readonly schemaHash: string;
+  readonly sourceHash: string;
+  readonly format: "manifesto/source-map-v1";
+  readonly coordinateUnit: "utf16" | "bytes";
+  readonly emissionFingerprint: string;
+  readonly entries: Record<LocalTargetKey, SourceMapEntry>;
+};
+
+type SourceMapEntry = {
+  readonly target: SourceMapPath;
+  readonly span: SourceSpan;
+};
+
+type SourceMapPath =
+  | { readonly kind: "domain"; readonly domain: { readonly name: string } }
+  | { readonly kind: "type"; readonly type: { readonly name: string } }
+  | {
+      readonly kind: "type_field";
+      readonly type: { readonly name: string };
+      readonly field: { readonly name: string };
+    }
+  | { readonly kind: "state_field"; readonly field: { readonly name: string } }
+  | { readonly kind: "computed"; readonly computed: { readonly name: string } }
+  | { readonly kind: "action"; readonly action: { readonly name: string } };
+
+type SourceSpan = {
+  readonly start: SourcePoint;
+  readonly end: SourcePoint;
+};
+
+type SourcePoint = {
+  readonly line: number;
+  readonly column: number;
+  readonly offset?: number;
+};
+
+type SourceMapEmissionContext = {
+  readonly coordinateUnit: "utf16" | "bytes";
+  readonly compilerVersion: string;
+  readonly emissionOptionsFingerprint: string;
+};
+```
+
+Current v1 `SourceMapPath.kind` forms are byte-identical to the landed `LocalTargetKey` kind set:
+
+```text
+domain
+type
+type_field
+state_field
+computed
+action
+```
+
+Current v1 source-map scope:
+
+- declaration-level mappings only
+- no body-statement resolution
+- no `action_param` mappings in the current landed subset
+
+Current v1 cache scope by artifact:
+
+| Artifact | Cache identity |
+|---------|----------------|
+| `DomainSchema` / `SchemaGraph` | `schemaHash` |
+| `AnnotationIndex` | `(schemaHash, sourceHash)` under a fixed compiler version |
+| `SourceMapIndex` / `DomainModule` | `(schemaHash, sourceHash, emissionFingerprint)` |
+
+Normative rules:
+
+| Rule ID | Level | Description |
+|---------|-------|-------------|
+| SMAP-1 | MUST | `SourceMapIndex` MUST exist only as a tooling-only out-of-schema sidecar |
+| SMAP-2 | MUST | `DomainModule.sourceMap` MUST be the only current compiler-owned source-location surface |
+| SMAP-3 | MUST | `SourceMapIndex.schemaHash` MUST equal `hash` on the emitted `DomainSchema` |
+| SMAP-4 | MUST | `SourceMapIndex.entries` MUST use the same current landed target-key universe as `AnnotationIndex` |
+| SMAP-5 | MUST | `SourceMapEntry.target` MUST structurally agree with its `LocalTargetKey` entry key |
+| SMAP-6 | MUST | `format` and `coordinateUnit` MUST remain separate fields; `format` is protocol version, `coordinateUnit` is payload encoding |
+| SMAP-7 | MUST | `emissionFingerprint` MUST be deterministic for a fixed semantic source and `SourceMapEmissionContext` |
+| SMAP-8 | MUST | source-map extraction MUST be modeled as a deterministic compiler operation over emitted source/module inputs plus explicit `SourceMapEmissionContext` |
+| SMAP-9 | MUST | `SourceMapIndex` and `DomainModule` caching MUST use `(schemaHash, sourceHash, emissionFingerprint)` rather than `schemaHash` alone |
+| SMAP-10 | MUST | current stable trace replay scope for source-map consumers is action-level only through `TraceGraph.intent.type -> action:<ActionName>` |
+| SMAP-11 | MUST NOT | consumers MUST NOT treat `TraceNode.sourcePath` as a stabilized compiler-side source-map contract in the current version |
+
+Current invariants:
+
+| Invariant | Meaning |
+|-----------|---------|
+| INV-SMAP-1 | Adding or removing `SourceMapIndex` emission MUST leave emitted `DomainSchema` byte-identical |
+| INV-SMAP-2 | Adding or removing `SourceMapIndex` emission MUST leave emitted `SchemaGraph` identical |
+| INV-SMAP-3 | For any snapshot and intent, runtime legality and compute results MUST remain identical regardless of source-map emission |
+| INV-SMAP-4 | Tooling-only `DomainModule` artifacts that carry `sourceMap` MUST remain outside runtime schema-input seams |
+
+---
+
+## 9. Diagnostics
+
+The following diagnostics remain active in this area:
+
+- `E043` for unsupported non-trivial schema-position unions
+- `E044` for recursive schema-position refs that cannot be soundly lowered
+- `E047` / `E048` for `dispatchable when` scope violations
+- `E053` for misplaced or floating `@meta`, including unsupported attachment sites
+- `E054` for unsupported `action_param` annotation syntax in the current contract
+- `E055` for annotation payload values that are not JSON-like literals, including MEL expressions and semantic references
+- `E056` for annotation payload nesting depth overflow
+- `E057` for emitted annotation targets that do not map to the emitted `DomainSchema`
+- `E058` for emitted source-map targets that do not map to the emitted `DomainSchema`
+- spread-form diagnostics for forbidden adjacent JS-like syntax such as array spread, rest destructuring, computed keys, and optional chaining
+- spread operand diagnostics for primitives, arrays, records, and unsupported object-only unions
+- presence-aware assignability diagnostics when optional spread contributors do not satisfy required target fields
+- optional-field consumption diagnostics when a spread-derived `T | null` value must be explicitly normalized before reaching a non-null sink
+
+The following historical diagnostics are superseded in the current contract:
+
+- `E045` nullable schema-position rejection
+- `E046` record schema-position rejection
+
+They remain historical references only and are no longer part of the current compiler surface.
+
+---
+
+## 10. Summary
+
+The current compiler contract is:
+
+- rich MEL types stay precise through `TypeDefinition`
+- compatibility `FieldSpec` remains available for coarse tooling and legacy consumers
+- nullable and record schema-position types are supported
+- pure collection builtins are supported in expressions
+- additive MEL surface expansions MUST preserve existing builtin meanings and lower only through the compiler-owned MEL → Core boundary
+- object-literal spread is the sole bounded parser-level shorthand in the current MEL surface
+- spread and direct `merge()` share one presence-aware object typing model
+- optional fields produced by spread are observed as `T | null` at read boundaries and require explicit normalization for non-null sinks
+- structural annotations via `@meta` compile into a tooling-only `AnnotationIndex` sidecar
+- declaration-level source locations compile into a tooling-only `SourceMapIndex` sidecar on `DomainModule`
+- `action_param` annotations remain outside the current v1 surface
+- `dispatchable when` is part of the full action contract
+- `SchemaGraph` remains availability-only and input-independent
+
+This is the current full compiler surface to use for implementation, tooling, and documentation.

--- a/packages/compiler/docs/VERSION-INDEX.md
+++ b/packages/compiler/docs/VERSION-INDEX.md
@@ -1,16 +1,16 @@
 # MEL Compiler Documentation Index
 
 > **Package:** `@manifesto-ai/compiler`
-> **Last Updated:** 2026-04-16
+> **Last Updated:** 2026-04-23
 
 ---
 
 ## Latest Version
 
-- **Current Full SPEC:** [v1.1.0](SPEC-v1.1.0.md) (Full)
+- **Current Full SPEC:** [v1.2.0](SPEC-v1.2.0.md) (Full)
 - **FDR:** [v0.5.0](FDR-v0.5.0.md) (Full)
 
-**Note:** [v1.1.0](SPEC-v1.1.0.md) is the current integrated compiler contract. It carries forward the v1.0.0 baseline and adds the compiler-owned declaration-level source location sidecar `SourceMapIndex`, explicit source-map emission context, and artifact-specific cache identity rules while preserving the existing runtime-facing `DomainSchema` contract.
+**Note:** [v1.2.0](SPEC-v1.2.0.md) is the current integrated compiler contract. It carries forward the v1.1.0 baseline and adds object-literal spread as the sole bounded parser-level shorthand, presence-aware object typing for spread/direct `merge()`, and the optional-field read contract while preserving the existing runtime-facing `DomainSchema` contract.
 
 **ADR Sources:** [ADR-021](../../../docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md) defines the current structural-annotation sidecar contract, and [ADR-022](../../../docs/internals/adr/022-compiler-owned-source-location-sidecar-source-map-index.md) defines the current source-location sidecar contract.
 
@@ -20,7 +20,8 @@
 
 | Version | SPEC | FDR | Type | Status |
 |---------|------|-----|------|--------|
-| v1.1.0 | [SPEC](SPEC-v1.1.0.md) | [FDR](FDR-v0.5.0.md) | Full | Current |
+| v1.2.0 | [SPEC](SPEC-v1.2.0.md) | [FDR](FDR-v0.5.0.md) | Full | Current |
+| v1.1.0 | [SPEC](SPEC-v1.1.0.md) | [FDR](FDR-v0.5.0.md) | Historical Full Predecessor | Superseded |
 | v1.0.0 | [SPEC](SPEC-v1.0.0.md) | [FDR](FDR-v0.5.0.md) | Historical Full Predecessor | Superseded |
 | v0.9.0 | [SPEC](SPEC-v0.9.0.md) | [FDR](../../sdk/docs/FDR-v3.1.0-draft.md) | Historical Addendum (merged into v1.0.0) | Superseded |
 | v0.8.0 | [SPEC](SPEC-v0.8.0.md) | [FDR](../../sdk/docs/FDR-v3.1.0-draft.md) | Historical Addendum (merged into v1.0.0) | Superseded |
@@ -41,10 +42,10 @@
 
 ### For Current
 
-1. Read [SPEC-v1.1.0.md](SPEC-v1.1.0.md) for the current full compiler contract.
+1. Read [SPEC-v1.2.0.md](SPEC-v1.2.0.md) for the current full compiler contract.
 2. Use [SPEC-v0.8.0.md](SPEC-v0.8.0.md) and [SPEC-v0.9.0.md](SPEC-v0.9.0.md) only for historical addendum context.
 3. For rationale history, use [FDR-v0.5.0.md](FDR-v0.5.0.md).
-4. If you are working on tooling sidecars, read [SPEC-v1.1.0.md](SPEC-v1.1.0.md) for the current v1.1 contract, then [ADR-021](../../../docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md) and [ADR-022](../../../docs/internals/adr/022-compiler-owned-source-location-sidecar-source-map-index.md) for architectural rationale.
+4. If you are working on tooling sidecars, read [SPEC-v1.2.0.md](SPEC-v1.2.0.md) for the current v1.2 contract, then [ADR-021](../../../docs/internals/adr/021-mel-structural-annotation-system-meta-sidecar.md) and [ADR-022](../../../docs/internals/adr/022-compiler-owned-source-location-sidecar-source-map-index.md) for architectural rationale.
 
 ### For v0.4.0 (Historical Patch)
 

--- a/packages/compiler/docs/compiler-SPEC-compilance-test-suite.md
+++ b/packages/compiler/docs/compiler-SPEC-compilance-test-suite.md
@@ -1,6 +1,6 @@
 # Compiler SPEC Compilance Test Suite (CCTS)
 
-> **Purpose:** Define the compliance harness for `@manifesto-ai/compiler` against the current MEL compiler contract in SPEC-v1.1.0.
+> **Purpose:** Define the compliance harness for `@manifesto-ai/compiler` against the current MEL compiler contract in SPEC-v1.2.0.
 > **Audience:** Compiler maintainers and contributors extending MEL semantics.
 > **Status:** Operational
 
@@ -13,9 +13,9 @@ CCTS exists to make compiler SPEC compliance executable.
 It has two simultaneous jobs:
 
 1. Turn normative MEL rules into named, reviewable test targets.
-2. Separate enforced baseline rules from the residual normative gaps that are still pending implementation.
+2. Make residual normative gaps explicit when they exist, instead of letting them disappear into implicit behavior.
 
-This is intentionally a **staged blocking** suite:
+This is intentionally a **rule-mode-visible blocking** suite:
 
 - `blocking` rules fail the suite when violated.
 - `pending` rules are probed and reported as `WARN` or `SKIP` until implementation catches up.
@@ -48,7 +48,7 @@ packages/compiler/src/__tests__/compliance/
 
 The suite mirrors the Host HCTS shape, but adds explicit inventory and coverage layers:
 
-- spec inventory (`SPEC-v1.1.0.md` rule surface)
+- spec inventory (`SPEC-v1.2.0.md` rule surface)
 - shared rule registry
 - case/rule coverage map
 - test adapter wrapping exported APIs
@@ -124,7 +124,7 @@ Current acceptance shape:
 
 - inventory/registry/coverage matrix checks pass
 - blocking rules pass
-- any newly introduced pending probes remain visible for the residual backlog and do not regress into silent coverage gaps
+- any pending probes, when introduced, remain visible for the residual backlog and do not regress into silent coverage gaps
 - existing compiler tests continue to run alongside CCTS
 
 ---
@@ -137,7 +137,7 @@ CCTS still does **not**:
 - emit `trace.ndjson`
 - parse the SPEC document automatically
 
-Those are valid follow-up steps once the registry and suite skeleton are stable.
+Those are valid future extensions once the registry and suite skeleton are stable.
 
 ---
 

--- a/packages/compiler/src/__tests__/compile-mel-patch.test.ts
+++ b/packages/compiler/src/__tests__/compile-mel-patch.test.ts
@@ -779,6 +779,44 @@ describe("compileMelPatch", () => {
     });
   });
 
+  it("rejects array-first coalesce object spread operands in patch expressions", () => {
+    const melText = `
+      patch draft = {
+        ...coalesce([], { a: 1 })
+      }
+    `;
+
+    const result = compileMelPatch(melText, {
+      mode: "patch",
+      actionName: "regression-compileMelPatch-array-first-coalesce-spread",
+    });
+
+    expect(result.ops).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      code: "E_TYPE_MISMATCH",
+      message: "Object spread operands must be object-shaped or T | null where T is object-shaped",
+    });
+  });
+
+  it("rejects array-first coalesce merge operands in patch expressions", () => {
+    const melText = `
+      patch draft = merge(coalesce([], { a: 1 }))
+    `;
+
+    const result = compileMelPatch(melText, {
+      mode: "patch",
+      actionName: "regression-compileMelPatch-array-first-coalesce-merge",
+    });
+
+    expect(result.ops).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      code: "E_TYPE_MISMATCH",
+      message: "Object spread operands must be object-shaped or T | null where T is object-shaped",
+    });
+  });
+
   it("supports unary minus in patch expressions", () => {
     const melText = `
       patch delta = -input.amount

--- a/packages/compiler/src/__tests__/compile-mel-patch.test.ts
+++ b/packages/compiler/src/__tests__/compile-mel-patch.test.ts
@@ -634,6 +634,112 @@ describe("compileMelPatch", () => {
     ]);
   });
 
+  it("supports object spread in patch expressions and lowers through merge", () => {
+    const melText = `
+      patch draft = {
+        ...draft,
+        customerId: input.customerId,
+        submissionState: "submitted"
+      }
+    `;
+
+    const result = compileMelPatch(melText, {
+      mode: "patch",
+      actionName: "regression-compileMelPatch-object-spread",
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.ops).toHaveLength(1);
+    expect(result.ops[0]).toMatchObject({
+      op: "set",
+      value: {
+        kind: "merge",
+        objects: [
+          { kind: "get", path: "draft" },
+          {
+            kind: "object",
+            fields: {
+              customerId: { kind: "get", path: "input.customerId" },
+              submissionState: { kind: "lit", value: "submitted" },
+            },
+          },
+        ],
+      },
+    });
+
+    const concretePatches = evaluateRuntimePatches(
+      result.ops,
+      createEvaluationContext({
+        meta: { intentId: "intent-object-spread" },
+        snapshot: {
+          data: {
+            draft: {
+              customerId: "customer-1",
+              appliedCouponId: "coupon-1",
+              submissionState: "idle",
+            },
+          },
+          computed: {},
+        },
+        input: { customerId: "customer-2" },
+      })
+    );
+
+    expect(toLegacyPatches(concretePatches)).toEqual([
+      {
+        op: "set",
+        path: "draft",
+        value: {
+          customerId: "customer-2",
+          appliedCouponId: "coupon-1",
+          submissionState: "submitted",
+        },
+      },
+    ]);
+  });
+
+  it("rejects definitely invalid object spread operands in patch expressions", () => {
+    const melText = `
+      patch draft = {
+        ...1,
+        submissionState: "submitted"
+      }
+    `;
+
+    const result = compileMelPatch(melText, {
+      mode: "patch",
+      actionName: "regression-compileMelPatch-object-spread-invalid",
+    });
+
+    expect(result.ops).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      code: "E_TYPE_MISMATCH",
+      message: "Object spread operands must be object-shaped or T | null where T is object-shaped",
+    });
+  });
+
+  it("rejects empty-array object spread operands in patch expressions", () => {
+    const melText = `
+      patch draft = {
+        ...[],
+        submissionState: "submitted"
+      }
+    `;
+
+    const result = compileMelPatch(melText, {
+      mode: "patch",
+      actionName: "regression-compileMelPatch-empty-array-object-spread",
+    });
+
+    expect(result.ops).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      code: "E_TYPE_MISMATCH",
+      message: "Object spread operands must be object-shaped or T | null where T is object-shaped",
+    });
+  });
+
   it("supports unary minus in patch expressions", () => {
     const melText = `
       patch delta = -input.amount

--- a/packages/compiler/src/__tests__/compile-mel-patch.test.ts
+++ b/packages/compiler/src/__tests__/compile-mel-patch.test.ts
@@ -817,6 +817,36 @@ describe("compileMelPatch", () => {
     });
   });
 
+  it("accepts object-first coalesce object spread operands with unreachable array fallbacks in patch expressions", () => {
+    const melText = `
+      patch draft = {
+        ...coalesce(merge({ a: 1 }), [])
+      }
+    `;
+
+    const result = compileMelPatch(melText, {
+      mode: "patch",
+      actionName: "regression-compileMelPatch-object-first-coalesce-spread",
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.ops).toHaveLength(1);
+  });
+
+  it("accepts object-first coalesce merge operands with unreachable array fallbacks in patch expressions", () => {
+    const melText = `
+      patch draft = merge(coalesce(merge({ a: 1 }), []))
+    `;
+
+    const result = compileMelPatch(melText, {
+      mode: "patch",
+      actionName: "regression-compileMelPatch-object-first-coalesce-merge",
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.ops).toHaveLength(1);
+  });
+
   it("supports unary minus in patch expressions", () => {
     const melText = `
       patch delta = -input.amount

--- a/packages/compiler/src/__tests__/compile-mel-patch.test.ts
+++ b/packages/compiler/src/__tests__/compile-mel-patch.test.ts
@@ -740,6 +740,45 @@ describe("compileMelPatch", () => {
     });
   });
 
+  it("rejects object spread operands that deterministically yield arrays in patch expressions", () => {
+    const melText = `
+      patch draft = {
+        ...coalesce([], []),
+        submissionState: "submitted"
+      }
+    `;
+
+    const result = compileMelPatch(melText, {
+      mode: "patch",
+      actionName: "regression-compileMelPatch-array-valued-object-spread",
+    });
+
+    expect(result.ops).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      code: "E_TYPE_MISMATCH",
+      message: "Object spread operands must be object-shaped or T | null where T is object-shaped",
+    });
+  });
+
+  it("rejects merge operands that deterministically yield arrays in patch expressions", () => {
+    const melText = `
+      patch draft = merge(cond(true, [], []))
+    `;
+
+    const result = compileMelPatch(melText, {
+      mode: "patch",
+      actionName: "regression-compileMelPatch-array-valued-merge",
+    });
+
+    expect(result.ops).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      code: "E_TYPE_MISMATCH",
+      message: "Object spread operands must be object-shaped or T | null where T is object-shaped",
+    });
+  });
+
   it("supports unary minus in patch expressions", () => {
     const melText = `
       patch delta = -input.amount

--- a/packages/compiler/src/__tests__/compliance/ccts-coverage.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-coverage.ts
@@ -21,6 +21,7 @@ export const CCTS_CASES = {
   GRAMMAR_CANONICAL_SURFACE: "CCTS-GRAM-002",
   GRAMMAR_INVALID_SYSTEM_REF: "CCTS-GRAM-003",
   GRAMMAR_ONCE_INTENT_CONTEXTUAL: "CCTS-GRAM-004",
+  GRAMMAR_OBJECT_SPREAD_BOUNDARY: "CCTS-GRAM-005",
 
   ANNOTATIONS_SURFACE: "CCTS-ANN-001",
   ANNOTATIONS_PAYLOAD: "CCTS-ANN-002",
@@ -43,6 +44,8 @@ export const CCTS_CASES = {
   STATE_COALESCE_NARROWING: "CCTS-STATE-009",
   STATE_VALUES_RECORD_TYPING: "CCTS-STATE-010",
   STATE_ARG_SELECTION_COVERAGE: "CCTS-STATE-011",
+  STATE_OBJECT_SPREAD_TYPING: "CCTS-STATE-012",
+  STATE_OBJECT_SPREAD_CONSUME: "CCTS-STATE-013",
 
   ACTIONS_GUARDED_BODY: "CCTS-ACT-001",
   ACTIONS_ONCE_DESUGARING: "CCTS-ACT-002",
@@ -64,6 +67,7 @@ export const CCTS_CASES = {
   IR_MATCH_SUGAR: "CCTS-IR-011",
   IR_ARG_SELECTION_SUGAR: "CCTS-IR-012",
   IR_SUGAR_DIAGNOSTICS: "CCTS-IR-013",
+  IR_OBJECT_SPREAD_LOWERING: "CCTS-IR-014",
 
   FLOW_COMPOSITION: "CCTS-FLOW-001",
   FLOW_VALIDATION: "CCTS-FLOW-002",
@@ -86,12 +90,13 @@ export const COMPILER_COMPLIANCE_CASES: readonly CompilerComplianceCase[] = [
   complianceCase(CCTS_CASES.GRAMMAR_CANONICAL_SURFACE, "grammar", "Non-canonical surface syntax is rejected."),
   complianceCase(CCTS_CASES.GRAMMAR_INVALID_SYSTEM_REF, "grammar", "Invalid system references are diagnosed."),
   complianceCase(CCTS_CASES.GRAMMAR_ONCE_INTENT_CONTEXTUAL, "grammar", "onceIntent is parsed contextually."),
+  complianceCase(CCTS_CASES.GRAMMAR_OBJECT_SPREAD_BOUNDARY, "grammar", "Current object-spread surface and adjacent JS-form boundaries are enforced in compliance."),
 
-  complianceCase(CCTS_CASES.ANNOTATIONS_SURFACE, "annotations", "@meta target placement, sibling sidecar target-key shape, and tooling sidecar emission determinism are staged."),
-  complianceCase(CCTS_CASES.ANNOTATIONS_PAYLOAD, "annotations", "@meta payload literal-only and depth constraints are staged."),
-  complianceCase(CCTS_CASES.ANNOTATIONS_INVARIANTS, "annotations", "Tooling sidecar semantic erasure invariants are staged."),
-  complianceCase(CCTS_CASES.ANNOTATIONS_RUNTIME_BOUNDARY, "annotations", "Tooling-only DomainModule runtime-boundary guards are staged."),
-  complianceCase(CCTS_CASES.ANNOTATIONS_DIAGNOSTICS, "annotations", "Annotation and source-map diagnostic families are staged."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_SURFACE, "annotations", "@meta target placement, sibling sidecar target-key shape, and tooling sidecar emission determinism are enforced."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_PAYLOAD, "annotations", "@meta payload literal-only and depth constraints are enforced."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_INVARIANTS, "annotations", "Tooling sidecar semantic erasure invariants are enforced."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_RUNTIME_BOUNDARY, "annotations", "Tooling-only DomainModule runtime-boundary guards are enforced."),
+  complianceCase(CCTS_CASES.ANNOTATIONS_DIAGNOSTICS, "annotations", "Annotation and source-map diagnostic families are enforced."),
 
   complianceCase(CCTS_CASES.CONTEXT_COMPUTED_SYSTEM, "context", "$system is rejected in computed expressions."),
   complianceCase(CCTS_CASES.CONTEXT_STATE_INIT_SYSTEM, "context", "$system is rejected in state initializers."),
@@ -108,6 +113,8 @@ export const COMPILER_COMPLIANCE_CASES: readonly CompilerComplianceCase[] = [
   complianceCase(CCTS_CASES.STATE_COALESCE_NARROWING, "state-and-computed", "coalesce narrows compatible nullable branches for downstream typing."),
   complianceCase(CCTS_CASES.STATE_VALUES_RECORD_TYPING, "state-and-computed", "values(Record<string, T>) preserves typed collection flow semantics."),
   complianceCase(CCTS_CASES.STATE_ARG_SELECTION_COVERAGE, "state-and-computed", "argmax/argmin keep nullable labels only when candidate eligibility is not exhaustively covered."),
+  complianceCase(CCTS_CASES.STATE_OBJECT_SPREAD_TYPING, "state-and-computed", "Current object-spread typing and patch assignability are enforced."),
+  complianceCase(CCTS_CASES.STATE_OBJECT_SPREAD_CONSUME, "state-and-computed", "Current optional spread-field consumption rules are enforced."),
 
   complianceCase(CCTS_CASES.ACTIONS_GUARDED_BODY, "actions-and-control", "Action mutations remain guarded."),
   complianceCase(CCTS_CASES.ACTIONS_ONCE_DESUGARING, "actions-and-control", "once() desugars to intent-guarded marker writes."),
@@ -129,6 +136,7 @@ export const COMPILER_COMPLIANCE_CASES: readonly CompilerComplianceCase[] = [
   complianceCase(CCTS_CASES.IR_MATCH_SUGAR, "lowering-and-ir", "match() remains finite literal-key branch sugar with source-order lowering."),
   complianceCase(CCTS_CASES.IR_ARG_SELECTION_SUGAR, "lowering-and-ir", "argmax()/argmin() remain fixed-candidate deterministic selection sugar."),
   complianceCase(CCTS_CASES.IR_SUGAR_DIAGNOSTICS, "lowering-and-ir", "Bounded sugar shape diagnostics remain visible."),
+  complianceCase(CCTS_CASES.IR_OBJECT_SPREAD_LOWERING, "lowering-and-ir", "Current object-spread lowering and direct merge parity are enforced."),
 
   complianceCase(CCTS_CASES.FLOW_COMPOSITION, "flow-composition", "flow/include remains compile-time composition only."),
   complianceCase(CCTS_CASES.FLOW_VALIDATION, "flow-composition", "Flow declaration and include contracts are tracked."),
@@ -182,10 +190,14 @@ export const COMPILER_RULE_COVERAGE: readonly CompilerComplianceCoverageEntry[] 
   ...coverMany(["PATCH-MERGE-1"], [CCTS_CASES.STATE_PATCH_MERGE]),
   ...coverMany(["COALESCE-1"], [CCTS_CASES.STATE_COALESCE_NARROWING]),
   ...coverMany(["COLLECT-VALUES-1"], [CCTS_CASES.STATE_VALUES_RECORD_TYPING]),
+  ...coverMany(["SPREAD-OPERAND-1", "SPREAD-PATCH-1", "SPREAD-PRESENCE-1"], [CCTS_CASES.STATE_OBJECT_SPREAD_TYPING]),
+  ...coverMany(["SPREAD-CONSUME-1"], [CCTS_CASES.STATE_OBJECT_SPREAD_CONSUME]),
   ...coverMany(["MEL-SUGAR-4"], [CCTS_CASES.IR_ARG_SELECTION_SUGAR, CCTS_CASES.STATE_ARG_SELECTION_COVERAGE]),
 
   ...coverMany(["COMPILER-MEL-1"], [CCTS_CASES.ACTIONS_ONCE_INTENT_DESUGARING]),
   ...coverMany(["COMPILER-MEL-3"], [CCTS_CASES.GRAMMAR_ONCE_INTENT_CONTEXTUAL]),
+  ...coverMany(["SPREAD-SURFACE-1", "SPREAD-DIAG-1"], [CCTS_CASES.GRAMMAR_OBJECT_SPREAD_BOUNDARY]),
+  ...coverMany(["SPREAD-LOWER-1", "SPREAD-MERGE-TYPE-1"], [CCTS_CASES.IR_OBJECT_SPREAD_LOWERING]),
 
   ...coverMany(["FLOW-PARAM-1", "FLOW-PARAM-2", "FLOW-CALL-1", "FLOW-CALL-2", "E013", "E014", "E015", "E016", "E017", "E018", "E019", "E020", "E021", "E022", "E023", "E024"], [CCTS_CASES.FLOW_VALIDATION]),
 

--- a/packages/compiler/src/__tests__/compliance/ccts-rules.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-rules.ts
@@ -43,6 +43,7 @@ export const COMPILER_COMPLIANCE_RULES: readonly CompilerComplianceRule[] = [
   ...registryMany(["TYPE-LOWER-1", "TYPE-LOWER-2", "TYPE-LOWER-3", "TYPE-LOWER-4", "TYPE-LOWER-5"], "blocking"),
   ...registryMany(["TYPE-LOWER-6", "TYPE-LOWER-7", "TYPE-LOWER-8", "TYPE-LOWER-9"], "blocking"),
   ...registryMany(["PATCH-MERGE-1", "COALESCE-1", "COLLECT-VALUES-1"], "blocking"),
+  ...registryMany(["SPREAD-OPERAND-1", "SPREAD-PATCH-1", "SPREAD-PRESENCE-1", "SPREAD-CONSUME-1"], "blocking"),
   ...registryMany(["SGRAPH-1", "SGRAPH-2", "SGRAPH-3", "SGRAPH-4", "SGRAPH-5", "SGRAPH-6", "SGRAPH-7", "SGRAPH-8", "SGRAPH-9", "SGRAPH-10", "SGRAPH-11", "SGRAPH-12", "SGRAPH-13", "SGRAPH-14", "SGRAPH-15"], "blocking"),
 
   ...registryMany(["ENTITY-1", "ENTITY-2", "ENTITY-2a", "ENTITY-2b", "ENTITY-3", "ENTITY-4", "ENTITY-5", "ENTITY-7", "ENTITY-8", "ENTITY-9"], "blocking"),
@@ -52,6 +53,7 @@ export const COMPILER_COMPLIANCE_RULES: readonly CompilerComplianceRule[] = [
   registry("COMPILER-MEL-2a", "informational"),
   registry("COMPILER-MEL-4", "blocking"),
   ...registryMany(["MEL-SUGAR-1", "MEL-SUGAR-2", "MEL-SUGAR-3", "MEL-SUGAR-4"], "blocking"),
+  ...registryMany(["SPREAD-LOWER-1", "SPREAD-MERGE-TYPE-1"], "blocking"),
 
   ...registryMany(["META-1", "META-2", "META-3", "META-4", "META-5", "META-6", "META-7", "META-8", "META-9", "META-10"], "blocking"),
   ...registryMany(["INV-META-1", "INV-META-2", "INV-META-3", "INV-META-4", "INV-META-5", "INV-META-6"], "blocking"),
@@ -62,6 +64,7 @@ export const COMPILER_COMPLIANCE_RULES: readonly CompilerComplianceRule[] = [
   registry("SCHEMA-RESERVED-1", "blocking"),
 
   ...registryMany(["E001", "E002", "E003", "E004", "E005", "E009", "E010", "E011"], "blocking"),
+  ...registryMany(["SPREAD-SURFACE-1", "SPREAD-DIAG-1"], "blocking"),
   ...registryMany(["E006", "E007", "E008"], "blocking"),
   ...registryMany(["E012", "E013", "E014", "E015", "E016", "E017", "E018", "E019", "E020", "E021", "E022", "E023", "E024", "E030", "E030a", "E030b", "E031", "E032", "E033", "E034", "E035", "E041", "E042", "E043", "E044", "E049", "E050", "E051", "E052"], "blocking"),
   ...registryMany(["E053", "E054", "E055", "E056", "E057", "E058"], "blocking"),

--- a/packages/compiler/src/__tests__/compliance/ccts-spec-inventory.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-spec-inventory.ts
@@ -81,6 +81,18 @@ export const COMPILER_SPEC_INVENTORY: readonly CompilerComplianceInventoryItem[]
   inventory("PATCH-MERGE-1", "docs/mel/REFERENCE.md `patch merge` / docs/mel/SYNTAX.md `patch path merge expr`", "MUST", "state-and-computed"),
   inventory("COALESCE-1", "docs/mel/REFERENCE.md `coalesce(a, b, ...)`", "MUST", "state-and-computed"),
   inventory("COLLECT-VALUES-1", "docs/mel/REFERENCE.md `values(obj)` / docs/mel/SYNTAX.md computed examples", "MUST", "state-and-computed"),
+  inventory("SPREAD-OPERAND-1", "§5.2 Typing rules", "MUST", "state-and-computed", {
+    notes: "Object-literal spread operands must be object-shaped or `T | null` where `T` is object-shaped.",
+  }),
+  inventory("SPREAD-PATCH-1", "§5.2 Normative rules / Typing rules", "MUST", "state-and-computed", {
+    notes: "`patch path = { ...expr, key: value }` remains a set patch checked against the target type.",
+  }),
+  inventory("SPREAD-PRESENCE-1", "§5.2 Typing rules", "MUST", "state-and-computed", {
+    notes: "Spread result typing is presence-aware; optional contributors do not satisfy required targets without a later unconditional contribution.",
+  }),
+  inventory("SPREAD-CONSUME-1", "§5.2 Typing rules", "MUST", "state-and-computed", {
+    notes: "Direct reads from optional spread-result fields are observed as `T | null` and require explicit normalization for non-null sinks.",
+  }),
   ...inventoryMany(["SGRAPH-1", "SGRAPH-2", "SGRAPH-3", "SGRAPH-4", "SGRAPH-5", "SGRAPH-6", "SGRAPH-7", "SGRAPH-8", "SGRAPH-9", "SGRAPH-10", "SGRAPH-11", "SGRAPH-12", "SGRAPH-13", "SGRAPH-14"], "SPEC v0.8.0 §6/§7/§8", "MUST", "introspection"),
   inventory("SGRAPH-15", "SPEC v0.8.0 §6", "SHOULD", "introspection"),
 
@@ -94,6 +106,12 @@ export const COMPILER_SPEC_INVENTORY: readonly CompilerComplianceInventoryItem[]
   }),
 
   ...inventoryMany(["MEL-SUGAR-1", "MEL-SUGAR-2", "MEL-SUGAR-3", "MEL-SUGAR-4"], "§5.1", "MUST", "lowering-and-ir"),
+  inventory("SPREAD-LOWER-1", "§5.2 Normative rules", "MUST", "lowering-and-ir", {
+    notes: "Object-literal spread lowers to canonical `merge(...)` with source order preserved.",
+  }),
+  inventory("SPREAD-MERGE-TYPE-1", "§5.2 Typing rules", "MUST", "lowering-and-ir", {
+    notes: "Direct `merge()` typing must stay aligned with the lowered spread form.",
+  }),
 
   ...inventoryMany(["META-1", "META-2", "META-3", "META-4", "META-5", "META-6", "META-7", "META-8", "META-9", "META-10"], "§8.2-§8.4", "MUST", "annotations"),
   ...inventoryMany(["INV-META-1", "INV-META-2", "INV-META-3", "INV-META-4", "INV-META-5", "INV-META-6"], "§8.4", "CRITICAL", "annotations"),
@@ -103,6 +121,12 @@ export const COMPILER_SPEC_INVENTORY: readonly CompilerComplianceInventoryItem[]
 
   ...inventoryMany(["E001", "E002"], "§11.6", "MUST", "context"),
   ...inventoryMany(["E003", "E004"], "§11.6", "MUST", "grammar"),
+  inventory("SPREAD-SURFACE-1", "§5.2", "MUST", "grammar", {
+    notes: "Object-literal spread is the sole bounded parser-level shorthand admitted in current MEL.",
+  }),
+  inventory("SPREAD-DIAG-1", "§5.2 / §9", "MUST", "grammar", {
+    notes: "Adjacent JS-like forms around spread must remain rejected with spread-specific diagnostics.",
+  }),
   inventory("E005", "§13.6", "MUST", "context"),
   ...inventoryMany(["E006", "E007", "E008", "E009", "E010", "E011"], "§13.6", "MUST", "actions-and-control"),
   inventory("E012", "§13.6", "MUST", "state-and-computed"),

--- a/packages/compiler/src/__tests__/compliance/suite/entity-primitives.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/entity-primitives.spec.ts
@@ -282,6 +282,18 @@ describe("CCTS Entity Primitive Suite", () => {
         computed selected = findById(tasks, "task-1")
       }
     `);
+    const duplicateSpreadInitializer = adapter.compile(`
+      domain Demo {
+        type Task = { id: string, title: string }
+        state {
+          tasks: Array<Task> = [
+            { ...{ id: "task-1" }, title: "A" },
+            { ...{ id: "task-1" }, title: "B" }
+          ]
+        }
+        computed selected = findById(tasks, "task-1")
+      }
+    `);
 
     expectAllCompliance([
       evaluateRule(getRuleOrThrow("ENTITY-2"), hasDiagnosticCode(missingId.errors, "E030"), {
@@ -313,6 +325,11 @@ describe("CCTS Entity Primitive Suite", () => {
         passMessage: "E030b diagnoses duplicate entity ids in state initializers.",
         failMessage: "E030b is not emitted for duplicate entity ids in state initializers.",
         evidence: diagnosticEvidence(duplicateInitializer.errors),
+      }),
+      evaluateRule(getRuleOrThrow("E030b"), hasDiagnosticCode(duplicateSpreadInitializer.errors, "E030b"), {
+        passMessage: "E030b diagnoses duplicate entity ids introduced through initializer spreads.",
+        failMessage: "E030b is not emitted for duplicate entity ids introduced through initializer spreads.",
+        evidence: diagnosticEvidence(duplicateSpreadInitializer.errors),
       }),
     ]);
   });

--- a/packages/compiler/src/__tests__/compliance/suite/grammar.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/grammar.spec.ts
@@ -132,4 +132,65 @@ describe("CCTS Grammar Suite", () => {
       }),
     ]);
   });
+
+  it(caseTitle(CCTS_CASES.GRAMMAR_OBJECT_SPREAD_BOUNDARY, "(SPREAD-SURFACE-1/SPREAD-DIAG-1) object-spread surface and boundary diagnostics are enforced"), () => {
+    const surfaceResult = adapter.compile(`
+      domain Demo {
+        type Profile = { name: string }
+
+        state {
+          profile: Profile = { name: "" }
+        }
+
+        computed copy = { ...profile, name: "next" }
+      }
+    `);
+    const arraySpreadResult = adapter.compile(`
+      domain Demo {
+        computed copy = [...items]
+      }
+    `);
+    const computedKeyResult = adapter.compile(`
+      domain Demo {
+        state {
+          name: string = ""
+        }
+
+        computed keyed = { [name]: 1 }
+      }
+    `);
+    const optionalChainingResult = adapter.compile(`
+      domain Demo {
+        type Profile = { name: string }
+
+        state {
+          profile: Profile = { name: "" }
+        }
+
+        computed maybeName = profile?.name
+      }
+    `);
+    const boundaryDiagnosticsHold = [arraySpreadResult, computedKeyResult, optionalChainingResult].every((result) =>
+      result.errors.some((diagnostic) =>
+        diagnostic.message.includes("Object spread is the only bounded JavaScript-like sugar admitted in current MEL.")
+      )
+    );
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("SPREAD-SURFACE-1"), surfaceResult.success, {
+        passMessage: "Object-literal spread is admitted as the bounded v1.2 parser-level shorthand.",
+        failMessage: "Object-literal spread is not admitted even though SPEC v1.2 declares it current.",
+        evidence: diagnosticEvidence(surfaceResult.errors),
+      }),
+      evaluateRule(getRuleOrThrow("SPREAD-DIAG-1"), boundaryDiagnosticsHold, {
+        passMessage: "Adjacent JS-like forms around object spread remain rejected.",
+        failMessage: "Adjacent JS-like forms around object spread were not rejected.",
+        evidence: [
+          ...diagnosticEvidence(arraySpreadResult.errors),
+          ...diagnosticEvidence(computedKeyResult.errors),
+          ...diagnosticEvidence(optionalChainingResult.errors),
+        ],
+      }),
+    ]);
+  });
 });

--- a/packages/compiler/src/__tests__/compliance/suite/lowering-and-ir.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/lowering-and-ir.spec.ts
@@ -1216,4 +1216,70 @@ describe("CCTS Lowering and IR Suite", () => {
       }),
     ]);
   });
+
+  it(caseTitle(CCTS_CASES.IR_OBJECT_SPREAD_LOWERING, "(SPREAD-LOWER-1/SPREAD-MERGE-TYPE-1) object-spread lowering and merge parity are enforced"), () => {
+    const source = `
+      domain Demo {
+        type Draft = {
+          customerId: string,
+          appliedCouponId: string | null,
+          submissionState: "idle" | "submitted"
+        }
+
+        state {
+          draft: Draft = {
+            customerId: "",
+            appliedCouponId: null,
+            submissionState: "idle"
+          }
+        }
+
+        computed spreadSubmitted = {
+          ...draft,
+          submissionState: "submitted"
+        }
+
+        computed mergeSubmitted = merge(
+          draft,
+          {
+            submissionState: "submitted"
+          }
+        )
+      }
+    `;
+    const canonical = adapter.canonical(source);
+    const compiled = adapter.compile(source);
+    const spreadExpr = canonical.value?.computed.fields["spreadSubmitted"]?.expr;
+    const mergeExpr = canonical.value?.computed.fields["mergeSubmitted"]?.expr;
+    const runtimeSpread = compiled.value?.computed.fields["spreadSubmitted"]?.expr;
+    const runtimeMerge = compiled.value?.computed.fields["mergeSubmitted"]?.expr;
+    const loweredToMerge =
+      canonical.success &&
+      spreadExpr?.kind === "call" &&
+      spreadExpr.fn === "merge";
+    const runtimeParity =
+      compiled.success &&
+      JSON.stringify(runtimeSpread) === JSON.stringify(runtimeMerge);
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("SPREAD-LOWER-1"), loweredToMerge, {
+        passMessage: "Object-literal spread lowers to canonical merge(...) calls.",
+        failMessage: "Object-literal spread is not lowering through canonical merge(...).",
+        evidence: [
+          noteEvidence("Observed spread canonical expr", spreadExpr ?? null),
+          ...diagnosticEvidence(canonical.errors),
+        ],
+      }),
+      evaluateRule(getRuleOrThrow("SPREAD-MERGE-TYPE-1"), runtimeParity, {
+        passMessage: "Direct merge() typing and lowered spread form remain aligned.",
+        failMessage: "Direct merge() and lowered spread form do not share one observable lowering/type path.",
+        evidence: [
+          noteEvidence("Observed merge canonical expr", mergeExpr ?? null),
+          noteEvidence("Observed spread runtime expr", runtimeSpread ?? null),
+          noteEvidence("Observed merge runtime expr", runtimeMerge ?? null),
+          ...diagnosticEvidence(compiled.errors),
+        ],
+      }),
+    ]);
+  });
 });

--- a/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/state-and-computed.spec.ts
@@ -768,4 +768,97 @@ describe("CCTS State and Computed Suite", () => {
       }),
     ]);
   });
+
+  it(caseTitle(CCTS_CASES.STATE_OBJECT_SPREAD_TYPING, "(SPREAD-OPERAND-1/SPREAD-PATCH-1/SPREAD-PRESENCE-1) object-spread typing and patch assignability are enforced"), () => {
+    const result = adapter.compile(`
+      domain Demo {
+        type Draft = {
+          customerId: string,
+          appliedCouponId: string | null,
+          submissionState: "idle" | "submitted"
+        }
+
+        state {
+          draft: Draft | null = null
+        }
+
+        action submit(customerId: string) {
+          onceIntent {
+            patch draft = {
+              ...draft,
+              customerId: customerId,
+              appliedCouponId: null,
+              submissionState: "submitted"
+            }
+          }
+        }
+      }
+    `);
+    const invalidStateInitializerResult = adapter.compile(`
+      domain Demo {
+        type Config = {
+          theme: string
+        }
+
+        state {
+          cfg: Config = {
+            ...1,
+            theme: "light"
+          }
+        }
+      }
+    `);
+    const operandSurfaceHolds =
+      result.success &&
+      !invalidStateInitializerResult.success &&
+      hasDiagnosticCode(invalidStateInitializerResult.diagnostics, ["E_TYPE_MISMATCH"]);
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("SPREAD-OPERAND-1"), operandSurfaceHolds, {
+        passMessage: "Object-literal spread accepts nullable object operands and rejects non-object state-initializer operands.",
+        failMessage: "Object-literal spread operand validation still leaks or rejects part of the v1.2 surface.",
+        evidence: [
+          ...diagnosticEvidence(result.errors),
+          ...diagnosticEvidence(invalidStateInitializerResult.errors),
+        ],
+      }),
+      evaluateRule(getRuleOrThrow("SPREAD-PATCH-1"), result.success, {
+        passMessage: "Spread-backed object literals are accepted in set-patch assignment positions.",
+        failMessage: "Set-patch object literals using spread are still blocked.",
+        evidence: diagnosticEvidence(result.errors),
+      }),
+      evaluateRule(getRuleOrThrow("SPREAD-PRESENCE-1"), result.success, {
+        passMessage: "Presence-aware typing for spread-backed objects accepts explicit unconditional contributions.",
+        failMessage: "Presence-aware spread typing did not hold for the current v1.2 contract.",
+        evidence: diagnosticEvidence(result.errors),
+      }),
+    ]);
+  });
+
+  it(caseTitle(CCTS_CASES.STATE_OBJECT_SPREAD_CONSUME, "(SPREAD-CONSUME-1) optional spread-result reads require explicit normalization"), () => {
+    const result = adapter.compile(`
+      domain Demo {
+        type Draft = {
+          customerId: string,
+          appliedCouponId: string | null,
+          submissionState: "idle" | "submitted"
+        }
+
+        state {
+          draft: Draft | null = null
+        }
+
+        computed partialDraft = { ...draft }
+        computed safeCustomerId = coalesce(partialDraft.customerId, "guest")
+      }
+    `);
+
+    expectAllCompliance([
+      evaluateRule(getRuleOrThrow("SPREAD-CONSUME-1"), result.success, {
+        passMessage: "Optional fields introduced by spread can be observed as nullable values and normalized explicitly.",
+        failMessage: "Spread-result consumption did not satisfy the current optional-read contract.",
+        evidence: diagnosticEvidence(result.errors),
+      }),
+    ]);
+  });
 });

--- a/packages/compiler/src/__tests__/evaluation.test.ts
+++ b/packages/compiler/src/__tests__/evaluation.test.ts
@@ -132,6 +132,18 @@ describe("evaluateExpr", () => {
         null
       );
     });
+
+    it("should return null for missing meta intent and action paths", () => {
+      const ctx = createTestContext({
+        meta: {} as EvaluationContext["meta"],
+      });
+      expect(evaluateExpr({ kind: "get", path: "meta.intentId" }, ctx)).toBe(
+        null
+      );
+      expect(evaluateExpr({ kind: "get", path: "meta.actionName" }, ctx)).toBe(
+        null
+      );
+    });
   });
 
   describe("comparison operators", () => {

--- a/packages/compiler/src/analyzer/entity-primitives.ts
+++ b/packages/compiler/src/analyzer/entity-primitives.ts
@@ -234,7 +234,15 @@ function validateExpr(
 
     case "objectLiteral":
       for (const property of expr.properties) {
-        validateExpr(property.value, context, env, symbols, diagnostics, dedupe, transformDepth);
+        validateExpr(
+          property.kind === "objectProperty" ? property.value : property.expr,
+          context,
+          env,
+          symbols,
+          diagnostics,
+          dedupe,
+          transformDepth
+        );
       }
       break;
 
@@ -392,7 +400,10 @@ function validateFieldInitializerUniqueness(
       continue;
     }
 
-    const idProp = element.properties.find((property) => property.key === "id");
+    const idProp = element.properties.find(
+      (property): property is Extract<typeof property, { kind: "objectProperty" }> =>
+        property.kind === "objectProperty" && property.key === "id"
+    );
     if (!idProp || idProp.value.kind !== "literal") {
       continue;
     }

--- a/packages/compiler/src/analyzer/entity-primitives.ts
+++ b/packages/compiler/src/analyzer/entity-primitives.ts
@@ -29,6 +29,11 @@ const ENTITY_PRIMITIVE_FNS = new Set([
 
 type ExprContext = "computed" | "action" | "guard" | "available" | "dispatchable" | "patch";
 
+type LiteralEntityIdResolution =
+  | { kind: "literal"; value: string | number; location: Diagnostic["location"] }
+  | { kind: "absent" }
+  | { kind: "unknown" };
+
 function addDiagnostic(
   diagnostics: Diagnostic[],
   dedupe: Set<string>,
@@ -400,22 +405,12 @@ function validateFieldInitializerUniqueness(
       continue;
     }
 
-    const idProp = element.properties.find(
-      (property): property is Extract<typeof property, { kind: "objectProperty" }> =>
-        property.kind === "objectProperty" && property.key === "id"
-    );
-    if (!idProp || idProp.value.kind !== "literal") {
+    const id = resolveLiteralEntityId(element);
+    if (id.kind !== "literal") {
       continue;
     }
 
-    if (
-      typeof idProp.value.value !== "string" &&
-      typeof idProp.value.value !== "number"
-    ) {
-      continue;
-    }
-
-    const key = `${typeof idProp.value.value}:${String(idProp.value.value)}`;
+    const key = `${typeof id.value}:${String(id.value)}`;
     const previous = seen.get(key);
     if (previous) {
       addDiagnostic(
@@ -423,12 +418,51 @@ function validateFieldInitializerUniqueness(
         dedupe,
         "E030b",
         "Duplicate '.id' values detected in state initializer.",
-        idProp.value.location
+        id.location
       );
       continue;
     }
-    seen.set(key, idProp.value.location);
+    seen.set(key, id.location);
   }
+}
+
+function resolveLiteralEntityId(
+  expr: ExprNode
+): LiteralEntityIdResolution {
+  if (expr.kind !== "objectLiteral") {
+    return { kind: "unknown" };
+  }
+
+  let current: LiteralEntityIdResolution = { kind: "absent" };
+  for (const property of expr.properties) {
+    if (property.kind === "objectProperty") {
+      if (property.key !== "id") {
+        continue;
+      }
+
+      if (
+        property.value.kind === "literal" &&
+        (typeof property.value.value === "string" || typeof property.value.value === "number")
+      ) {
+        current = {
+          kind: "literal",
+          value: property.value.value,
+          location: property.value.location,
+        };
+        continue;
+      }
+
+      current = { kind: "unknown" };
+      continue;
+    }
+
+    const spreadId = resolveLiteralEntityId(property.expr);
+    if (spreadId.kind !== "absent") {
+      current = spreadId;
+    }
+  }
+
+  return current;
 }
 
 function getCollectionElementType(

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -15,7 +15,7 @@ import type { SpreadOperandClassification } from "./object-contribution-types.js
 export type {
   SpreadOperandClassification,
 } from "./object-contribution-types.js";
-export { isDefinitelyArrayExpr } from "./object-contribution-types.js";
+export { mayYieldArrayExpr } from "./object-contribution-types.js";
 
 export type TypeEnv = Map<string, TypeExprNode>;
 export type ComparableSurfaceClass = "primitive" | "nonprimitive" | "unknown";

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -6,6 +6,15 @@ import type {
   TypeDeclNode,
   TypeExprNode,
 } from "../parser/ast.js";
+import {
+  classifySpreadOperandType as classifySpreadOperandTypeWithResolver,
+  inferMergeContributionType,
+  inferObjectLiteralContributionType,
+} from "./object-contribution-types.js";
+import type { SpreadOperandClassification } from "./object-contribution-types.js";
+export type {
+  SpreadOperandClassification,
+} from "./object-contribution-types.js";
 
 export type TypeEnv = Map<string, TypeExprNode>;
 export type ComparableSurfaceClass = "primitive" | "nonprimitive" | "unknown";
@@ -151,25 +160,7 @@ export function inferExprType(
       return getIndexType(inferExprType(expr.object, env, symbols), symbols);
 
     case "objectLiteral":
-      return {
-        kind: "objectType",
-        fields: expr.properties
-          .map((property) => {
-            const propertyType = inferExprType(property.value, env, symbols);
-            if (!propertyType) {
-              return null;
-            }
-            return {
-              kind: "typeField" as const,
-              name: property.key,
-              typeExpr: propertyType,
-              optional: false,
-              location: property.location,
-            };
-          })
-          .filter((field): field is NonNullable<typeof field> => field !== null),
-        location: expr.location,
-      };
+      return inferObjectLiteralContributionType(expr, env, symbols, inferExprType, resolveType);
 
     case "arrayLiteral": {
       const elementType = joinTypeCandidates(
@@ -371,7 +362,16 @@ export function getPropertyType(
 
   if (resolved.kind === "objectType") {
     const field = resolved.fields.find((candidate) => candidate.name === property);
-    return field?.typeExpr ?? null;
+    if (!field) {
+      return null;
+    }
+    if (!field.optional) {
+      return field.typeExpr;
+    }
+    return joinTypeCandidates(
+      [field.typeExpr, simpleType("null", field.location)],
+      field.location
+    );
   }
 
   if (resolved.kind === "unionType") {
@@ -466,6 +466,13 @@ export function isNullType(typeExpr: TypeExprNode): boolean {
     (typeExpr.kind === "simpleType" && typeExpr.name === "null") ||
     (typeExpr.kind === "literalType" && typeExpr.value === null)
   );
+}
+
+export function classifySpreadOperandType(
+  typeExpr: TypeExprNode | null,
+  symbols: DomainTypeSymbols
+): SpreadOperandClassification {
+  return classifySpreadOperandTypeWithResolver(typeExpr, symbols, resolveType);
 }
 
 function inferComputedType(name: string, symbols: DomainTypeSymbols): TypeExprNode | null {
@@ -666,6 +673,10 @@ function inferFunctionCallType(
     return inferValuesType(expr, env, symbols);
   }
 
+  if (expr.name === "merge") {
+    return inferMergeContributionType(expr, env, symbols, inferExprType, resolveType);
+  }
+
   return null;
 }
 
@@ -688,7 +699,12 @@ function joinTypeCandidates(
   candidates: Array<TypeExprNode | null>,
   location: TypeExprNode["location"]
 ): TypeExprNode | null {
-  const present = candidates.filter((candidate): candidate is TypeExprNode => candidate !== null);
+  const present = candidates
+    .filter((candidate): candidate is TypeExprNode => candidate !== null)
+    .flatMap((candidate) => {
+      const flattened = candidate.kind === "unionType" ? candidate.types : [candidate];
+      return flattened;
+    });
   if (present.length === 0) {
     return null;
   }

--- a/packages/compiler/src/analyzer/expr-type-surface.ts
+++ b/packages/compiler/src/analyzer/expr-type-surface.ts
@@ -15,6 +15,7 @@ import type { SpreadOperandClassification } from "./object-contribution-types.js
 export type {
   SpreadOperandClassification,
 } from "./object-contribution-types.js";
+export { isDefinitelyArrayExpr } from "./object-contribution-types.js";
 
 export type TypeEnv = Map<string, TypeExprNode>;
 export type ComparableSurfaceClass = "primitive" | "nonprimitive" | "unknown";

--- a/packages/compiler/src/analyzer/flow-composition.ts
+++ b/packages/compiler/src/analyzer/flow-composition.ts
@@ -21,6 +21,10 @@ import type {
   TypeExprNode,
   WhenStmtNode,
 } from "../parser/ast.js";
+import {
+  inferMergeContributionType,
+  inferObjectLiteralContributionType,
+} from "./object-contribution-types.js";
 
 const MAX_INCLUDE_DEPTH = 16;
 
@@ -500,7 +504,9 @@ function cloneExprWithBindings(expr: ExprNode, bindings: ValueBindings): ExprNod
         ...cloneNode(expr),
         properties: expr.properties.map((property) => ({
           ...cloneNode(property),
-          value: cloneExprWithBindings(property.value, bindings),
+          ...(property.kind === "objectProperty"
+            ? { value: cloneExprWithBindings(property.value, bindings) }
+            : { expr: cloneExprWithBindings(property.expr, bindings) }),
         })),
       };
 
@@ -721,25 +727,7 @@ function inferExprType(expr: ExprNode, typeEnv: TypeEnv, symbols: FlowSymbols): 
     }
 
     case "objectLiteral":
-      return {
-        kind: "objectType",
-        fields: expr.properties
-          .map((property) => {
-            const propertyType = inferExprType(property.value, typeEnv, symbols);
-            if (!propertyType) {
-              return null;
-            }
-            return {
-              kind: "typeField" as const,
-              name: property.key,
-              typeExpr: propertyType,
-              optional: false,
-              location: property.location,
-            };
-          })
-          .filter((field): field is NonNullable<typeof field> => field !== null),
-        location: expr.location,
-      };
+      return inferObjectLiteralContributionType(expr, typeEnv, symbols, inferExprType, resolveType);
 
     case "arrayLiteral": {
       if (expr.elements.length === 0) {
@@ -756,8 +744,13 @@ function inferExprType(expr: ExprNode, typeEnv: TypeEnv, symbols: FlowSymbols): 
       };
     }
 
-    case "systemIdent":
     case "functionCall":
+      if (expr.name === "merge") {
+        return inferMergeContributionType(expr, typeEnv, symbols, inferExprType, resolveType);
+      }
+      return null;
+
+    case "systemIdent":
     case "binary":
     case "unary":
     case "ternary":
@@ -790,19 +783,32 @@ function getPropertyType(typeExpr: TypeExprNode | null, property: string, symbol
 
   if (resolved.kind === "objectType") {
     const field = resolved.fields.find((candidate) => candidate.name === property);
-    return field?.typeExpr ?? null;
+    if (!field) {
+      return null;
+    }
+    if (!field.optional) {
+      return field.typeExpr;
+    }
+    return joinTypeCandidates(
+      [
+        field.typeExpr,
+        {
+          kind: "simpleType",
+          name: "null",
+          location: field.location,
+        },
+      ],
+      field.location
+    );
   }
 
   if (resolved.kind === "unionType") {
-    for (const member of resolved.types) {
-      if (member.kind === "simpleType" && member.name === "null") {
-        continue;
-      }
-      const memberType = getPropertyType(member, property, symbols);
-      if (memberType) {
-        return memberType;
-      }
-    }
+    const memberTypes = resolved.types
+      .filter((member) => !isNullType(member))
+      .map((member) => getPropertyType(member, property, symbols))
+      .filter((member): member is TypeExprNode => member !== null);
+
+    return joinTypeCandidates(memberTypes, resolved.location);
   }
 
   return null;
@@ -823,15 +829,12 @@ function getIndexType(typeExpr: TypeExprNode | null, symbols: FlowSymbols): Type
   }
 
   if (resolved.kind === "unionType") {
-    for (const member of resolved.types) {
-      if (member.kind === "simpleType" && member.name === "null") {
-        continue;
-      }
-      const memberType = getIndexType(member, symbols);
-      if (memberType) {
-        return memberType;
-      }
-    }
+    const memberTypes = resolved.types
+      .filter((member) => !isNullType(member))
+      .map((member) => getIndexType(member, symbols))
+      .filter((member): member is TypeExprNode => member !== null);
+
+    return joinTypeCandidates(memberTypes, resolved.location);
   }
 
   return null;
@@ -899,6 +902,9 @@ function isAssignable(sourceType: TypeExprNode, targetType: TypeExprNode, symbol
         }
         return false;
       }
+      if (sourceField.optional && !targetField.optional) {
+        return false;
+      }
       const fieldAssignable = isAssignable(sourceField.typeExpr, targetField.typeExpr, symbols);
       if (fieldAssignable !== true) {
         return fieldAssignable;
@@ -916,6 +922,49 @@ function isAssignable(sourceType: TypeExprNode, targetType: TypeExprNode, symbol
   }
 
   return null;
+}
+
+function isNullType(typeExpr: TypeExprNode): boolean {
+  return (
+    (typeExpr.kind === "simpleType" && typeExpr.name === "null") ||
+    (typeExpr.kind === "literalType" && typeExpr.value === null)
+  );
+}
+
+function joinTypeCandidates(
+  candidates: Array<TypeExprNode | null>,
+  location: TypeExprNode["location"]
+): TypeExprNode | null {
+  const present = candidates
+    .filter((candidate): candidate is TypeExprNode => candidate !== null)
+    .flatMap((candidate) => candidate.kind === "unionType" ? candidate.types : [candidate]);
+  if (present.length === 0) {
+    return null;
+  }
+  if (present.length === 1) {
+    return present[0];
+  }
+
+  const deduped: TypeExprNode[] = [];
+  const seen = new Set<string>();
+  for (const candidate of present) {
+    const key = JSON.stringify(candidate);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(candidate);
+  }
+
+  if (deduped.length === 1) {
+    return deduped[0];
+  }
+
+  return {
+    kind: "unionType",
+    types: deduped,
+    location,
+  };
 }
 
 export function validateAndExpandFlows(program: ProgramNode): FlowExpansionResult {

--- a/packages/compiler/src/analyzer/object-contribution-types.ts
+++ b/packages/compiler/src/analyzer/object-contribution-types.ts
@@ -13,6 +13,13 @@ type ResolveType<Symbols> = (
   symbols: Symbols
 ) => TypeExprNode | null;
 
+type ExprTypeContext<Env, Symbols> = {
+  env: Env;
+  symbols: Symbols;
+  inferExprType: InferExprType<Env, Symbols>;
+  resolveType: ResolveType<Symbols>;
+};
+
 export function inferObjectLiteralContributionType<Env, Symbols>(
   expr: Extract<ExprNode, { kind: "objectLiteral" }>,
   env: Env,
@@ -119,9 +126,16 @@ export function classifySpreadOperandType<Symbols>(
   return "invalid";
 }
 
-export function mayYieldArrayExpr(expr: ExprNode | undefined): boolean {
+export function mayYieldArrayExpr<Env, Symbols>(
+  expr: ExprNode | undefined,
+  context?: ExprTypeContext<Env, Symbols>
+): boolean {
   if (!expr) {
     return false;
+  }
+
+  if (mayBeArrayType(inferResolvedExprType(expr, context), context)) {
+    return true;
   }
 
   if (expr.kind === "arrayLiteral") {
@@ -129,7 +143,7 @@ export function mayYieldArrayExpr(expr: ExprNode | undefined): boolean {
   }
 
   if (expr.kind === "ternary") {
-    return mayYieldArrayExpr(expr.consequent) || mayYieldArrayExpr(expr.alternate);
+    return mayYieldArrayExpr(expr.consequent, context) || mayYieldArrayExpr(expr.alternate, context);
   }
 
   if (expr.kind !== "functionCall") {
@@ -138,15 +152,15 @@ export function mayYieldArrayExpr(expr: ExprNode | undefined): boolean {
 
   if (expr.name === "coalesce") {
     for (const arg of expr.args) {
-      if (isDefinitelyNullExpr(arg)) {
+      if (isDefinitelyNullExpr(arg, context)) {
         continue;
       }
 
-      if (mayYieldArrayExpr(arg)) {
+      if (mayYieldArrayExpr(arg, context)) {
         return true;
       }
 
-      if (isDefinitelyNonNullExpr(arg)) {
+      if (isDefinitelyNonNullExpr(arg, context)) {
         return false;
       }
     }
@@ -155,19 +169,27 @@ export function mayYieldArrayExpr(expr: ExprNode | undefined): boolean {
   }
 
   if ((expr.name === "cond" || expr.name === "if") && expr.args.length >= 3) {
-    return mayYieldArrayExpr(expr.args[1]) || mayYieldArrayExpr(expr.args[2]);
+    return mayYieldArrayExpr(expr.args[1], context) || mayYieldArrayExpr(expr.args[2], context);
   }
 
   return false;
 }
 
-function isDefinitelyNullExpr(expr: ExprNode): boolean {
+function isDefinitelyNullExpr<Env, Symbols>(
+  expr: ExprNode,
+  context?: ExprTypeContext<Env, Symbols>
+): boolean {
+  const inferred = inferResolvedExprType(expr, context);
+  if (inferred && isDefinitelyNullType(inferred, context)) {
+    return true;
+  }
+
   if (expr.kind === "literal") {
     return expr.value === null;
   }
 
   if (expr.kind === "ternary") {
-    return isDefinitelyNullExpr(expr.consequent) && isDefinitelyNullExpr(expr.alternate);
+    return isDefinitelyNullExpr(expr.consequent, context) && isDefinitelyNullExpr(expr.alternate, context);
   }
 
   if (expr.kind !== "functionCall") {
@@ -175,17 +197,25 @@ function isDefinitelyNullExpr(expr: ExprNode): boolean {
   }
 
   if (expr.name === "coalesce") {
-    return expr.args.length > 0 && expr.args.every((arg) => isDefinitelyNullExpr(arg));
+    return expr.args.length > 0 && expr.args.every((arg) => isDefinitelyNullExpr(arg, context));
   }
 
   if ((expr.name === "cond" || expr.name === "if") && expr.args.length >= 3) {
-    return isDefinitelyNullExpr(expr.args[1]) && isDefinitelyNullExpr(expr.args[2]);
+    return isDefinitelyNullExpr(expr.args[1], context) && isDefinitelyNullExpr(expr.args[2], context);
   }
 
   return false;
 }
 
-function isDefinitelyNonNullExpr(expr: ExprNode): boolean {
+function isDefinitelyNonNullExpr<Env, Symbols>(
+  expr: ExprNode,
+  context?: ExprTypeContext<Env, Symbols>
+): boolean {
+  const inferred = inferResolvedExprType(expr, context);
+  if (inferred && isDefinitelyNonNullType(inferred, context)) {
+    return true;
+  }
+
   if (expr.kind === "literal") {
     return expr.value !== null;
   }
@@ -195,7 +225,7 @@ function isDefinitelyNonNullExpr(expr: ExprNode): boolean {
   }
 
   if (expr.kind === "ternary") {
-    return isDefinitelyNonNullExpr(expr.consequent) && isDefinitelyNonNullExpr(expr.alternate);
+    return isDefinitelyNonNullExpr(expr.consequent, context) && isDefinitelyNonNullExpr(expr.alternate, context);
   }
 
   if (expr.kind !== "functionCall") {
@@ -203,7 +233,7 @@ function isDefinitelyNonNullExpr(expr: ExprNode): boolean {
   }
 
   if (expr.name === "coalesce") {
-    return expr.args.some((arg) => isDefinitelyNonNullExpr(arg));
+    return expr.args.some((arg) => isDefinitelyNonNullExpr(arg, context));
   }
 
   if (expr.name === "merge") {
@@ -211,10 +241,88 @@ function isDefinitelyNonNullExpr(expr: ExprNode): boolean {
   }
 
   if ((expr.name === "cond" || expr.name === "if") && expr.args.length >= 3) {
-    return isDefinitelyNonNullExpr(expr.args[1]) && isDefinitelyNonNullExpr(expr.args[2]);
+    return isDefinitelyNonNullExpr(expr.args[1], context) && isDefinitelyNonNullExpr(expr.args[2], context);
   }
 
   return false;
+}
+
+function inferResolvedExprType<Env, Symbols>(
+  expr: ExprNode,
+  context?: ExprTypeContext<Env, Symbols>
+): TypeExprNode | null {
+  if (!context) {
+    return null;
+  }
+
+  return context.resolveType(
+    context.inferExprType(expr, context.env, context.symbols),
+    context.symbols
+  );
+}
+
+function mayBeArrayType<Env, Symbols>(
+  typeExpr: TypeExprNode | null,
+  context?: ExprTypeContext<Env, Symbols>
+): boolean {
+  if (!typeExpr || !context) {
+    return false;
+  }
+
+  const resolved = context.resolveType(typeExpr, context.symbols);
+  if (!resolved) {
+    return false;
+  }
+
+  if (resolved.kind === "arrayType") {
+    return true;
+  }
+
+  if (resolved.kind === "unionType") {
+    return resolved.types.some((member) => mayBeArrayType(member, context));
+  }
+
+  return false;
+}
+
+function isDefinitelyNullType<Env, Symbols>(
+  typeExpr: TypeExprNode,
+  context?: ExprTypeContext<Env, Symbols>
+): boolean {
+  if (!context) {
+    return isNullType(typeExpr);
+  }
+
+  const resolved = context.resolveType(typeExpr, context.symbols);
+  if (!resolved) {
+    return false;
+  }
+
+  if (resolved.kind === "unionType") {
+    return resolved.types.length > 0 && resolved.types.every((member) => isDefinitelyNullType(member, context));
+  }
+
+  return isNullType(resolved);
+}
+
+function isDefinitelyNonNullType<Env, Symbols>(
+  typeExpr: TypeExprNode,
+  context?: ExprTypeContext<Env, Symbols>
+): boolean {
+  if (!context) {
+    return !isNullType(typeExpr);
+  }
+
+  const resolved = context.resolveType(typeExpr, context.symbols);
+  if (!resolved) {
+    return false;
+  }
+
+  if (resolved.kind === "unionType") {
+    return resolved.types.length > 0 && resolved.types.every((member) => isDefinitelyNonNullType(member, context));
+  }
+
+  return !isNullType(resolved);
 }
 
 function mergeObjectContributionTypes<Symbols>(

--- a/packages/compiler/src/analyzer/object-contribution-types.ts
+++ b/packages/compiler/src/analyzer/object-contribution-types.ts
@@ -119,6 +119,34 @@ export function classifySpreadOperandType<Symbols>(
   return "invalid";
 }
 
+export function isDefinitelyArrayExpr(expr: ExprNode | undefined): boolean {
+  if (!expr) {
+    return false;
+  }
+
+  if (expr.kind === "arrayLiteral") {
+    return true;
+  }
+
+  if (expr.kind === "ternary") {
+    return isDefinitelyArrayExpr(expr.consequent) && isDefinitelyArrayExpr(expr.alternate);
+  }
+
+  if (expr.kind !== "functionCall") {
+    return false;
+  }
+
+  if (expr.name === "coalesce") {
+    return expr.args.length > 0 && expr.args.every((arg) => isDefinitelyArrayExpr(arg));
+  }
+
+  if ((expr.name === "cond" || expr.name === "if") && expr.args.length >= 3) {
+    return isDefinitelyArrayExpr(expr.args[1]) && isDefinitelyArrayExpr(expr.args[2]);
+  }
+
+  return false;
+}
+
 function mergeObjectContributionTypes<Symbols>(
   contributors: TypeExprNode[],
   location: TypeExprNode["location"],

--- a/packages/compiler/src/analyzer/object-contribution-types.ts
+++ b/packages/compiler/src/analyzer/object-contribution-types.ts
@@ -107,10 +107,11 @@ export function classifySpreadOperandType<Symbols>(
     return "invalid";
   }
 
-  const nonNullMembers = resolved.types
+  const resolvedMembers = resolved.types
     .map((member) => resolveType(member, symbols))
-    .filter((member): member is TypeExprNode => member !== null && !isNullType(member));
-  const hasNullBranch = resolved.types.some((member) => isNullType(member));
+    .filter((member): member is TypeExprNode => member !== null);
+  const nonNullMembers = resolvedMembers.filter((member) => !isNullType(member));
+  const hasNullBranch = resolvedMembers.some((member) => isNullType(member));
   if (hasNullBranch && nonNullMembers.length === 1 && nonNullMembers[0].kind === "objectType") {
     return "nullable-object";
   }
@@ -187,10 +188,11 @@ function getContributionFields<Symbols>(
     return null;
   }
 
-  const nonNullMembers = resolved.types
+  const resolvedMembers = resolved.types
     .map((member) => resolveType(member, symbols))
-    .filter((member): member is TypeExprNode => member !== null && !isNullType(member));
-  const hasNullBranch = resolved.types.some((member) => isNullType(member));
+    .filter((member): member is TypeExprNode => member !== null);
+  const nonNullMembers = resolvedMembers.filter((member) => !isNullType(member));
+  const hasNullBranch = resolvedMembers.some((member) => isNullType(member));
   if (!hasNullBranch || nonNullMembers.length !== 1) {
     return null;
   }

--- a/packages/compiler/src/analyzer/object-contribution-types.ts
+++ b/packages/compiler/src/analyzer/object-contribution-types.ts
@@ -119,7 +119,7 @@ export function classifySpreadOperandType<Symbols>(
   return "invalid";
 }
 
-export function isDefinitelyArrayExpr(expr: ExprNode | undefined): boolean {
+export function mayYieldArrayExpr(expr: ExprNode | undefined): boolean {
   if (!expr) {
     return false;
   }
@@ -129,7 +129,7 @@ export function isDefinitelyArrayExpr(expr: ExprNode | undefined): boolean {
   }
 
   if (expr.kind === "ternary") {
-    return isDefinitelyArrayExpr(expr.consequent) && isDefinitelyArrayExpr(expr.alternate);
+    return mayYieldArrayExpr(expr.consequent) || mayYieldArrayExpr(expr.alternate);
   }
 
   if (expr.kind !== "functionCall") {
@@ -137,11 +137,77 @@ export function isDefinitelyArrayExpr(expr: ExprNode | undefined): boolean {
   }
 
   if (expr.name === "coalesce") {
-    return expr.args.length > 0 && expr.args.every((arg) => isDefinitelyArrayExpr(arg));
+    for (const arg of expr.args) {
+      if (isDefinitelyNullExpr(arg)) {
+        continue;
+      }
+
+      if (mayYieldArrayExpr(arg)) {
+        return true;
+      }
+
+      if (isDefinitelyNonNullExpr(arg)) {
+        return false;
+      }
+    }
+
+    return false;
   }
 
   if ((expr.name === "cond" || expr.name === "if") && expr.args.length >= 3) {
-    return isDefinitelyArrayExpr(expr.args[1]) && isDefinitelyArrayExpr(expr.args[2]);
+    return mayYieldArrayExpr(expr.args[1]) || mayYieldArrayExpr(expr.args[2]);
+  }
+
+  return false;
+}
+
+function isDefinitelyNullExpr(expr: ExprNode): boolean {
+  if (expr.kind === "literal") {
+    return expr.value === null;
+  }
+
+  if (expr.kind === "ternary") {
+    return isDefinitelyNullExpr(expr.consequent) && isDefinitelyNullExpr(expr.alternate);
+  }
+
+  if (expr.kind !== "functionCall") {
+    return false;
+  }
+
+  if (expr.name === "coalesce") {
+    return expr.args.length > 0 && expr.args.every((arg) => isDefinitelyNullExpr(arg));
+  }
+
+  if ((expr.name === "cond" || expr.name === "if") && expr.args.length >= 3) {
+    return isDefinitelyNullExpr(expr.args[1]) && isDefinitelyNullExpr(expr.args[2]);
+  }
+
+  return false;
+}
+
+function isDefinitelyNonNullExpr(expr: ExprNode): boolean {
+  if (expr.kind === "literal") {
+    return expr.value !== null;
+  }
+
+  if (expr.kind === "arrayLiteral" || expr.kind === "objectLiteral") {
+    return true;
+  }
+
+  if (expr.kind === "ternary") {
+    return isDefinitelyNonNullExpr(expr.consequent) && isDefinitelyNonNullExpr(expr.alternate);
+  }
+
+  if (expr.kind !== "functionCall") {
+    return false;
+  }
+
+  if (expr.name === "coalesce") {
+    return expr.args.some((arg) => isDefinitelyNonNullExpr(arg));
+  }
+
+  if ((expr.name === "cond" || expr.name === "if") && expr.args.length >= 3) {
+    return isDefinitelyNonNullExpr(expr.args[1]) && isDefinitelyNonNullExpr(expr.args[2]);
   }
 
   return false;

--- a/packages/compiler/src/analyzer/object-contribution-types.ts
+++ b/packages/compiler/src/analyzer/object-contribution-types.ts
@@ -206,6 +206,10 @@ function isDefinitelyNonNullExpr(expr: ExprNode): boolean {
     return expr.args.some((arg) => isDefinitelyNonNullExpr(arg));
   }
 
+  if (expr.name === "merge") {
+    return true;
+  }
+
   if ((expr.name === "cond" || expr.name === "if") && expr.args.length >= 3) {
     return isDefinitelyNonNullExpr(expr.args[1]) && isDefinitelyNonNullExpr(expr.args[2]);
   }

--- a/packages/compiler/src/analyzer/object-contribution-types.ts
+++ b/packages/compiler/src/analyzer/object-contribution-types.ts
@@ -1,0 +1,250 @@
+import type { ExprNode, TypeExprNode } from "../parser/ast.js";
+
+export type SpreadOperandClassification = "object" | "nullable-object" | "invalid" | "unknown";
+
+type InferExprType<Env, Symbols> = (
+  expr: ExprNode,
+  env: Env,
+  symbols: Symbols
+) => TypeExprNode | null;
+
+type ResolveType<Symbols> = (
+  typeExpr: TypeExprNode | null,
+  symbols: Symbols
+) => TypeExprNode | null;
+
+export function inferObjectLiteralContributionType<Env, Symbols>(
+  expr: Extract<ExprNode, { kind: "objectLiteral" }>,
+  env: Env,
+  symbols: Symbols,
+  inferExprType: InferExprType<Env, Symbols>,
+  resolveType: ResolveType<Symbols>
+): TypeExprNode | null {
+  const contributors: TypeExprNode[] = [];
+  let bufferedFields: Extract<TypeExprNode, { kind: "objectType" }>["fields"] = [];
+
+  const flushBufferedFields = () => {
+    if (bufferedFields.length === 0) {
+      return;
+    }
+
+    contributors.push({
+      kind: "objectType",
+      fields: bufferedFields,
+      location: expr.location,
+    });
+    bufferedFields = [];
+  };
+
+  for (const property of expr.properties) {
+    if (property.kind === "objectProperty") {
+      const propertyType = inferExprType(property.value, env, symbols);
+      if (!propertyType) {
+        return null;
+      }
+
+      bufferedFields.push({
+        kind: "typeField",
+        name: property.key,
+        typeExpr: propertyType,
+        optional: false,
+        location: property.location,
+      });
+      continue;
+    }
+
+    flushBufferedFields();
+    const spreadType = inferExprType(property.expr, env, symbols);
+    if (!spreadType) {
+      return null;
+    }
+    contributors.push(spreadType);
+  }
+
+  flushBufferedFields();
+
+  if (contributors.length === 0) {
+    return {
+      kind: "objectType",
+      fields: [],
+      location: expr.location,
+    };
+  }
+
+  return mergeObjectContributionTypes(contributors, expr.location, symbols, resolveType);
+}
+
+export function inferMergeContributionType<Env, Symbols>(
+  expr: Extract<ExprNode, { kind: "functionCall" }>,
+  env: Env,
+  symbols: Symbols,
+  inferExprType: InferExprType<Env, Symbols>,
+  resolveType: ResolveType<Symbols>
+): TypeExprNode | null {
+  const contributors = expr.args.map((arg) => inferExprType(arg, env, symbols));
+  if (contributors.some((typeExpr) => typeExpr === null)) {
+    return null;
+  }
+
+  return mergeObjectContributionTypes(contributors as TypeExprNode[], expr.location, symbols, resolveType);
+}
+
+export function classifySpreadOperandType<Symbols>(
+  typeExpr: TypeExprNode | null,
+  symbols: Symbols,
+  resolveType: ResolveType<Symbols>
+): SpreadOperandClassification {
+  const resolved = resolveType(typeExpr, symbols);
+  if (!resolved) {
+    return "unknown";
+  }
+
+  if (resolved.kind === "objectType") {
+    return "object";
+  }
+
+  if (resolved.kind !== "unionType") {
+    return "invalid";
+  }
+
+  const nonNullMembers = resolved.types
+    .map((member) => resolveType(member, symbols))
+    .filter((member): member is TypeExprNode => member !== null && !isNullType(member));
+  const hasNullBranch = resolved.types.some((member) => isNullType(member));
+  if (hasNullBranch && nonNullMembers.length === 1 && nonNullMembers[0].kind === "objectType") {
+    return "nullable-object";
+  }
+
+  return "invalid";
+}
+
+function mergeObjectContributionTypes<Symbols>(
+  contributors: TypeExprNode[],
+  location: TypeExprNode["location"],
+  symbols: Symbols,
+  resolveType: ResolveType<Symbols>
+): TypeExprNode | null {
+  const mergedFields = new Map<string, Extract<TypeExprNode, { kind: "objectType" }>["fields"][number]>();
+
+  for (const contributor of contributors) {
+    const contributionFields = getContributionFields(contributor, symbols, resolveType);
+    if (!contributionFields) {
+      return null;
+    }
+
+    for (const field of contributionFields) {
+      const existing = mergedFields.get(field.name);
+      if (!existing) {
+        mergedFields.set(field.name, field);
+        continue;
+      }
+
+      if (!field.optional) {
+        mergedFields.set(field.name, field);
+        continue;
+      }
+
+      const mergedType = joinTypeCandidates([existing.typeExpr, field.typeExpr], field.location);
+      if (!mergedType) {
+        return null;
+      }
+
+      mergedFields.set(field.name, {
+        kind: "typeField",
+        name: field.name,
+        typeExpr: mergedType,
+        optional: existing.optional,
+        location: field.location,
+      });
+    }
+  }
+
+  return {
+    kind: "objectType",
+    fields: [...mergedFields.values()],
+    location,
+  };
+}
+
+function getContributionFields<Symbols>(
+  typeExpr: TypeExprNode,
+  symbols: Symbols,
+  resolveType: ResolveType<Symbols>
+): Extract<TypeExprNode, { kind: "objectType" }>["fields"] | null {
+  const resolved = resolveType(typeExpr, symbols);
+  if (!resolved) {
+    return null;
+  }
+
+  if (resolved.kind === "objectType") {
+    return resolved.fields.map((field) => ({
+      ...field,
+      optional: field.optional,
+    }));
+  }
+
+  if (resolved.kind !== "unionType") {
+    return null;
+  }
+
+  const nonNullMembers = resolved.types
+    .map((member) => resolveType(member, symbols))
+    .filter((member): member is TypeExprNode => member !== null && !isNullType(member));
+  const hasNullBranch = resolved.types.some((member) => isNullType(member));
+  if (!hasNullBranch || nonNullMembers.length !== 1) {
+    return null;
+  }
+
+  const onlyMember = nonNullMembers[0];
+  if (onlyMember.kind !== "objectType") {
+    return null;
+  }
+
+  return onlyMember.fields.map((field) => ({
+    ...field,
+    optional: true,
+  }));
+}
+
+function isNullType(typeExpr: TypeExprNode): boolean {
+  return (
+    (typeExpr.kind === "simpleType" && typeExpr.name === "null") ||
+    (typeExpr.kind === "literalType" && typeExpr.value === null)
+  );
+}
+
+function joinTypeCandidates(
+  candidates: Array<TypeExprNode | null>,
+  location: TypeExprNode["location"]
+): TypeExprNode | null {
+  const present = candidates
+    .filter((candidate): candidate is TypeExprNode => candidate !== null)
+    .flatMap((candidate) => candidate.kind === "unionType" ? candidate.types : [candidate]);
+  if (present.length === 0) {
+    return null;
+  }
+  if (present.length === 1) {
+    return present[0];
+  }
+
+  const deduped: TypeExprNode[] = [];
+  const seen = new Set<string>();
+  for (const candidate of present) {
+    const key = JSON.stringify(candidate);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(candidate);
+  }
+
+  if (deduped.length === 1) {
+    return deduped[0];
+  }
+
+  return {
+    kind: "unionType",
+    types: deduped,
+    location,
+  };
+}

--- a/packages/compiler/src/analyzer/scope.ts
+++ b/packages/compiler/src/analyzer/scope.ts
@@ -275,7 +275,7 @@ export class ScopeAnalyzer {
 
       case "objectLiteral":
         for (const prop of expr.properties) {
-          this.analyzeExpr(prop.value, context);
+          this.analyzeExpr(prop.kind === "objectProperty" ? prop.value : prop.expr, context);
         }
         break;
 

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -35,6 +35,7 @@ import {
   getIndexType,
   getPropertyType,
   inferExprType,
+  isDefinitelyArrayExpr,
   isNullType,
   resolveType,
   type DomainTypeSymbols,
@@ -1335,7 +1336,7 @@ export class SemanticValidator {
           }
 
           const spreadType = this.validateExpr(prop.expr, context, env);
-          if (this.symbols && spreadType) {
+          if (this.symbols) {
             this.requireSpreadOperand(spreadType, prop.location, prop.expr);
           }
         }
@@ -2034,7 +2035,7 @@ export class SemanticValidator {
 
     const outcome =
       actualType === null
-        ? expr?.kind === "arrayLiteral" && expr.elements.length === 0
+        ? isDefinitelyArrayExpr(expr)
           ? "invalid"
           : "unknown"
         : classifySpreadOperandType(actualType, this.symbols);

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -687,7 +687,7 @@ export class SemanticValidator {
           const before = this.ctx.diagnostics.length;
           this.validateStateInitializer(prop.expr);
           if (before === this.ctx.diagnostics.length) {
-            this.requireSpreadOperand(this.inferType(prop.expr, new Map()), prop.location, prop.expr);
+            this.requireSpreadOperand(this.inferType(prop.expr, new Map()), prop.location, prop.expr, new Map());
           }
         }
         return;
@@ -1337,7 +1337,7 @@ export class SemanticValidator {
 
           const spreadType = this.validateExpr(prop.expr, context, env);
           if (this.symbols) {
-            this.requireSpreadOperand(spreadType, prop.location, prop.expr);
+            this.requireSpreadOperand(spreadType, prop.location, prop.expr, env);
           }
         }
         return this.inferType(expr, env);
@@ -1896,7 +1896,7 @@ export class SemanticValidator {
 
       case "merge":
         for (const [index, arg] of args.entries()) {
-          this.requireSpreadOperand(argTypes[index], arg.location, arg);
+          this.requireSpreadOperand(argTypes[index], arg.location, arg, env);
         }
         break;
 
@@ -2027,17 +2027,25 @@ export class SemanticValidator {
   private requireSpreadOperand(
     actualType: TypeExprNode | null,
     location: SourceLocation,
-    expr?: ExprNode
+    expr?: ExprNode,
+    env: TypeEnv = new Map()
   ): void {
     if (!this.symbols) {
       return;
     }
 
-    const outcome = mayYieldArrayExpr(expr)
-      ? "invalid"
-      : actualType === null
+    const typeOutcome = actualType === null
       ? "unknown"
       : classifySpreadOperandType(actualType, this.symbols);
+    const arrayBranchReachable = mayYieldArrayExpr(expr, {
+      env,
+      symbols: this.symbols,
+      inferExprType,
+      resolveType,
+    });
+    const outcome = arrayBranchReachable
+      ? "invalid"
+      : typeOutcome;
 
     if (outcome === "invalid") {
       this.error(

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -35,7 +35,7 @@ import {
   getIndexType,
   getPropertyType,
   inferExprType,
-  isDefinitelyArrayExpr,
+  mayYieldArrayExpr,
   isNullType,
   resolveType,
   type DomainTypeSymbols,
@@ -2033,12 +2033,11 @@ export class SemanticValidator {
       return;
     }
 
-    const outcome =
-      actualType === null
-        ? isDefinitelyArrayExpr(expr)
-          ? "invalid"
-          : "unknown"
-        : classifySpreadOperandType(actualType, this.symbols);
+    const outcome = mayYieldArrayExpr(expr)
+      ? "invalid"
+      : actualType === null
+      ? "unknown"
+      : classifySpreadOperandType(actualType, this.symbols);
 
     if (outcome === "invalid") {
       this.error(

--- a/packages/compiler/src/analyzer/validator.ts
+++ b/packages/compiler/src/analyzer/validator.ts
@@ -28,6 +28,7 @@ import { createWarning } from "../diagnostics/types.js";
 import type { SourceLocation } from "../lexer/source-location.js";
 import { validateEntityPrimitives } from "./entity-primitives.js";
 import {
+  classifySpreadOperandType,
   collectDomainTypeSymbols,
   createActionTypeEnv,
   getArrayElementType,
@@ -158,6 +159,9 @@ function isAssignableType(
         if (targetField.optional) {
           continue;
         }
+        return false;
+      }
+      if (sourceField.optional && !targetField.optional) {
         return false;
       }
       const fieldAssignable = isAssignableType(sourceField.typeExpr, targetField.typeExpr, symbols);
@@ -674,7 +678,16 @@ export class SemanticValidator {
 
       case "objectLiteral":
         for (const prop of expr.properties) {
-          this.validateStateInitializer(prop.value);
+          if (prop.kind === "objectProperty") {
+            this.validateStateInitializer(prop.value);
+            continue;
+          }
+
+          const before = this.ctx.diagnostics.length;
+          this.validateStateInitializer(prop.expr);
+          if (before === this.ctx.diagnostics.length) {
+            this.requireSpreadOperand(this.inferType(prop.expr, new Map()), prop.location, prop.expr);
+          }
         }
         return;
 
@@ -912,7 +925,7 @@ export class SemanticValidator {
 
       case "objectLiteral":
         for (const prop of expr.properties) {
-          this.validateAvailableExpr(prop.value);
+          this.validateAvailableExpr(prop.kind === "objectProperty" ? prop.value : prop.expr);
         }
         break;
 
@@ -988,7 +1001,7 @@ export class SemanticValidator {
 
       case "objectLiteral":
         for (const prop of expr.properties) {
-          this.validateDispatchableExpr(prop.value);
+          this.validateDispatchableExpr(prop.kind === "objectProperty" ? prop.value : prop.expr);
         }
         break;
 
@@ -1316,7 +1329,15 @@ export class SemanticValidator {
 
       case "objectLiteral":
         for (const prop of expr.properties) {
-          this.validateExpr(prop.value, context, env);
+          if (prop.kind === "objectProperty") {
+            this.validateExpr(prop.value, context, env);
+            continue;
+          }
+
+          const spreadType = this.validateExpr(prop.expr, context, env);
+          if (this.symbols && spreadType) {
+            this.requireSpreadOperand(spreadType, prop.location, prop.expr);
+          }
         }
         return this.inferType(expr, env);
 
@@ -1872,6 +1893,12 @@ export class SemanticValidator {
         }
         break;
 
+      case "merge":
+        for (const [index, arg] of args.entries()) {
+          this.requireSpreadOperand(argTypes[index], arg.location, arg);
+        }
+        break;
+
       case "coalesce":
         this.validateCoalesceTypes(argTypes, location);
         break;
@@ -1990,6 +2017,31 @@ export class SemanticValidator {
     if (outcome === false) {
       this.error(
         `Function 'len' expects a string, array, object, or record argument, got ${describeTypeExpr(actualType, this.symbols)}`,
+        location,
+        "E_TYPE_MISMATCH"
+      );
+    }
+  }
+
+  private requireSpreadOperand(
+    actualType: TypeExprNode | null,
+    location: SourceLocation,
+    expr?: ExprNode
+  ): void {
+    if (!this.symbols) {
+      return;
+    }
+
+    const outcome =
+      actualType === null
+        ? expr?.kind === "arrayLiteral" && expr.elements.length === 0
+          ? "invalid"
+          : "unknown"
+        : classifySpreadOperandType(actualType, this.symbols);
+
+    if (outcome === "invalid") {
+      this.error(
+        `Object spread operands must be object-shaped or T | null where T is object-shaped, got ${describeTypeExpr(actualType, this.symbols)}`,
         location,
         "E_TYPE_MISMATCH"
       );

--- a/packages/compiler/src/annotations.ts
+++ b/packages/compiler/src/annotations.ts
@@ -325,6 +325,10 @@ function exprToJsonLiteral(
 
       const objectValue: Record<string, JsonLiteral> = {};
       for (const property of expr.properties) {
+        if (property.kind !== "objectProperty") {
+          diagnostics.push(createError("E055", INVALID_PAYLOAD_MESSAGE, property.location));
+          return { ok: false };
+        }
         const result = exprToJsonLiteral(property.value, depth + 1, diagnostics);
         if (!result.ok) {
           return { ok: false };

--- a/packages/compiler/src/api/compile-mel-patch-collector.ts
+++ b/packages/compiler/src/api/compile-mel-patch-collector.ts
@@ -15,6 +15,7 @@ import {
   classifyComparableExpr,
   inferExprType,
   mayYieldArrayExpr,
+  resolveType,
   type DomainTypeSymbols,
 } from "../analyzer/expr-type-surface.js";
 import { toMelExpr } from "./compile-mel-patch-expr.js";
@@ -640,7 +641,12 @@ class PatchExprValidator {
     errors: Diagnostic[]
   ): void {
     const inferred = inferExprType(expr, new Map(), this.symbols);
-    const mayYieldInvalidSpread = mayYieldArrayExpr(expr);
+    const mayYieldInvalidSpread = mayYieldArrayExpr(expr, {
+      env: new Map(),
+      symbols: this.symbols,
+      inferExprType,
+      resolveType,
+    });
 
     if (!inferred) {
       if (!mayYieldInvalidSpread) {

--- a/packages/compiler/src/api/compile-mel-patch-collector.ts
+++ b/packages/compiler/src/api/compile-mel-patch-collector.ts
@@ -14,7 +14,7 @@ import {
   classifySpreadOperandType,
   classifyComparableExpr,
   inferExprType,
-  isDefinitelyArrayExpr,
+  mayYieldArrayExpr,
   type DomainTypeSymbols,
 } from "../analyzer/expr-type-surface.js";
 import { toMelExpr } from "./compile-mel-patch-expr.js";
@@ -640,18 +640,18 @@ class PatchExprValidator {
     errors: Diagnostic[]
   ): void {
     const inferred = inferExprType(expr, new Map(), this.symbols);
-    const isDefinitelyInvalidSpread = isDefinitelyArrayExpr(expr);
+    const mayYieldInvalidSpread = mayYieldArrayExpr(expr);
 
     if (!inferred) {
-      if (!isDefinitelyInvalidSpread) {
+      if (!mayYieldInvalidSpread) {
         return;
       }
     }
 
-    const classification = inferred
-      ? classifySpreadOperandType(inferred, this.symbols)
-      : isDefinitelyInvalidSpread
+    const classification = mayYieldInvalidSpread
       ? "invalid"
+      : inferred
+      ? classifySpreadOperandType(inferred, this.symbols)
       : "unknown";
 
     if (classification !== "invalid") {

--- a/packages/compiler/src/api/compile-mel-patch-collector.ts
+++ b/packages/compiler/src/api/compile-mel-patch-collector.ts
@@ -11,7 +11,9 @@ import type {
   PatchStmtNode,
 } from "../parser/ast.js";
 import {
+  classifySpreadOperandType,
   classifyComparableExpr,
+  inferExprType,
   type DomainTypeSymbols,
 } from "../analyzer/expr-type-surface.js";
 import { toMelExpr } from "./compile-mel-patch-expr.js";
@@ -582,7 +584,13 @@ class PatchExprValidator {
 
       case "objectLiteral":
         for (const property of expr.properties) {
-          this.validateExpr(property.value, errors);
+          if (property.kind === "objectProperty") {
+            this.validateExpr(property.value, errors);
+            continue;
+          }
+
+          this.validateExpr(property.expr, errors);
+          this.validateSpreadOperand(property.expr, property.location, errors);
         }
         return;
 
@@ -616,6 +624,38 @@ class PatchExprValidator {
       severity: "error",
       code: "E_TYPE_MISMATCH",
       message: "eq/neq operands must be primitive types (null, boolean, number, string)",
+      location: this.mapLocation(location),
+      });
+  }
+
+  private validateSpreadOperand(
+    expr: ExprNode,
+    location: Diagnostic["location"],
+    errors: Diagnostic[]
+  ): void {
+    const inferred = inferExprType(expr, new Map(), this.symbols);
+    const isDefinitelyInvalidSpread = expr.kind === "arrayLiteral" && expr.elements.length === 0;
+
+    if (!inferred) {
+      if (!isDefinitelyInvalidSpread) {
+        return;
+      }
+    }
+
+    const classification = inferred
+      ? classifySpreadOperandType(inferred, this.symbols)
+      : isDefinitelyInvalidSpread
+      ? "invalid"
+      : "unknown";
+
+    if (classification !== "invalid") {
+      return;
+    }
+
+    errors.push({
+      severity: "error",
+      code: "E_TYPE_MISMATCH",
+      message: "Object spread operands must be object-shaped or T | null where T is object-shaped",
       location: this.mapLocation(location),
     });
   }

--- a/packages/compiler/src/api/compile-mel-patch-collector.ts
+++ b/packages/compiler/src/api/compile-mel-patch-collector.ts
@@ -14,6 +14,7 @@ import {
   classifySpreadOperandType,
   classifyComparableExpr,
   inferExprType,
+  isDefinitelyArrayExpr,
   type DomainTypeSymbols,
 } from "../analyzer/expr-type-surface.js";
 import { toMelExpr } from "./compile-mel-patch-expr.js";
@@ -553,6 +554,11 @@ class PatchExprValidator {
         for (const arg of expr.args) {
           this.validateExpr(arg, errors);
         }
+        if (expr.name === "merge") {
+          for (const arg of expr.args) {
+            this.validateSpreadOperand(arg, arg.location, errors);
+          }
+        }
         return;
 
       case "binary":
@@ -634,7 +640,7 @@ class PatchExprValidator {
     errors: Diagnostic[]
   ): void {
     const inferred = inferExprType(expr, new Map(), this.symbols);
-    const isDefinitelyInvalidSpread = expr.kind === "arrayLiteral" && expr.elements.length === 0;
+    const isDefinitelyInvalidSpread = isDefinitelyArrayExpr(expr);
 
     if (!inferred) {
       if (!isDefinitelyInvalidSpread) {

--- a/packages/compiler/src/generator/ir.ts
+++ b/packages/compiler/src/generator/ir.ts
@@ -499,9 +499,7 @@ function typeExprToFieldSpec(
 
     case "unionType": {
       const nonNullTypes = typeExpr.types.filter(
-        (candidate) =>
-          !(candidate.kind === "simpleType" && candidate.name === "null") &&
-          !(candidate.kind === "literalType" && candidate.value === null)
+        (candidate) => !isNullTypeExpr(candidate, ctx, seenTypeRefs)
       );
       const hasNull = nonNullTypes.length !== typeExpr.types.length;
       const enumValues: unknown[] = [];
@@ -577,6 +575,39 @@ function typeExprToFieldSpec(
       };
     }
   }
+}
+
+function resolveTypeExprForFieldSpec(
+  typeExpr: TypeExprNode,
+  ctx: GeneratorContext,
+  seenTypeRefs: readonly string[] = []
+): TypeExprNode | null {
+  if (typeExpr.kind !== "simpleType") {
+    return typeExpr;
+  }
+
+  const typeDef = ctx.typeDefs.get(typeExpr.name);
+  if (!typeDef) {
+    return typeExpr;
+  }
+
+  if (seenTypeRefs.includes(typeExpr.name)) {
+    return null;
+  }
+
+  return resolveTypeExprForFieldSpec(typeDef.typeExpr, ctx, [...seenTypeRefs, typeExpr.name]);
+}
+
+function isNullTypeExpr(
+  typeExpr: TypeExprNode,
+  ctx: GeneratorContext,
+  seenTypeRefs: readonly string[] = []
+): boolean {
+  const resolved = resolveTypeExprForFieldSpec(typeExpr, ctx, seenTypeRefs);
+  return (
+    (resolved?.kind === "simpleType" && resolved.name === "null") ||
+    (resolved?.kind === "literalType" && resolved.value === null)
+  );
 }
 
 /**

--- a/packages/compiler/src/generator/ir.ts
+++ b/packages/compiler/src/generator/ir.ts
@@ -1024,7 +1024,15 @@ function evaluateInitializer(expr: ExprNode, ctx: GeneratorContext): unknown {
     case "objectLiteral": {
       const obj: Record<string, unknown> = {};
       for (const prop of expr.properties) {
-        obj[prop.key] = evaluateInitializer(prop.value, ctx);
+        if (prop.kind === "objectProperty") {
+          obj[prop.key] = evaluateInitializer(prop.value, ctx);
+          continue;
+        }
+
+        const spreadValue = evaluateInitializer(prop.expr, ctx);
+        if (spreadValue !== null && !Array.isArray(spreadValue) && typeof spreadValue === "object") {
+          Object.assign(obj, spreadValue);
+        }
       }
       return obj;
     }

--- a/packages/compiler/src/lexer/lexer.ts
+++ b/packages/compiler/src/lexer/lexer.ts
@@ -75,7 +75,15 @@ export class Lexer {
       case "]": this.addToken("RBRACKET"); break;
       case ",": this.addToken("COMMA"); break;
       case ";": this.addToken("SEMICOLON"); break;
-      case ".": this.addToken("DOT"); break;
+      case ".":
+        if (this.peek() === "." && this.peekNext() === ".") {
+          this.advance();
+          this.advance();
+          this.addToken("ELLIPSIS");
+        } else {
+          this.addToken("DOT");
+        }
+        break;
       case "+": this.addToken("PLUS"); break;
       case "-": this.addToken("MINUS"); break;
       case "*": this.addToken("STAR"); break;

--- a/packages/compiler/src/lexer/tokens.ts
+++ b/packages/compiler/src/lexer/tokens.ts
@@ -63,6 +63,7 @@ export type TokenKind =
   | "COMMA" // ,
   | "SEMICOLON" // ;
   | "DOT" // .
+  | "ELLIPSIS" // ...
   | "PIPE" // |
   // Literals
   | "NUMBER"

--- a/packages/compiler/src/lowering/to-mel-expr.ts
+++ b/packages/compiler/src/lowering/to-mel-expr.ts
@@ -66,13 +66,7 @@ export function toMelExpr(
       };
 
     case "objectLiteral":
-      return {
-        kind: "obj",
-        fields: input.properties.map((property) => ({
-          key: property.key,
-          value: toMelExpr(property.value, options),
-        })),
-      };
+      return lowerObjectLiteral(input, options);
 
     case "arrayLiteral":
       return {
@@ -80,6 +74,64 @@ export function toMelExpr(
         elements: input.elements.map((element) => toMelExpr(element, options)),
       };
   }
+}
+
+function lowerObjectLiteral(
+  input: Extract<ExprNode, { kind: "objectLiteral" }>,
+  options: ToMelExprOptions
+): MelExprNode {
+  const hasSpread = input.properties.some((property) => property.kind === "objectSpread");
+  if (!hasSpread) {
+    return {
+      kind: "obj",
+      fields: input.properties.map((property) => {
+        if (property.kind !== "objectProperty") {
+          throw new Error("Unexpected non-property in non-spread object literal");
+        }
+
+        return {
+          key: property.key,
+          value: toMelExpr(property.value, options),
+        };
+      }),
+    };
+  }
+
+  const contributors: MelExprNode[] = [];
+  let bufferedFields: Array<{ key: string; value: MelExprNode }> = [];
+
+  const flushBufferedFields = () => {
+    if (bufferedFields.length === 0) {
+      return;
+    }
+
+    contributors.push({
+      kind: "obj",
+      fields: bufferedFields,
+    });
+    bufferedFields = [];
+  };
+
+  for (const property of input.properties) {
+    if (property.kind === "objectProperty") {
+      bufferedFields.push({
+        key: property.key,
+        value: toMelExpr(property.value, options),
+      });
+      continue;
+    }
+
+    flushBufferedFields();
+    contributors.push(toMelExpr(property.expr, options));
+  }
+
+  flushBufferedFields();
+
+  return {
+    kind: "call",
+    fn: "merge",
+    args: contributors,
+  };
 }
 
 export function getPathExpr(...segments: string[]): MelExprNode {

--- a/packages/compiler/src/parser/ast.ts
+++ b/packages/compiler/src/parser/ast.ts
@@ -448,13 +448,20 @@ export interface TernaryExprNode extends ASTNode {
  */
 export interface ObjectLiteralExprNode extends ASTNode {
   kind: "objectLiteral";
-  properties: ObjectPropertyNode[];
+  properties: ObjectLiteralEntryNode[];
 }
+
+export type ObjectLiteralEntryNode = ObjectPropertyNode | ObjectSpreadNode;
 
 export interface ObjectPropertyNode extends ASTNode {
   kind: "objectProperty";
   key: string;
   value: ExprNode;
+}
+
+export interface ObjectSpreadNode extends ASTNode {
+  kind: "objectSpread";
+  expr: ExprNode;
 }
 
 /**

--- a/packages/compiler/src/parser/parser.ts
+++ b/packages/compiler/src/parser/parser.ts
@@ -37,6 +37,7 @@ import {
   type ExprNode,
   type PathNode,
   type PathSegmentNode,
+  type ObjectLiteralEntryNode,
   type ObjectPropertyNode,
 } from "./ast.js";
 import {
@@ -839,6 +840,12 @@ export class Parser {
     let left = this.parsePrimary();
 
     while (true) {
+      if (this.check("QUESTION") && this.peekNext().kind === "DOT") {
+        throw this.errorAtCurrent(
+          "Object spread is the only bounded JavaScript-like sugar admitted in current MEL. Optional chaining is not supported."
+        );
+      }
+
       const precedence = getBinaryPrecedence(this.peek().kind);
       if (precedence <= minPrecedence) break;
 
@@ -1057,19 +1064,35 @@ export class Parser {
 
   private parseObjectLiteral(): ExprNode {
     const start = this.consume("LBRACE", "Expected '{'").location;
-    const properties: ObjectPropertyNode[] = [];
+    const properties: ObjectLiteralEntryNode[] = [];
 
     while (!this.check("RBRACE") && !this.isAtEnd()) {
-      const keyToken = this.consume("IDENTIFIER", "Expected property name");
-      this.consume("COLON", "Expected ':' after property name");
-      const value = this.parseExpression();
+      if (this.check("LBRACKET")) {
+        throw this.errorAtCurrent(
+          "Object spread is the only bounded JavaScript-like sugar admitted in current MEL. Computed object keys are not supported."
+        );
+      }
 
-      properties.push({
-        kind: "objectProperty",
-        key: keyToken.lexeme,
-        value,
-        location: mergeLocations(keyToken.location, value.location),
-      });
+      if (this.match("ELLIPSIS")) {
+        const spreadStart = this.previous().location;
+        const spreadExpr = this.parseExpression();
+        properties.push({
+          kind: "objectSpread",
+          expr: spreadExpr,
+          location: mergeLocations(spreadStart, spreadExpr.location),
+        });
+      } else {
+        const keyToken = this.consume("IDENTIFIER", "Expected property name");
+        this.consume("COLON", "Expected ':' after property name");
+        const value = this.parseExpression();
+
+        properties.push({
+          kind: "objectProperty",
+          key: keyToken.lexeme,
+          value,
+          location: mergeLocations(keyToken.location, value.location),
+        });
+      }
 
       if (!this.check("RBRACE")) {
         this.consume("COMMA", "Expected ',' between properties");
@@ -1090,6 +1113,12 @@ export class Parser {
     const elements: ExprNode[] = [];
 
     while (!this.check("RBRACKET") && !this.isAtEnd()) {
+      if (this.check("ELLIPSIS")) {
+        throw this.errorAtCurrent(
+          "Object spread is the only bounded JavaScript-like sugar admitted in current MEL. Array spread is not supported."
+        );
+      }
+
       elements.push(this.parseExpression());
       if (!this.check("RBRACKET")) {
         this.consume("COMMA", "Expected ',' between elements");

--- a/packages/core/src/evaluator/expr.test.ts
+++ b/packages/core/src/evaluator/expr.test.ts
@@ -92,7 +92,12 @@ describe("Expression Evaluator", () => {
       const ctx = createTestContext({ count: 10, user: { name: "Alice" } });
       expect(evaluate({ kind: "get", path: "count" }, ctx)).toBe(10);
       expect(evaluate({ kind: "get", path: "user.name" }, ctx)).toBe("Alice");
-      expect(evaluate({ kind: "get", path: "nonexistent" }, ctx)).toBeUndefined();
+      expect(evaluate({ kind: "get", path: "nonexistent" }, ctx)).toBeNull();
+      expect(evaluate({
+        kind: "eq",
+        left: { kind: "get", path: "nonexistent" },
+        right: { kind: "lit", value: null },
+      }, ctx)).toBe(true);
     });
 
     it("get - should get values from input", () => {
@@ -115,6 +120,13 @@ describe("Expression Evaluator", () => {
       expect(evaluate({ kind: "get", path: "meta.intentId" }, ctx)).toBe("intent-123");
       expect(evaluate({ kind: "get", path: "meta.actionName" }, ctx)).toBe("testAction");
       expect(evaluate({ kind: "get", path: "meta.timestamp" }, ctx)).toBe(1234);
+    });
+
+    it("get - should normalize missing meta values to null", () => {
+      const ctx = createTestContext();
+      expect(evaluate({ kind: "get", path: "meta.intentId" }, ctx)).toBeNull();
+      expect(evaluate({ kind: "get", path: "meta.actionName" }, ctx)).toBeNull();
+      expect(evaluate({ kind: "get", path: "meta.missing" }, ctx)).toBeNull();
     });
   });
 

--- a/packages/core/src/evaluator/expr.ts
+++ b/packages/core/src/evaluator/expr.ts
@@ -245,14 +245,14 @@ function evaluateGet(path: string, ctx: EvalContext): ExprResult {
   // Handle collection context variables
   if (path.startsWith("$item")) {
     if (ctx.$item === undefined) {
-      return ok(undefined);
+      return ok(null);
     }
     if (path === "$item") {
       return ok(ctx.$item);
     }
     // e.g., $item.completed
     const subPath = path.slice(6); // Remove "$item."
-    return ok(getByPath(ctx.$item, subPath));
+    return ok(normalizeMissingPathValue(getByPath(ctx.$item, subPath)));
   }
 
   if (path === "$index") {
@@ -284,7 +284,7 @@ function evaluateGet(path: string, ctx: EvalContext): ExprResult {
     }
 
     // Unknown $system path
-    return ok(undefined);
+    return ok(null);
   }
 
   // Handle meta path (snapshot metadata)
@@ -292,35 +292,39 @@ function evaluateGet(path: string, ctx: EvalContext): ExprResult {
     const metaPath = path.slice(5); // Remove "meta."
 
     if (metaPath === "intentId") {
-      return ok(ctx.intentId);
+      return ok(normalizeMissingPathValue(ctx.intentId));
     }
 
     if (metaPath === "actionName") {
-      return ok(ctx.currentAction);
+      return ok(normalizeMissingPathValue(ctx.currentAction));
     }
 
-    return ok(getByPath(ctx.snapshot.meta, metaPath));
+    return ok(normalizeMissingPathValue(getByPath(ctx.snapshot.meta, metaPath)));
   }
 
   // Handle input path
   if (path.startsWith("input.") || path === "input") {
     const subPath = path === "input" ? "" : path.slice(6);
-    return ok(subPath ? getByPath(ctx.snapshot.input, subPath) : ctx.snapshot.input);
+    return ok(subPath ? normalizeMissingPathValue(getByPath(ctx.snapshot.input, subPath)) : ctx.snapshot.input);
   }
 
   // Handle computed path (schema lookup, no prefix)
   if (Object.prototype.hasOwnProperty.call(ctx.schema.computed.fields, path)) {
-    return ok(ctx.snapshot.computed[path]);
+    return ok(normalizeMissingPathValue(ctx.snapshot.computed[path]));
   }
 
   // Handle system path (snapshot.system, not $system)
   if (path.startsWith("system.")) {
     const subPath = path.slice(7);
-    return ok(getByPath(ctx.snapshot.system, subPath));
+    return ok(normalizeMissingPathValue(getByPath(ctx.snapshot.system, subPath)));
   }
 
   // Default: get from data
-  return ok(getByPath(ctx.snapshot.data, path));
+  return ok(normalizeMissingPathValue(getByPath(ctx.snapshot.data, path)));
+}
+
+function normalizeMissingPathValue(value: unknown): unknown {
+  return value === undefined ? null : value;
 }
 
 // ============ Binary Operations ============


### PR DESCRIPTION
## Summary

- Add object-literal spread syntax to MEL and lower it through the existing `merge(...)` semantics.
- Add presence-aware object contribution typing and validation for spread/merge operands.
- Align MEL docs, ADR 023, compiler SPEC v1.2.0, examples, and compliance coverage with the new surface.
- Normalize missing path reads to `null` in Core evaluation to match optional spread-result read semantics.

## Impact

MEL authors can now write object composition directly with `{ ...source, field: value }` inside object literals while preserving the existing Core IR boundary. Unsupported JavaScript-like forms such as array spread, optional chaining, computed object keys, and rest destructuring remain rejected.

## Validation

- `pnpm --filter @manifesto-ai/compiler test`
- `pnpm --filter @manifesto-ai/core test`