### PR TITLE
docs: finish sugar-first docs sweep

### DIFF
--- a/docs/concepts/effect.md
+++ b/docs/concepts/effect.md
@@ -88,7 +88,7 @@ Some effect-like flow nodes are pure array transforms and can run inline in Core
 ```mel
 effect array.filter({
   source: todos,
-  where: eq($item.completed, false),
+  where: !$item.completed,
   into: todos
 })
 ```

--- a/docs/concepts/flow.md
+++ b/docs/concepts/flow.md
@@ -42,7 +42,7 @@ domain TodoDomain {
 
   action addTodo(title: string, localId: string) {
     // Validation
-    when eq(len(title), 0) {
+    when len(title) == 0 {
       fail "EMPTY_TITLE"
     }
 
@@ -56,9 +56,7 @@ domain TodoDomain {
       })
 
       // API call
-      effect api.createTodo {
-        title: title
-      }
+      effect api.createTodo({ title: title })
     }
   }
 }
@@ -115,7 +113,7 @@ MEL compiles to JSON Flow structures that Core interprets:
 // RIGHT: Uses onceIntent for automatic re-entry safety
 action submit() {
   onceIntent {
-    patch count = add(count, 1)
+    patch count = count + 1
     effect api.submit({})
   }
 }
@@ -126,7 +124,7 @@ action submit() {
 ```mel
 // RIGHT: State-guarded
 action submit(timestamp: number) {
-  when isNull(submittedAt) {
+  when submittedAt == null {
     patch submittedAt = timestamp
     effect api.submit({})
   }
@@ -138,7 +136,7 @@ action submit(timestamp: number) {
 ```mel
 // WRONG: Runs every compute cycle - infinite loop!
 action submit() {
-  patch count = add(count, 1)
+  patch count = count + 1
   effect api.submit({})
 }
 ```
@@ -150,7 +148,7 @@ action checkAccess() {
   when user.isAdmin {
     patch access = "full"
   }
-  when not(user.isAdmin) {
+  when !user.isAdmin {
     patch access = "limited"
   }
 }
@@ -160,12 +158,12 @@ action checkAccess() {
 
 ```mel
 action createUser(email: string) {
-  when not(contains(email, "@")) {
-    fail "INVALID_EMAIL"
+  when trim(email) == "" {
+    fail "MISSING_EMAIL"
   }
 
   onceIntent {
-    effect api.createUser { email: email }
+    effect api.createUser({ email: email })
   }
 }
 ```
@@ -174,7 +172,7 @@ action createUser(email: string) {
 
 ```mel
 action load() {
-  when eq(status, "idle") {
+  when status == "idle" {
     patch status = "loading"
     effect api.load({})
   }
@@ -188,7 +186,7 @@ action load() {
 | `seq` | Execute steps in order | Statements in order |
 | `if` | Conditional branching | `when condition { ... }` |
 | `patch` | State mutation (set, unset, merge) | `patch field = value` |
-| `effect` | Declare external operation | `effect type { params }` |
+| `effect` | Declare external operation | `effect type({ params })` |
 | `call` | Invoke another flow | (Internal) |
 | `halt` | Normal termination | `stop` |
 | `fail` | Error termination | `fail "CODE"` |

--- a/docs/guide/essentials/actions-and-intents.md
+++ b/docs/guide/essentials/actions-and-intents.md
@@ -14,7 +14,7 @@ domain Counter {
 
   action add(amount: number) {
     onceIntent {
-      patch count = add(count, amount)
+      patch count = count + amount
     }
   }
 }

--- a/docs/guide/essentials/availability.md
+++ b/docs/guide/essentials/availability.md
@@ -12,11 +12,11 @@ domain Counter {
     count: number = 0
   }
 
-  computed canDecrement = gt(count, 0)
+  computed canDecrement = count > 0
 
   action decrement() available when canDecrement {
     onceIntent {
-      patch count = sub(count, 1)
+      patch count = count - 1
     }
   }
 }
@@ -27,11 +27,11 @@ domain Counter {
 ## Keep Input-Specific Gates Separate
 
 ```mel
-action shoot(cellIndex: number)
+action shoot(cellId: string)
   available when gameIsRunning
-  dispatchable when eq(at(cells, cellIndex), "unknown") {
+  dispatchable when cells[cellId] == "unknown" {
   onceIntent {
-    patch cells = updateAt(cells, cellIndex, "pending")
+    patch cells[cellId] = "pending"
   }
 }
 ```

--- a/docs/guide/essentials/computed-values.md
+++ b/docs/guide/essentials/computed-values.md
@@ -12,8 +12,8 @@ domain Counter {
     count: number = 0
   }
 
-  computed doubled = mul(count, 2)
-  computed canDecrement = gt(count, 0)
+  computed doubled = count * 2
+  computed canDecrement = count > 0
 }
 ```
 
@@ -33,7 +33,7 @@ console.log(snapshot.computed.canDecrement);
 ```mel
 action decrement() available when canDecrement {
   onceIntent {
-    patch count = sub(count, 1)
+    patch count = count - 1
   }
 }
 ```

--- a/docs/guide/essentials/effects.md
+++ b/docs/guide/essentials/effects.md
@@ -9,7 +9,7 @@ Core does not fetch, write databases, call APIs, or send messages. A MEL action 
 ```mel
 domain UserProfile {
   state {
-    userName: string? = null
+    userName: string | null = null
     loading: boolean = false
   }
 
@@ -74,7 +74,7 @@ action completeTodo(id: string) {
   onceIntent {
     effect array.map({
       source: todos,
-      select: eq($item.id, id) ? { ...$item, completed: true } : $item,
+      select: $item.id == id ? { ...$item, completed: true } : $item,
       into: todos
     })
   }

--- a/docs/guide/essentials/mel-domain-basics.md
+++ b/docs/guide/essentials/mel-domain-basics.md
@@ -17,11 +17,11 @@ domain Counter {
     label: Label = { text: "Counter" }
   }
 
-  computed doubled = mul(count, 2)
+  computed doubled = count * 2
 
   action increment() {
     onceIntent {
-      patch count = add(count, 1)
+      patch count = count + 1
     }
   }
 }

--- a/docs/guide/essentials/state.md
+++ b/docs/guide/essentials/state.md
@@ -17,7 +17,7 @@ domain TodoApp {
   state {
     todos: Array<Todo> = []
     filter: "all" | "active" | "completed" = "all"
-    selectedTodoId: string? = null
+    selectedTodoId: string | null = null
   }
 }
 ```

--- a/docs/guides/reentry-safe-flows.md
+++ b/docs/guides/reentry-safe-flows.md
@@ -54,7 +54,7 @@ Now the work is tied to a single intent.
 Not every action is one-shot forever. Some actions are repeatable, but only when state says they should run.
 
 ```mel
-action retry() available when eq(status, "error") {
+action retry() available when status == "error" {
   onceIntent {
     patch status = "loading"
     patch error = null
@@ -79,7 +79,7 @@ action clearCompleted() {
   onceIntent {
     effect array.filter({
       source: todos,
-      where: eq($item.completed, false),
+      where: !$item.completed,
       into: todos
     })
   }
@@ -119,7 +119,7 @@ Then ask:
 
 ```mel
 action increment() {
-  patch count = add(count, 1)
+  patch count = count + 1
 }
 ```
 

--- a/docs/tutorial/02-actions-and-state.md
+++ b/docs/tutorial/02-actions-and-state.md
@@ -38,7 +38,7 @@ domain TodoList {
   }
 
   computed totalCount = len(todos)
-  computed hasTodos = gt(totalCount, 0)
+  computed hasTodos = totalCount > 0
 
   action addTodo(title: string, id: string) {
     onceIntent {
@@ -54,7 +54,7 @@ domain TodoList {
     onceIntent {
       effect array.map({
         source: todos,
-        select: eq($item.id, id) ? { ...$item, completed: not($item.completed) } : $item,
+        select: $item.id == id ? { ...$item, completed: !$item.completed } : $item,
         into: todos
       })
     }
@@ -70,7 +70,7 @@ domain TodoList {
     onceIntent {
       effect array.filter({
         source: todos,
-        where: eq($item.completed, false),
+        where: !$item.completed,
         into: todos
       })
     }

--- a/docs/tutorial/03-effects.md
+++ b/docs/tutorial/03-effects.md
@@ -32,13 +32,13 @@ domain UserProfile {
   }
 
   state {
-    user: User? = null
+    user: User | null = null
     loading: boolean = false
-    error: string? = null
-    requestedId: string? = null
+    error: string | null = null
+    requestedId: string | null = null
   }
 
-  computed hasUser = neq(user, null)
+  computed hasUser = user != null
 
   action fetchUser(id: string) {
     onceIntent {

--- a/docs/tutorial/04-todo-app.md
+++ b/docs/tutorial/04-todo-app.md
@@ -38,7 +38,7 @@ domain TodoApp {
   }
 
   computed totalCount = len(todos)
-  computed hasTodos = gt(totalCount, 0)
+  computed hasTodos = totalCount > 0
 
   action addTodo(title: string, id: string) {
     onceIntent {
@@ -54,7 +54,7 @@ domain TodoApp {
     onceIntent {
       effect array.map({
         source: todos,
-        select: eq($item.id, id) ? { ...$item, completed: not($item.completed) } : $item,
+        select: $item.id == id ? { ...$item, completed: !$item.completed } : $item,
         into: todos
       })
     }
@@ -70,7 +70,7 @@ domain TodoApp {
     onceIntent when hasTodos {
       effect array.filter({
         source: todos,
-        where: eq($item.completed, false),
+        where: !$item.completed,
         into: todos
       })
     }


### PR DESCRIPTION
## Summary

- finish the sugar-first MEL sweep across the remaining user-facing guide, tutorial, concept, and integration-adjacent docs
- replace leftover function-form operator examples with the current preferred source surface
- align nullable and effect-call examples with the current MEL docs tone so the learning path no longer mixes old and new surface styles

## Why

The previous docs refresh updated MEL reference pages and a few entry pages, but the broader learning path still contained older MEL examples. Readers moving from quick start into essentials, tutorials, and concepts were still seeing mixed syntax and older surface conventions.

## Impact

The user-facing docs now teach one MEL writing style consistently: symbolic operators and the current sugar-first source form first, with legacy-style examples removed from the normal learning flow. This reduces friction when moving between quick start, essentials, tutorials, guides, and concepts.

## Validation

- `git diff --check`
- `pnpm docs:check:maintained`
- `pnpm docs:build`
