### PR TITLE
feat(sdk): add bound intent dry-run surface

### DIFF
--- a/cts/activation-cts/src/acts-coverage.ts
+++ b/cts/activation-cts/src/acts-coverage.ts
@@ -66,7 +66,7 @@ export const ACTIVATION_COMPLIANCE_CASES: readonly ActivationComplianceCase[] = 
   complianceCase(
     ACTS_CASES.BASE_INTROSPECTION_SURFACE,
     "base",
-    "Activated base runtime exposes getSchemaGraph() and simulate() as read-only introspection verbs.",
+    "Activated base runtime exposes getSchemaGraph(), simulateIntent(), and simulate() as read-only introspection verbs.",
   ),
   complianceCase(
     ACTS_CASES.BASE_SCHEMA_GRAPH_LOOKUP,
@@ -76,12 +76,12 @@ export const ACTIVATION_COMPLIANCE_CASES: readonly ActivationComplianceCase[] = 
   complianceCase(
     ACTS_CASES.BASE_SIMULATE_NON_COMMITTING,
     "base",
-    "simulate() is non-committing and returns projected snapshot, changedPaths, requirements, new availability, and optional diagnostics.trace.",
+    "simulateIntent() and simulate() are non-committing and return projected snapshot, changedPaths, requirements, new availability, and optional diagnostics.trace.",
   ),
   complianceCase(
     ACTS_CASES.BASE_SIMULATE_HALTED,
     "base",
-    "simulate() preserves Core halted status without publishing runtime state.",
+    "simulateIntent() and simulate() preserve Core halted status without publishing runtime state.",
   ),
   complianceCase(
     ACTS_CASES.BASE_REPORT_SURFACE,
@@ -141,7 +141,7 @@ export const ACTIVATION_COMPLIANCE_CASES: readonly ActivationComplianceCase[] = 
   complianceCase(
     ACTS_CASES.TYPES_BASE_INTROSPECTION,
     "types",
-    "Activated base runtime exposes typed introspection refs, graph helpers, and simulate() result types including optional diagnostics.trace.",
+    "Activated base runtime exposes typed introspection refs, graph helpers, and public dry-run result types including optional diagnostics.trace.",
   ),
 ] as const;
 

--- a/cts/activation-cts/src/suite/base.spec.ts
+++ b/cts/activation-cts/src/suite/base.spec.ts
@@ -187,28 +187,33 @@ describe("ACTS Base Suite", () => {
   it(
     caseTitle(
       ACTS_CASES.BASE_INTROSPECTION_SURFACE,
-      "Activated base runtime exposes getSchemaGraph() and simulate() as read-only introspection verbs.",
+      "Activated base runtime exposes getSchemaGraph(), simulateIntent(), and simulate() as read-only introspection verbs.",
     ),
     () => {
       const world = createManifesto<CounterDomain>(createCounterSchema(), {}).activate();
       const graph = world.getSchemaGraph();
+      const intent = world.createIntent(world.MEL.actions.increment);
       const simulated = world.simulate(world.MEL.actions.increment);
+      const simulatedIntent = world.simulateIntent(intent);
 
       expectAllCompliance([
         evaluateRule(
           getRuleOrThrow("ACTS-BASE-6"),
           "getSchemaGraph" in world
             && "simulate" in world
+            && "simulateIntent" in world
             && Array.isArray(graph.nodes)
             && Array.isArray(graph.edges)
             && simulated.snapshot.data.count === 1
+            && simulatedIntent.snapshot.data.count === 1
             && world.getSnapshot().data.count === 0,
           {
-            passMessage: "Base runtime exposes getSchemaGraph() and simulate() without committing state.",
-            failMessage: "Base runtime did not expose the introspection surface or simulate() committed state.",
+            passMessage: "Base runtime exposes getSchemaGraph(), simulateIntent(), and simulate() without committing state.",
+            failMessage: "Base runtime did not expose the introspection surface or public dry-run committed state.",
             evidence: [
               noteEvidence("Observed graph nodes", graph.nodes),
               noteEvidence("Observed simulated snapshot", simulated.snapshot),
+              noteEvidence("Observed bound-intent simulated snapshot", simulatedIntent.snapshot),
             ],
           },
         ),
@@ -274,12 +279,14 @@ describe("ACTS Base Suite", () => {
   it(
     caseTitle(
       ACTS_CASES.BASE_SIMULATE_NON_COMMITTING,
-      "simulate() is non-committing and returns projected snapshot, changedPaths, requirements, new availability, and optional diagnostics.trace.",
+      "simulateIntent() and simulate() are non-committing and return projected snapshot, changedPaths, requirements, new availability, and optional diagnostics.trace.",
     ),
     () => {
       const world = createManifesto<CounterDomain>(createCounterSchema(), {}).activate();
       const before = world.getSnapshot();
+      const loadIntent = world.createIntent(world.MEL.actions.load);
       const simulated = world.simulate(world.MEL.actions.load);
+      const simulatedIntent = world.simulateIntent(loadIntent);
       const after = world.getSnapshot();
       type NoOpProjectedDomain = {
         actions: {
@@ -314,11 +321,14 @@ describe("ACTS Base Suite", () => {
         },
       }), {}).activate();
       const noOpBefore = noOpWorld.getSnapshot();
+      const noOpIntent = noOpWorld.createIntent(noOpWorld.MEL.actions.touchHostDirect);
       const nowSpy = vi.spyOn(Date, "now");
       nowSpy.mockReturnValueOnce(100);
       const firstNoOp = noOpWorld.simulate(noOpWorld.MEL.actions.touchHostDirect);
       nowSpy.mockReturnValueOnce(200);
       const secondNoOp = noOpWorld.simulate(noOpWorld.MEL.actions.touchHostDirect);
+      nowSpy.mockReturnValueOnce(300);
+      const noOpIntentResult = noOpWorld.simulateIntent(noOpIntent);
       nowSpy.mockRestore();
       const noOpAfter = noOpWorld.getSnapshot();
 
@@ -329,20 +339,26 @@ describe("ACTS Base Suite", () => {
             && after.data.status === "idle"
             && after.data.count === before.data.count
             && simulated.status === "pending"
+            && simulatedIntent.status === simulated.status
             && simulated.snapshot.data.status === "loading"
+            && simulatedIntent.snapshot.data.status === simulated.snapshot.data.status
             && simulated.requirements.length === 1
+            && simulatedIntent.requirements.length === simulated.requirements.length
             && simulated.changedPaths.includes("data.status")
             && simulated.changedPaths.includes("system.status")
+            && JSON.stringify(simulatedIntent.changedPaths) === JSON.stringify(simulated.changedPaths)
+            && JSON.stringify(simulatedIntent.newAvailableActions) === JSON.stringify(simulated.newAvailableActions)
             && JSON.stringify(simulated.changedPaths) === JSON.stringify([...simulated.changedPaths].sort())
             && simulated.changedPaths.every((path) =>
               !path.includes("$")
               && path !== "system.pendingRequirements"
               && path !== "system.currentAction"),
           {
-            passMessage: "simulate() stays non-committing and returns projected-only dry-run results.",
-            failMessage: "simulate() committed runtime state or leaked canonical-only diff paths.",
+            passMessage: "simulateIntent() and simulate() stay non-committing and return projected-only dry-run results.",
+            failMessage: "Public dry-run committed runtime state or leaked canonical-only diff paths.",
             evidence: [
               noteEvidence("Observed simulated result", simulated),
+              noteEvidence("Observed bound-intent simulated result", simulatedIntent),
               noteEvidence("Visible snapshot after simulate()", after),
             ],
           },
@@ -353,6 +369,7 @@ describe("ACTS Base Suite", () => {
             && firstNoOp.changedPaths.length === 0
             && firstNoOp.requirements.length === 0
             && JSON.stringify(firstNoOp) === JSON.stringify(secondNoOp)
+            && JSON.stringify(firstNoOp) === JSON.stringify(noOpIntentResult)
             && JSON.stringify(noOpBefore) === JSON.stringify(noOpAfter),
           {
             passMessage: "Projected no-op simulation stays empty and repeatable.",
@@ -360,6 +377,7 @@ describe("ACTS Base Suite", () => {
             evidence: [
               noteEvidence("First no-op simulate()", firstNoOp),
               noteEvidence("Second no-op simulate()", secondNoOp),
+              noteEvidence("Bound-intent no-op simulateIntent()", noOpIntentResult),
             ],
           },
         ),
@@ -373,23 +391,31 @@ describe("ACTS Base Suite", () => {
   it(
     caseTitle(
       ACTS_CASES.BASE_SIMULATE_HALTED,
-      "simulate() preserves Core halted status without publishing runtime state.",
+      "simulateIntent() and simulate() preserve Core halted status without publishing runtime state.",
     ),
     () => {
       const world = createManifesto<HaltingDomain>(createHaltingSchema(), {}).activate();
+      const intent = world.createIntent(world.MEL.actions.finalize);
       const simulated = world.simulate(world.MEL.actions.finalize);
+      const simulatedIntent = world.simulateIntent(intent);
 
       expectAllCompliance([
         evaluateRule(
           getRuleOrThrow("ACTS-BASE-9"),
           simulated.status === "halted"
+            && simulatedIntent.status === simulated.status
             && simulated.changedPaths.length === 0
+            && simulatedIntent.changedPaths.length === 0
             && simulated.requirements.length === 0
+            && simulatedIntent.requirements.length === 0
             && world.getSnapshot().data.status === "idle",
           {
-            passMessage: "simulate() preserves halted status without publishing state.",
-            failMessage: "simulate() did not preserve halted status or published state unexpectedly.",
-            evidence: [noteEvidence("Observed simulated result", simulated)],
+            passMessage: "simulateIntent() and simulate() preserve halted status without publishing state.",
+            failMessage: "Public dry-run did not preserve halted status or published state unexpectedly.",
+            evidence: [
+              noteEvidence("Observed simulated result", simulated),
+              noteEvidence("Observed bound-intent simulated result", simulatedIntent),
+            ],
           },
         ),
       ]);

--- a/cts/activation-cts/src/types/base-introspection.ts
+++ b/cts/activation-cts/src/types/base-introspection.ts
@@ -15,9 +15,15 @@ void graph.traceDown(world.MEL.state.count);
 void graph.traceUp("state:count");
 
 const simulated = world.simulate(world.MEL.actions.increment);
+const intent = world.createIntent(world.MEL.actions.increment);
+const simulatedIntent = world.simulateIntent(intent);
 const changedPaths: readonly string[] = simulated.changedPaths;
 const available: readonly (keyof CounterDomain["actions"])[] = simulated.newAvailableActions;
 const trace = simulated.diagnostics?.trace;
+const intentChangedPaths: readonly string[] = simulatedIntent.changedPaths;
+const intentAvailable: readonly (keyof CounterDomain["actions"])[] =
+  simulatedIntent.newAvailableActions;
+const intentTrace = simulatedIntent.diagnostics?.trace;
 const reportPromise: Promise<DispatchReport<CounterDomain>> = world.dispatchAsyncWithReport(
   world.createIntent(world.MEL.actions.increment),
 );
@@ -42,6 +48,9 @@ void actionName;
 void changedPaths;
 void available;
 void trace;
+void intentChangedPaths;
+void intentAvailable;
+void intentTrace;
 void reportPromise;
 
 // @ts-expect-error FieldRef no longer exposes path as part of the public contract

--- a/cts/activation-cts/src/types/governed-runtime.ts
+++ b/cts/activation-cts/src/types/governed-runtime.ts
@@ -28,6 +28,9 @@ lineage.dispatchAsyncWithReport;
 void lineage.commitAsync(
   lineage.createIntent(lineage.MEL.actions.increment),
 );
+void lineage.simulateIntent(
+  lineage.createIntent(lineage.MEL.actions.increment),
+);
 const lineageReport: Promise<CommitReport<CounterDomain>> = lineage.commitAsyncWithReport(
   lineage.createIntent(lineage.MEL.actions.increment),
 );
@@ -55,6 +58,9 @@ governed.commitAsync;
 governed.commitAsyncWithReport;
 
 void governed.proposeAsync(
+  governed.createIntent(governed.MEL.actions.increment),
+);
+void governed.simulateIntent(
   governed.createIntent(governed.MEL.actions.increment),
 );
 void governed.getLatestHead();

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -50,6 +50,7 @@ const guideSidebar: DefaultTheme.SidebarItem[] = [
       { text: 'Bundler Setup', link: '/guides/bundler-setup' },
       { text: 'Effect Handlers', link: '/guides/effect-handlers' },
       { text: 'Tooling', link: '/guides/developer-tooling' },
+      { text: 'Runtime Tooling Surface', link: '/guides/runtime-tooling-surface' },
       { text: 'Code Generation', link: '/guides/code-generation' },
       { text: 'AI Agents', link: '/integration/ai-agents' },
     ]

--- a/docs/api/actions-and-availability.md
+++ b/docs/api/actions-and-availability.md
@@ -67,7 +67,7 @@ The intended public caller ladder is:
 
 1. `getAvailableActions()` / `isActionAvailable()` for the coarse current decision surface
 2. `getIntentBlockers()` / `whyNot()` / `explainIntent()` for the first failing layer
-3. `simulate()` when the candidate intent is admitted
+3. `simulateIntent(intent)` when the candidate intent is already bound, or `simulate(action, ...input)` when it is not
 4. the runtime write verb when you are ready to execute or submit
 
 ## Agent Pattern

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -44,6 +44,8 @@ If you are learning Manifesto for the first time, start with the [Guide](/guide/
 | [@manifesto-ai/studio-core](./studio-core) | You want projection-first analysis APIs in TypeScript tooling |
 | [@manifesto-ai/studio-mcp](./studio-mcp) | You want an MCP inspection surface for agents or remote clients |
 
+For Studio, agent, and adapter authors building on runtime state directly, read [Runtime Tooling Surface](/guides/runtime-tooling-surface) after the package overview.
+
 ## Related Docs
 
 - [Guide](/guide/introduction)

--- a/docs/api/intents.md
+++ b/docs/api/intents.md
@@ -87,6 +87,8 @@ const blockers = app.whyNot(intent);
 if (blockers) {
   console.log("not admitted", blockers);
 } else {
+  const simulated = app.simulateIntent(intent);
+  console.log(simulated.changedPaths);
   await app.dispatchAsync(intent);
 }
 ```

--- a/docs/api/lineage.md
+++ b/docs/api/lineage.md
@@ -77,8 +77,17 @@ On a lineage runtime:
 - `getWorldSnapshot(worldId)` is the stored sealed canonical snapshot
 - `dispatchAsync()` and `dispatchAsyncWithReport()` are no longer part of the promoted runtime surface
 
+## Lineage-Backed Inspection
+
+Use `getWorldSnapshot(worldId)` when a tool needs to inspect a stored world without changing the live visible runtime. Pair that stored canonical snapshot with `@manifesto-ai/sdk/extensions` for projection, explanation, and read-only simulation.
+
+Use `restore(worldId)` only when the product is intentionally resuming the visible runtime from that world.
+
+The full Studio/tooling recipe is in [Runtime Tooling Surface](/guides/runtime-tooling-surface).
+
 ## Related Docs
 
 - [SDK API](./sdk.md)
 - [Governance API](./governance.md)
+- [Runtime Tooling Surface](/guides/runtime-tooling-surface)
 - [Advanced Runtime Assembly](/guides/governed-composition)

--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -1130,6 +1130,7 @@ _Source: `packages/sdk/src/index.ts`_
 - `TypedMEL`
 - `TypedOn`
 - `TypedSimulate`
+- `TypedSimulateIntent`
 - `TypedSubscribe`
 - `Unsubscribe`
 

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -24,6 +24,7 @@ The base runtime returned by `createManifesto(...).activate()` exposes:
 | `explainIntent(intent)` / `why(intent)` | Explain availability, dispatchability, or dry-run admission |
 | `whyNot(intent)` | Return blockers, or `null` when admitted |
 | `simulate(action, ...input)` | Dry-run against the current runtime state, with optional debug-grade `diagnostics.trace` |
+| `simulateIntent(intent)` | Dry-run an existing typed intent without unpacking or rebinding input |
 | `on(event, handler)` | Subscribe to runtime dispatch events |
 | `dispose()` | Release the runtime and stop future dispatch |
 
@@ -41,7 +42,7 @@ console.log(app.getAvailableActions());
 
 Treat `getAvailableActions()` and `isActionAvailable()` as current-snapshot reads only. They are not durable capability tokens. The active runtime still revalidates legality when it executes or submits work.
 
-`simulate()` is the admitted dry-run step on this surface. It returns the projected next snapshot, dry-run requirements, new available actions, sorted `changedPaths`, and may also expose optional inspection-only `diagnostics.trace` derived from the same dry-run compute pass. SDK dry-run surfaces may normalize volatile host-time fields such as trace-node timestamps or duration so repeated reads stay stable.
+`simulateIntent(intent)` is the admitted dry-run step when your caller already has a typed intent from `createIntent()`. `simulate(action, ...input)` remains the convenience form that binds and dry-runs in one call. Both return the projected next snapshot, dry-run requirements, new available actions, sorted `changedPaths`, and may also expose optional inspection-only `diagnostics.trace` derived from the same dry-run compute pass. SDK dry-run surfaces may normalize volatile host-time fields such as trace-node timestamps or duration so repeated reads stay stable.
 
 ## Legality Ladder
 
@@ -49,7 +50,7 @@ The intended public decision order is:
 
 1. availability via `getAvailableActions()` / `isActionAvailable()`
 2. blocker or explanation reads via `getIntentBlockers()`, `whyNot()`, or `explainIntent()`
-3. admitted dry-run via `simulate()`
+3. admitted dry-run via `simulateIntent()` or `simulate()`
 4. execution via the runtime's write verb
 
 `getIntentBlockers(action, ...input)` is the pre-bind blocker read. `whyNot(intent)` is the bound-intent convenience read. They preserve the same first-failing-layer ordering, but invalid input still rejects through the explanation path before blocker projection.

--- a/docs/api/sdk.md
+++ b/docs/api/sdk.md
@@ -53,6 +53,7 @@ The current effect-authoring helper seam is:
   - `isActionAvailable`
   - `getSchemaGraph`
   - `simulate`
+  - `simulateIntent`
   - `MEL`
   - `schema`
   - `dispose`
@@ -97,6 +98,7 @@ instance.getSnapshot();
 instance.getCanonicalSnapshot();
 instance.getSchemaGraph();
 instance.simulate(instance.MEL.actions.increment);
+instance.simulateIntent(intent);
 console.log(report.kind);
 ```
 
@@ -113,7 +115,7 @@ import type { LineageCommitRuntime } from "@manifesto-ai/lineage";
 import type { GovernanceProposalRuntime } from "@manifesto-ai/governance";
 ```
 
-- `ManifestoLegalityRuntime<T>` is the shared helper-safe legality/preparation surface: `createIntent`, `whyNot`, `simulate`, and `MEL`
+- `ManifestoLegalityRuntime<T>` is the shared helper-safe legality/preparation surface: `createIntent`, `whyNot`, `simulate`, `simulateIntent`, and `MEL`
 - `ManifestoDispatchRuntime<T>` is the base-only execution surface
 - `LineageCommitRuntime<T>` is the lineage-only execution surface
 - `GovernanceProposalRuntime<T>` is the governed-only execution surface
@@ -226,15 +228,27 @@ The intended legality ladder for callers is:
 3. admitted dry-run
 4. execution
 
-`whyNot()` and `getIntentBlockers()` are the lightweight first-failing-layer reads. `simulate()` is the admitted dry-run step.
+`whyNot()` and `getIntentBlockers()` are the lightweight first-failing-layer reads. `simulateIntent(intent)` is the admitted dry-run step when the caller already has a typed intent. `simulate(action, ...args)` remains the convenience form when the caller has not bound an intent yet.
 
 ## Static Graph And Dry-Run Introspection
 
 Use `getSchemaGraph()` when you need the projected static dependency graph for the activated schema. Ref-based lookup through `instance.MEL.*` is the canonical surface; kind-prefixed ids such as `state:count` are debug-only convenience.
 
-Use `simulate()` when you need a non-committing dry-run of an action against the current runtime state. It returns the projected snapshot, effect requirements, new action availability, sorted `changedPaths`, and may also expose optional inspection-only `diagnostics.trace`. Unavailable actions reject with `ACTION_UNAVAILABLE`; available but invalid-input intents reject with `INVALID_INPUT`; available but non-dispatchable intents reject with `INTENT_NOT_DISPATCHABLE`. Treat `changedPaths` and diagnostics as inspection/debug output rather than the canonical branching API.
+Use `simulateIntent(intent)` when tooling has already normalized a candidate operation into a `TypedIntent` through `createIntent()`. It dry-runs that bound intent against the current runtime state without unpacking or rebinding `intent.input`.
 
-If the action is available but the bound intent input is invalid, `simulate()` rejects with `INVALID_INPUT` before dispatchability.
+```typescript
+const intent = instance.createIntent(instance.MEL.actions.increment);
+const explanation = instance.explainIntent(intent);
+
+if (explanation.kind === "admitted") {
+  const simulated = instance.simulateIntent(intent);
+  console.log(simulated.snapshot);
+}
+```
+
+Use `simulate(action, ...args)` when you want the runtime to bind the intent and dry-run it in one call. Both dry-run forms return the projected snapshot, effect requirements, new action availability, sorted `changedPaths`, and may also expose optional inspection-only `diagnostics.trace`. Unavailable actions reject with `ACTION_UNAVAILABLE`; available but invalid-input intents reject with `INVALID_INPUT`; available but non-dispatchable intents reject with `INTENT_NOT_DISPATCHABLE`. Treat `changedPaths` and diagnostics as inspection/debug output rather than the canonical branching API.
+
+If the action is available but the bound intent input is invalid, `simulateIntent()` and `simulate()` reject with `INVALID_INPUT` before dispatchability.
 
 If `diagnostics.trace` is present, it is derived from the dry-run Core trace for the same admitted compute pass that produced the simulated snapshot, status, and requirements. SDK dry-run surfaces may normalize volatile host-time fields such as trace-node timestamps or duration so repeated reads stay stable.
 

--- a/docs/api/studio-core.md
+++ b/docs/api/studio-core.md
@@ -82,9 +82,11 @@ All of these are JSON-serializable and surface-neutral.
 - [`@manifesto-ai/studio-cli`](./studio-cli) wraps this package for terminal workflows.
 - [`@manifesto-ai/studio-mcp`](./studio-mcp) wraps the same analysis surface as MCP tools.
 - UI packages and dashboards should build on this package instead of re-implementing graph or findings logic.
+- [Runtime Tooling Surface](/guides/runtime-tooling-surface) maps Studio-style tooling to the public runtime, snapshot, and lineage seams.
 
 ## Related Docs
 
 - [Developer Tooling Guide](/guides/developer-tooling)
+- [Runtime Tooling Surface](/guides/runtime-tooling-surface)
 - [@manifesto-ai/studio-cli](./studio-cli)
 - [@manifesto-ai/studio-mcp](./studio-mcp)

--- a/docs/guides/developer-tooling.md
+++ b/docs/guides/developer-tooling.md
@@ -17,7 +17,8 @@ Manifesto's current DX stack is intentionally split into a small set of packages
 1. Use [@manifesto-ai/cli](/api/cli) to declare runtime and tooling intent in `manifesto.config.*`.
 2. Run [@manifesto-ai/mel-lsp](/api/mel-lsp) in the editor so MEL authoring stays schema-aware.
 3. Install [@manifesto-ai/skills](/api/skills) only for the AI tools your team actually uses.
-4. Reach for [@manifesto-ai/studio-cli](/api/studio-cli) locally and [@manifesto-ai/studio-mcp](/api/studio-mcp) when an agent or remote client needs read-only inspection tools.
+4. Read [Runtime Tooling Surface](/guides/runtime-tooling-surface) before building custom Studio, agent, or adapter workflows on the public runtime.
+5. Reach for [@manifesto-ai/studio-cli](/api/studio-cli) locally and [@manifesto-ai/studio-mcp](/api/studio-mcp) when an agent or remote client needs read-only inspection tools.
 
 ## Typical Workflows
 
@@ -68,6 +69,7 @@ Put HTTPS in front of the HTTP transport when a remote connector product needs a
 ## Important Boundaries
 
 - Studio snapshot inspection expects canonical snapshots from `runtime.getCanonicalSnapshot()`, not the projected result of `getSnapshot()`.
+- Runtime-aware tools that already hold a typed intent should use `simulateIntent(intent)` for current-snapshot dry-runs and `@manifesto-ai/sdk/extensions` for arbitrary canonical snapshots.
 - `@manifesto-ai/skills` does not auto-install from `postinstall`; setup is always explicit.
 - `@manifesto-ai/studio-core` is read-only and renderer-neutral. It analyzes a bundle and returns JSON projections; it does not execute effects or mutate runtime state.
 
@@ -76,6 +78,7 @@ If the project later needs reviewable writes or sealed history, step out of the 
 ## See Also
 
 - [Quick Start](/guide/quick-start)
+- [Runtime Tooling Surface](/guides/runtime-tooling-surface)
 - [AI Agents](/integration/ai-agents)
 - [When You Need Approval or History](/guides/approval-and-history)
 - [Bundler Setup](/guides/bundler-setup)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -13,6 +13,7 @@ If you are still learning the basics, start with [Quick Start](/guide/quick-star
 | [Debugging](./debugging) | A dispatch does not do what you expected |
 | [Code Generation](./code-generation) | You want generated TypeScript or Zod artifacts from a schema |
 | [Developer Tooling](./developer-tooling) | You want the CLI, MEL editor support, AI skills, or Studio inspection workflow |
+| [Runtime Tooling Surface](./runtime-tooling-surface) | You are building Studio, agent, or adapter tooling on public runtime contracts |
 | [Re-entry Safety](./reentry-safe-flows) | An action or effect runs more than once |
 
 ## Add The Advanced Runtime Later

--- a/docs/guides/runtime-tooling-surface.md
+++ b/docs/guides/runtime-tooling-surface.md
@@ -1,0 +1,112 @@
+# Runtime Tooling Surface
+
+> A curated contract map for Studio, agent adapters, and runtime-aware tools.
+
+Use this guide when you are building a tool that reads Manifesto runtime state, explains candidate intents, simulates transitions, or inspects lineage-backed history. The owning API and SPEC pages remain the normative source; this page connects the public seams that tooling consumers usually need together.
+
+## Contract Map
+
+| Need | Public Seam | Owning Docs |
+|------|-------------|-------------|
+| Runtime schema artifact | `DomainSchema` | [Application API](/api/application), [Current Contract](/internals/spec/current-contract) |
+| Tooling-only compiler sidecars | `DomainModule` | [Compiler API](/api/compiler) |
+| Computed declarations | `ComputedSpec` | [Core API](/api/core), [Public Surface Inventory](/api/public-surface) |
+| Action declarations | `ActionSpec` | [Core API](/api/core), [Public Surface Inventory](/api/public-surface) |
+| Runtime typing seam | `state.fieldTypes`, `action.inputType`, `action.params` | [Compiler API](/api/compiler), [Current Contract](/internals/spec/current-contract) |
+| Current-snapshot legality | `isActionAvailable()`, `whyNot()`, `explainIntent()` | [Actions and Availability](/api/actions-and-availability), [SDK API](/api/sdk) |
+| Current-snapshot dry-run | `simulateIntent(intent)`, `simulate(action, ...args)` | [Runtime Instance](/api/runtime), [SDK API](/api/sdk) |
+| Arbitrary-snapshot read-only analysis | `@manifesto-ai/sdk/extensions` | [SDK API](/api/sdk) |
+| Sealed world inspection | `getWorldSnapshot(worldId)` | [Lineage API](/api/lineage) |
+| Visible runtime resume | `restore(worldId)` | [Lineage API](/api/lineage) |
+
+## Intent-Centered Tooling Loop
+
+Tooling should normalize a candidate operation into one typed intent, then reuse that same value across explanation, dry-run, and the runtime write verb.
+
+```typescript
+const intent = app.createIntent(app.MEL.actions.spend, { amount: 20 });
+const explanation = app.explainIntent(intent);
+
+if (explanation.kind === "blocked") {
+  console.log(explanation.blockers);
+}
+
+if (explanation.kind === "admitted") {
+  const simulated = app.simulateIntent(intent);
+  console.log(simulated.changedPaths);
+  await app.dispatchAsync(intent);
+}
+```
+
+`simulateIntent(intent)` is the bound-intent dry-run path. Use it when your tool already has a `TypedIntent`. `simulate(action, ...args)` remains supported when you want the runtime to bind and dry-run in one call.
+
+The legality order is stable:
+
+1. availability
+2. input validation
+3. dispatchability
+4. admitted dry-run
+5. execution or proposal submission
+
+Unavailable actions reject dry-run with `ACTION_UNAVAILABLE`. Available actions with invalid input reject with `INVALID_INPUT` before dispatchability. Available actions with valid input but a failing fine gate reject with `INTENT_NOT_DISPATCHABLE`.
+
+## Runtime Typing Seam
+
+`ActionSpec.input` is the compatibility field-shape surface. Tools that need precise type information should prefer the current runtime typing seam:
+
+- `action.params` preserves action parameter order.
+- `action.inputType` carries the exact action-input `TypeDefinition` when present.
+- `state.fieldTypes` carries exact state-field `TypeDefinition` data when present.
+
+`ComputedSpec` remains the public declaration surface for derived values. Runtime consumers read computed values through snapshots; tooling consumers inspect computed declarations through the schema and graph projections.
+
+Runtime entry points consume `DomainSchema`. `DomainModule` sidecars, including compiler-owned annotations and source maps, are for tooling and build-time inspection only.
+
+## Snapshot Roles
+
+| Snapshot Role | Read With | Meaning |
+|---------------|-----------|---------|
+| Projected runtime snapshot | `getSnapshot()` | Default app-facing read model |
+| Current visible canonical snapshot | `getCanonicalSnapshot()` | Full substrate for persistence, debugging, and extension-kernel reads |
+| Stored sealed world snapshot | `getWorldSnapshot(worldId)` | Historical canonical snapshot sealed by Lineage |
+
+Use `getSnapshot()` for normal UI and application reads. Use `getCanonicalSnapshot()` when a tool needs the full substrate for extension-kernel analysis. Use `getWorldSnapshot(worldId)` to inspect a stored lineage world without changing the visible runtime.
+
+## Lineage-Backed Inspection
+
+For Studio-style history views, inspect stored worlds through Lineage and run read-only analysis through the SDK extension seam.
+
+```typescript
+import { getExtensionKernel } from "@manifesto-ai/sdk/extensions";
+
+const ext = getExtensionKernel(app);
+const sealed = await app.getWorldSnapshot(worldId);
+
+if (sealed) {
+  const projected = ext.projectSnapshot(sealed);
+  const intent = ext.createIntent(ext.MEL.actions.spend, { amount: 20 });
+  const explanation = ext.explainIntentFor(sealed, intent);
+
+  if (explanation.kind === "admitted") {
+    const simulated = ext.simulateSync(sealed, intent);
+    const simulatedProjected = ext.projectSnapshot(simulated.snapshot);
+    console.log(projected, simulatedProjected);
+  }
+}
+```
+
+Use `getWorldSnapshot(worldId)` for read-only historical inspection. Use `restore(worldId)` only when the product is intentionally resuming the visible runtime from that world. Normal tools should not call provider mutation helpers such as visible-snapshot setters.
+
+## Studio Boundaries
+
+`@manifesto-ai/studio-core` is projection-first and read-only. It accepts `DomainSchema` plus optional canonical snapshot, trace, lineage, and governance overlays, then returns JSON projections. It does not execute effects, apply patches, or mutate runtime state.
+
+Studio and agent tools should keep continuity in Lineage rather than inventing local shadow history. If a value matters to future computation, it belongs in Snapshot or a sealed lineage world, not in a private tool cache.
+
+## Related Docs
+
+- [Developer Tooling](/guides/developer-tooling)
+- [SDK API](/api/sdk)
+- [Lineage API](/api/lineage)
+- [Studio Core API](/api/studio-core)
+- [Current Contract](/internals/spec/current-contract)

--- a/docs/internals/spec/current-contract.md
+++ b/docs/internals/spec/current-contract.md
@@ -84,7 +84,8 @@ Current contract highlights:
 - `createIntent()` is anchored on the generated `MEL.actions.*` surface.
 - `dispatchAsync()` is the canonical base-runtime execution verb.
 - `dispatchAsyncWithReport()` is the additive base write-report companion.
-- `simulate()` is the non-committing dry-run surface and may expose debug-grade `diagnostics.trace`.
+- `simulateIntent(intent)` is the bound-intent non-committing dry-run surface and may expose debug-grade `diagnostics.trace`.
+- `simulate(action, ...args)` remains the action-ref convenience dry-run surface and delegates to the same bound-intent semantics.
 - `getSchemaGraph()` is the projected static graph read.
 - `isActionAvailable()` remains the coarse gate query.
 - `isIntentDispatchable()` and `getIntentBlockers()` are the fine legality/introspection queries.

--- a/packages/governance/docs/governance-SPEC.md
+++ b/packages/governance/docs/governance-SPEC.md
@@ -90,7 +90,7 @@ The inherited read surfaces keep their lineage/SDK meanings:
 - `getSnapshot()` is the projected application-facing runtime read
 - `getCanonicalSnapshot()` is the current visible canonical runtime substrate
 - `getWorldSnapshot(worldId)` is the stored canonical snapshot for a sealed world
-- `getAvailableActions()`, `isActionAvailable()`, `isIntentDispatchable()`, `getIntentBlockers()`, `getActionMetadata()`, `getSchemaGraph()`, and `simulate()` remain inherited read/query surfaces
+- `getAvailableActions()`, `isActionAvailable()`, `isIntentDispatchable()`, `getIntentBlockers()`, `getActionMetadata()`, `getSchemaGraph()`, `simulateIntent()`, and `simulate()` remain inherited read/query surfaces
 - `getAvailableActions()` and `isActionAvailable()` remain current visible-snapshot observational reads, not durable capability grants
 - inherited legality queries preserve the base SDK ordering: availability is checked before dispatchability
 - inherited `getIntentBlockers()` returns the first failing layer, so unavailable intents surface an `available` blocker without evaluating `dispatchable`

--- a/packages/governance/src/__tests__/types/helper-boundary.typecheck.ts
+++ b/packages/governance/src/__tests__/types/helper-boundary.typecheck.ts
@@ -32,7 +32,7 @@ function prepareIntent<
   const intent = runtime.createIntent(action, ...intentArgs);
   const blockers = runtime.whyNot(intent);
   if (blockers === null) {
-    void runtime.simulate(action, ...intentArgs);
+    void runtime.simulateIntent(intent);
   }
   return intent;
 }

--- a/packages/governance/src/with-governance.ts
+++ b/packages/governance/src/with-governance.ts
@@ -525,6 +525,7 @@ function activateGovernanceRuntime<T extends ManifestoDomainShape>(
     getActionMetadata: kernel.getActionMetadata,
     isActionAvailable: kernel.isActionAvailable,
     simulate: kernel.simulate,
+    simulateIntent: kernel.simulateIntent,
     explainIntent,
     why,
     whyNot,

--- a/packages/lineage/docs/lineage-SPEC.md
+++ b/packages/lineage/docs/lineage-SPEC.md
@@ -108,7 +108,7 @@ Normative rules:
 
 `getSnapshot()` remains the projected runtime read model inherited from SDK. `getCanonicalSnapshot()` returns the current visible runtime substrate. `getWorldSnapshot(worldId)` is different again: it reads the stored sealed canonical substrate for a specific world from lineage storage.
 
-The inherited SDK read surface also remains available on the activated lineage runtime, including `getAvailableActions()`, `isActionAvailable()`, `isIntentDispatchable()`, `getIntentBlockers()`, `getActionMetadata()`, `getSchemaGraph()`, and `simulate()`.
+The inherited SDK read surface also remains available on the activated lineage runtime, including `getAvailableActions()`, `isActionAvailable()`, `isIntentDispatchable()`, `getIntentBlockers()`, `getActionMetadata()`, `getSchemaGraph()`, `simulateIntent()`, and `simulate()`.
 
 `LineageCommitRuntime<T>` is the additive helper-boundary alias for lineage execution helpers. It does not reintroduce any base `dispatchAsync()` assumption into the promoted runtime.
 

--- a/packages/lineage/src/__tests__/types/helper-boundary.typecheck.ts
+++ b/packages/lineage/src/__tests__/types/helper-boundary.typecheck.ts
@@ -28,7 +28,7 @@ function prepareIntent<
   const intent = runtime.createIntent(action, ...intentArgs);
   const blockers = runtime.whyNot(intent);
   if (blockers === null) {
-    void runtime.simulate(action, ...intentArgs);
+    void runtime.simulateIntent(intent);
   }
   return intent;
 }

--- a/packages/lineage/src/with-lineage.ts
+++ b/packages/lineage/src/with-lineage.ts
@@ -359,6 +359,7 @@ function activateLineageRuntime<T extends ManifestoDomainShape>(
     getActionMetadata: kernel.getActionMetadata,
     isActionAvailable: kernel.isActionAvailable,
     simulate: kernel.simulate,
+    simulateIntent: kernel.simulateIntent,
     explainIntent,
     why,
     whyNot,

--- a/packages/sdk/docs/GUIDE.md
+++ b/packages/sdk/docs/GUIDE.md
@@ -2,7 +2,7 @@
 
 > Practical guide for the activation-first `@manifesto-ai/sdk` path.
 
-> **Current Contract Note:** This guide follows the current SDK v3.x living contract. `createManifesto()` returns a composable manifesto, runtime verbs appear only after `activate()`, the base surface includes dispatchability queries and projected introspection, `dispatchAsyncWithReport()` is the additive base write-report companion, and `@manifesto-ai/sdk/extensions` provides the safe post-activation arbitrary-snapshot seam plus a first-party simulation-session helper.
+> **Current Contract Note:** This guide follows the current SDK v3.x living contract. `createManifesto()` returns a composable manifesto, runtime verbs appear only after `activate()`, the base surface includes dispatchability queries, projected introspection, and bound-intent dry-run through `simulateIntent(intent)`, `dispatchAsyncWithReport()` is the additive base write-report companion, and `@manifesto-ai/sdk/extensions` provides the safe post-activation arbitrary-snapshot seam plus a first-party simulation-session helper.
 
 ## 1. Build The Activation Lifecycle
 
@@ -22,6 +22,7 @@ const snapshot = instance.getSnapshot();
 const canonical = instance.getCanonicalSnapshot();
 const graph = instance.getSchemaGraph();
 const preview = instance.simulate(instance.MEL.actions.increment);
+const intentPreview = instance.simulateIntent(intent);
 ```
 
 This is the normal SDK lifecycle:
@@ -103,7 +104,8 @@ const downstream = graph.traceDown(instance.MEL.state.count);
 const upstream = graph.traceUp(instance.MEL.actions.incrementIfEven);
 const debug = graph.traceDown("state:count");
 
-const preview = instance.simulate(instance.MEL.actions.increment);
+const intent = instance.createIntent(instance.MEL.actions.increment);
+const preview = instance.simulateIntent(intent);
 
 console.log(preview.snapshot);
 console.log(preview.changedPaths);
@@ -112,7 +114,7 @@ console.log(preview.newAvailableActions);
 
 Use `getSchemaGraph()` for projected static dependency inspection. Ref-based lookup through `instance.MEL.*` is canonical. Kind-prefixed ids such as `state:count` remain convenience/debug-only.
 
-Use `simulate()` for a non-committing dry-run against the current canonical snapshot. It returns the projected next snapshot, effect requirements, new availability, sorted `changedPaths`, and optional debug-grade `diagnostics.trace`. Treat `changedPaths` and diagnostics as explanation/debug output rather than the branching API.
+Use `simulateIntent(intent)` when you already have a typed intent. Use `simulate(action, ...args)` when you want the runtime to bind and dry-run in one call. Both perform a non-committing dry-run against the current canonical snapshot and return the projected next snapshot, effect requirements, new availability, sorted `changedPaths`, and optional debug-grade `diagnostics.trace`. Treat `changedPaths` and diagnostics as explanation/debug output rather than the branching API.
 
 ---
 

--- a/packages/sdk/docs/VERSION-INDEX.md
+++ b/packages/sdk/docs/VERSION-INDEX.md
@@ -1,13 +1,13 @@
 # SDK Version Index
 
 > **Package:** `@manifesto-ai/sdk`
-> **Last Updated:** 2026-04-13
+> **Last Updated:** 2026-04-24
 
 ## Current Contract
 
 | Version | Document | ADR | Notes | Status |
 |---------|----------|-----|-------|--------|
-| v3.x | [SPEC](sdk-SPEC.md) | [ADR-017](../../../docs/internals/adr/017-capability-decorator-pattern.md), [ADR-019](../../../docs/internals/adr/019-post-activation-extension-kernel.md), [ADR-020](../../../docs/internals/adr/020-intent-level-dispatchability.md) | Activation-first SDK with `activate()`, typed `createIntent()` including non-ambiguous single-parameter object binding, dequeue-time rejection codes for coarse vs fine legality, current-snapshot blocker explanations, projected `SchemaGraph`, `simulate()` with optional debug-grade `diagnostics.trace`, the additive base write-report companion `dispatchAsyncWithReport()`, the `@manifesto-ai/sdk/extensions` Extension Kernel including arbitrary-snapshot `isIntentDispatchableFor()`, the first-party `createSimulationSession()` helper, and the public provider authoring seam including `createBaseRuntimeInstance()` | Current |
+| v3.x | [SPEC](sdk-SPEC.md) | [ADR-017](../../../docs/internals/adr/017-capability-decorator-pattern.md), [ADR-019](../../../docs/internals/adr/019-post-activation-extension-kernel.md), [ADR-020](../../../docs/internals/adr/020-intent-level-dispatchability.md) | Activation-first SDK with `activate()`, typed `createIntent()` including non-ambiguous single-parameter object binding, dequeue-time rejection codes for coarse vs fine legality, current-snapshot blocker explanations, projected `SchemaGraph`, bound-intent `simulateIntent(intent)` plus action-ref `simulate()` with optional debug-grade `diagnostics.trace`, the additive base write-report companion `dispatchAsyncWithReport()`, the `@manifesto-ai/sdk/extensions` Extension Kernel including arbitrary-snapshot `isIntentDispatchableFor()`, the first-party `createSimulationSession()` helper, and the public provider authoring seam including `createBaseRuntimeInstance()` | Current |
 
 ## Draft Rationale Track
 

--- a/packages/sdk/docs/sdk-SPEC.md
+++ b/packages/sdk/docs/sdk-SPEC.md
@@ -8,7 +8,7 @@
 
 > **Historical Note:** Pre-ADR-017 SDK surfaces live in Git history. They are no longer kept as active package docs in the working tree.
 >
-> **Current Contract Status:** Projected introspection, intent-level dispatchability, refined single-parameter object binding in `createIntent()`, the `@manifesto-ai/sdk/extensions` Extension Kernel, the first-party `createSimulationSession()` helper on that seam, additive intent explanation reads via `explainIntentFor()`, `explainIntent()`, `why()`, and `whyNot()`, the helper-boundary capability aliases `ManifestoLegalityRuntime<T>` and `ManifestoDispatchRuntime<T>`, and the additive base write-report companion `dispatchAsyncWithReport()` are all part of the current SDK contract. The compiler-side extraction contract now lives in [SPEC-v1.1.0](../../compiler/docs/SPEC-v1.1.0.md), including tooling-only structural annotations via `@meta` and declaration-level source maps through `DomainModule.sourceMap`.
+> **Current Contract Status:** Projected introspection, intent-level dispatchability, refined single-parameter object binding in `createIntent()`, bound-intent dry-run via `simulateIntent(intent)`, the `@manifesto-ai/sdk/extensions` Extension Kernel, the first-party `createSimulationSession()` helper on that seam, additive intent explanation reads via `explainIntentFor()`, `explainIntent()`, `why()`, and `whyNot()`, the helper-boundary capability aliases `ManifestoLegalityRuntime<T>` and `ManifestoDispatchRuntime<T>`, and the additive base write-report companion `dispatchAsyncWithReport()` are all part of the current SDK contract. The compiler-side extraction contract now lives in [SPEC-v1.1.0](../../compiler/docs/SPEC-v1.1.0.md), including tooling-only structural annotations via `@meta` and declaration-level source maps through `DomainModule.sourceMap`.
 
 ## 1. Purpose
 
@@ -37,7 +37,7 @@ Normative rule prefixes:
 | `SDK-REPORT-*` | additive base write-report semantics |
 | `SDK-REPORT-SUB-*` | shared internal report substrate semantics |
 | `SDK-GRAPH-*` | `getSchemaGraph()` and `SchemaGraph` semantics |
-| `SDK-SIM-*` | `simulate()` semantics |
+| `SDK-SIM-*` | public dry-run semantics |
 | `SDK-EXT-*` | `@manifesto-ai/sdk/extensions` semantics |
 | `SDK-EXT-EXPLAIN-*` | extension-kernel intent explanation semantics |
 | `SDK-EXPLAIN-RT-*` | activated-runtime explanation convenience semantics |
@@ -600,6 +600,9 @@ type ManifestoBaseInstance<T extends ManifestoDomainShape> = {
     action: TypedActionRef<T, K>,
     ...args: CreateIntentArgs<T, K>
   ) => SimulateResult<T>;
+  readonly simulateIntent: <K extends keyof T["actions"]>(
+    intent: TypedIntent<T, K>
+  ) => SimulateResult<T>;
   readonly MEL: TypedMEL<T>;
   readonly schema: DomainSchema;
   readonly dispose: () => void;
@@ -617,7 +620,7 @@ The SDK also defines additive helper-boundary aliases:
 ```typescript
 type ManifestoLegalityRuntime<T extends ManifestoDomainShape> = Pick<
   ManifestoBaseInstance<T>,
-  "createIntent" | "whyNot" | "simulate" | "MEL"
+  "createIntent" | "whyNot" | "simulate" | "simulateIntent" | "MEL"
 >;
 
 type ManifestoDispatchRuntime<T extends ManifestoDomainShape> = Pick<
@@ -888,16 +891,16 @@ The legality ordering is normative:
 1. evaluate action availability
 2. if available, validate bound intent input against the activated action contract
 3. if input is valid, evaluate bound-intent dispatchability
-4. if admitted, perform the same dry-run transition contract as `simulate()`
+4. if admitted, perform the same dry-run transition contract as `simulateIntent()`
 
 The intended public legality ladder is:
 
 1. coarse availability via `getAvailableActions()` / `isActionAvailable()`
 2. first-failing-layer blocker or explanation reads via `getIntentBlockers()`, `whyNot()`, or `explainIntent()`
-3. admitted dry-run via `simulate()`
+3. admitted dry-run via `simulateIntent()` or `simulate()`
 4. runtime execution via `dispatchAsync()` or the additive report companion `dispatchAsyncWithReport()`
 
-`getIntentBlockers()` and `whyNot()` are the lightweight first-failing-layer reads. `getIntentBlockers()` is the pre-bind blocker query surface; `whyNot()` is the bound-intent convenience projection. `simulate()` is the admitted dry-run step. SDK MUST NOT require a second agent-only legality surface for that caller decision path.
+`getIntentBlockers()` and `whyNot()` are the lightweight first-failing-layer reads. `getIntentBlockers()` is the pre-bind blocker query surface; `whyNot()` is the bound-intent convenience projection. `simulateIntent(intent)` is the admitted dry-run step for callers that already hold a typed intent. `simulate(action, ...args)` remains the action-ref convenience form. SDK MUST NOT require a second agent-only legality surface for that caller decision path.
 
 If the action is unavailable, explanation reads MUST return the unavailable blocked result and MUST NOT surface invalid-input failures hidden behind that unavailable action.
 
@@ -940,26 +943,28 @@ The only supported graph relations are `feeds`, `mutates`, and `unlocks`.
 
 Input-dependent `dispatchable when` predicates MUST NOT be projected into `SchemaGraph`. The public graph remains a static schema-derived artifact over `available when`, writes, and computed dependencies only.
 
-### 7.5 `simulate()`
+### 7.5 `simulateIntent()` and `simulate()`
 
-`simulate()` performs a pure dry-run of an action against the current canonical snapshot without committing the result.
+`simulateIntent(intent)` performs a pure dry-run of an existing typed intent against the current canonical snapshot without committing the result.
 
-It MUST use the same intent packing as `createIntent()` and the same deterministic HostContext construction as `dispatchAsync()`.
+`simulate(action, ...args)` is the action-ref convenience form. It MUST bind the intent through the same SDK-owned packing rules as `createIntent()` and then use the same bound-intent dry-run semantics as `simulateIntent(intent)`.
 
-If the action is unavailable against the current canonical snapshot, `simulate()` MUST throw `ManifestoError` with code `ACTION_UNAVAILABLE`.
+Both dry-run forms MUST use the same deterministic HostContext construction as `dispatchAsync()`.
 
-If the action is available but the bound intent input is invalid against the current canonical snapshot, `simulate()` MUST throw `ManifestoError` with code `INVALID_INPUT`.
+If the action is unavailable against the current canonical snapshot, both dry-run forms MUST throw `ManifestoError` with code `ACTION_UNAVAILABLE`.
 
-If the action is available but the bound intent is not dispatchable against the current canonical snapshot, `simulate()` MUST throw `ManifestoError` with code `INTENT_NOT_DISPATCHABLE`.
+If the action is available but the bound intent input is invalid against the current canonical snapshot, both dry-run forms MUST throw `ManifestoError` with code `INVALID_INPUT`.
 
-For a successful dry-run, `simulate()` MUST:
+If the action is available but the bound intent is not dispatchable against the current canonical snapshot, both dry-run forms MUST throw `ManifestoError` with code `INTENT_NOT_DISPATCHABLE`.
+
+For a successful dry-run, both dry-run forms MUST:
 
 1. call Core `computeSync()`
 2. apply the emitted patches with Core `apply()`
 3. apply the emitted system transition with Core `applySystemDelta()`
 4. project the resulting canonical snapshot through the same public lens as `getSnapshot()`
 
-`simulate().snapshot` is the projected public snapshot that would become visible if the action ran now.
+The returned `snapshot` is the projected public snapshot that would become visible if the action ran now.
 
 `changedPaths` is an inspection/debug-only diff of the projected public snapshot. Callers SHOULD use `snapshot`, `getAvailableActions()`, `isActionAvailable()`, or explicit snapshot reads for programmatic branching instead of branching on display-path strings.
 
@@ -1114,7 +1119,7 @@ Blocker construction reuses the same internal blocker path as the base runtime's
 For `snapshot === app.getCanonicalSnapshot()` and an intent created from the same activated runtime:
 
 - blocked results MUST be semantically equivalent to `getIntentBlockers()` at the first failing layer
-- admitted results MUST be semantically equivalent to `simulate()` for projected snapshot, status, requirements, new available actions, and changed paths
+- admitted results MUST be semantically equivalent to the public current-snapshot dry-run surface for projected snapshot, status, requirements, new available actions, and changed paths
 
 #### 7.10.2 `createSimulationSession()`
 
@@ -1207,7 +1212,7 @@ Dispose MUST release all SDK-owned resources for the activated base instance, in
 | SDK-BASE-4 | MUST | `getAvailableActions()`, `isActionAvailable()`, `isIntentDispatchable()`, `getIntentBlockers()`, and `getActionMetadata()` MUST be typed from `keyof T["actions"]` |
 | SDK-BASE-5 | MUST | The canonical public surface MUST be the instance object; destructuring is optional ergonomics only |
 | SDK-BASE-6 | MUST NOT | The base SDK contract MUST NOT define top-level `dispatchAsync(instance, intent)` or `dispatchAsyncWithReport(instance, intent)` as normative execution surfaces |
-| SDK-BASE-7 | MUST | `getSchemaGraph()` and `simulate()` MUST remain read-only instance conveniences; they MUST NOT commit or publish runtime state |
+| SDK-BASE-7 | MUST | `getSchemaGraph()`, `simulateIntent()`, and `simulate()` MUST remain read-only instance conveniences; they MUST NOT commit or publish runtime state |
 | SDK-EXPLAIN-RT-1 | MUST | `explainIntent()` MUST evaluate against the runtime's current visible canonical snapshot only |
 | SDK-EXPLAIN-RT-2 | MUST | `explainIntent()` MUST be observationally pure |
 | SDK-EXPLAIN-RT-3 | MUST | `explainIntent()` MUST delegate to the extension-kernel explanation substrate rather than reimplementing a second explanation model |
@@ -1231,7 +1236,7 @@ Dispose MUST release all SDK-owned resources for the activated base instance, in
 | SDK-REPORT-SUB-2 | MUST | Shared report admission derivation MUST preserve the current legality order: availability -> input validation -> dispatchability |
 | SDK-REPORT-SUB-3 | MUST | Shared report admission derivation MUST continue to hide invalid-input failures behind an unavailable action |
 | SDK-REPORT-SUB-4 | MUST | First-failing-layer behavior MUST remain aligned with current blocker/explanation and rejected-dispatch semantics |
-| SDK-REPORT-SUB-5 | MUST | Projected changed-path derivation MUST reuse the same projected diff semantics already used by `simulate()` and admitted `explainIntent()` |
+| SDK-REPORT-SUB-5 | MUST | Projected changed-path derivation MUST reuse the same projected diff semantics already used by public dry-run results and admitted `explainIntent()` |
 | SDK-REPORT-SUB-6 | MUST | Failure classification MUST distinguish host-stage failure from reserved promoted-runtime seal-stage failure without fabricating a completed outcome |
 | SDK-REPORT-1 | MUST | `dispatchAsyncWithReport()` MUST preserve the same dequeue-time legality ordering and publication semantics as `dispatchAsync()` |
 | SDK-REPORT-2 | MUST NOT | `dispatchAsyncWithReport()` MUST NOT change the behavior or return contract of `dispatchAsync()` |
@@ -1250,31 +1255,33 @@ Dispose MUST release all SDK-owned resources for the activated base instance, in
 | SDK-GRAPH-4 | MUST | the only public relation labels are `feeds`, `mutates`, and `unlocks` |
 | SDK-GRAPH-5 | MUST | `traceUp()` and `traceDown()` ref overloads are the canonical SDK query surface |
 | SDK-GRAPH-6 | MUST | string lookup overloads MUST accept only kind-prefixed node ids and MUST be treated as convenience/debug-only |
-| SDK-SIM-1 | MUST NOT | SDK implementations let `simulate()` mutate, commit, or publish runtime state |
+| SDK-SIM-1 | MUST NOT | SDK implementations let `simulateIntent()` or `simulate()` mutate, commit, or publish runtime state |
 | SDK-SIM-2 | MUST | unavailable simulated actions MUST throw `ManifestoError` code `ACTION_UNAVAILABLE` before dry-run compute begins |
 | SDK-SIM-2b | MUST | available but invalid-input simulated intents MUST throw `ManifestoError` code `INVALID_INPUT` before dispatchability evaluation or dry-run compute begins |
 | SDK-SIM-2a | MUST | available but non-dispatchable simulated intents MUST throw `ManifestoError` code `INTENT_NOT_DISPATCHABLE` before dry-run compute begins |
-| SDK-SIM-3 | MUST | `simulate()` MUST use the same intent packing and HostContext construction as normal dispatch |
-| SDK-SIM-4 | MUST | `simulate()` MUST apply both Core `apply()` and Core `applySystemDelta()` to produce a complete simulated snapshot |
-| SDK-SIM-5 | MUST | `simulate().snapshot` MUST return the same projected surface shape as `getSnapshot()` |
-| SDK-SIM-6 | MUST | `simulate().newAvailableActions` MUST be evaluated against the canonical simulated snapshot |
-| SDK-SIM-7 | MUST | `simulate().changedPaths` MUST be diffed from the projected public snapshot only and MUST be treated as inspection/debug-only, not as the canonical branching API |
-| SDK-SIM-8 | MUST | `simulate().status` MUST mirror Core `ComputeStatus` exactly, including `halted` |
-| SDK-SIM-9 | MUST | If `simulate().diagnostics` is present, `diagnostics.trace` MUST be derived from the Core `ComputeResult.trace` from the same admitted dry-run compute pass, and MAY normalize volatile host-time fields such as node timestamps or duration |
-| SDK-SIM-10 | MUST | The presence or absence of `simulate().diagnostics` MUST NOT change dry-run legality, snapshot projection, status, requirements, changed paths, or new available actions |
+| SDK-SIM-3 | MUST | `simulate(action, ...args)` MUST use the same intent packing as `createIntent()` before dry-run |
+| SDK-SIM-3a | MUST | `simulateIntent(intent)` MUST accept the existing typed intent directly without requiring callers to unpack or re-bind `intent.input` |
+| SDK-SIM-3b | MUST | Both dry-run forms MUST use the same HostContext construction as normal dispatch |
+| SDK-SIM-4 | MUST | Both dry-run forms MUST apply both Core `apply()` and Core `applySystemDelta()` to produce a complete simulated snapshot |
+| SDK-SIM-5 | MUST | Dry-run result `snapshot` MUST return the same projected surface shape as `getSnapshot()` |
+| SDK-SIM-6 | MUST | Dry-run result `newAvailableActions` MUST be evaluated against the canonical simulated snapshot |
+| SDK-SIM-7 | MUST | Dry-run result `changedPaths` MUST be diffed from the projected public snapshot only and MUST be treated as inspection/debug-only, not as the canonical branching API |
+| SDK-SIM-8 | MUST | Dry-run result `status` MUST mirror Core `ComputeStatus` exactly, including `halted` |
+| SDK-SIM-9 | MUST | If dry-run `diagnostics` is present, `diagnostics.trace` MUST be derived from the Core `ComputeResult.trace` from the same admitted dry-run compute pass, and MAY normalize volatile host-time fields such as node timestamps or duration |
+| SDK-SIM-10 | MUST | The presence or absence of dry-run `diagnostics` MUST NOT change legality, snapshot projection, status, requirements, changed paths, or new available actions |
 | SDK-EXT-1 | MUST | `getExtensionKernel()` MUST accept only activated runtime instances and MUST return a frozen, bound Extension Kernel |
 | SDK-EXT-2 | MUST | `ExtensionKernel.projectSnapshot()` MUST apply the same public projection boundary as `getSnapshot()` |
 | SDK-EXT-3 | MUST | `ExtensionKernel.projectSnapshot()` MUST be observationally pure; it MUST NOT be implemented by mutating the visible runtime snapshot and reading it back |
-| SDK-EXT-4 | MUST | `ExtensionKernel.simulateSync()` MUST use the same `computeSync -> apply -> applySystemDelta` transition contract as `simulate()` |
-| SDK-EXT-5 | MUST | `ExtensionKernel.simulateSync()` MUST preserve the same unavailable-action and non-dispatchable-intent rejection semantics as `simulate()` |
+| SDK-EXT-4 | MUST | `ExtensionKernel.simulateSync()` MUST use the same `computeSync -> apply -> applySystemDelta` transition contract as public dry-run |
+| SDK-EXT-5 | MUST | `ExtensionKernel.simulateSync()` MUST preserve the same unavailable-action and non-dispatchable-intent rejection semantics as public dry-run |
 | SDK-EXT-6 | MUST | `ExtensionKernel.getAvailableActionsFor()`, `isActionAvailableFor()`, and `isIntentDispatchableFor()` MUST evaluate against the caller-provided canonical snapshot |
 | SDK-EXT-7 | MUST NOT | `@manifesto-ai/sdk/extensions` MUST expose publication-control, execution-control, queue-control, or provider-activation helpers |
 | SDK-EXT-8 | MUST NOT | Calls through `ExtensionKernel` MUST mutate the visible runtime snapshot, trigger subscribers, emit runtime events, or enqueue work on the source runtime |
 | SDK-EXT-9 | MUST | `ExtensionKernel.MEL`, `schema`, `createIntent`, and `getCanonicalSnapshot()` MUST remain observationally equivalent to the corresponding activated-runtime members |
-| SDK-EXT-10 | MUST | `ExtensionSimulateResult` MUST remain canonical and minimal; projected `changedPaths` and `newAvailableActions` belong to `simulate()` or explicit follow-up extension calls, not to `simulateSync()` |
+| SDK-EXT-10 | MUST | `ExtensionSimulateResult` MUST remain canonical and minimal; projected `changedPaths` and `newAvailableActions` belong to public dry-run results or explicit follow-up extension calls, not to `simulateSync()` |
 | SDK-EXT-10a | MAY | `ExtensionSimulateResult` MAY include optional debug-grade `diagnostics.trace` sourced from the same dry-run Core `ComputeResult.trace`, with volatile host-time fields normalized for stability |
 | SDK-EXT-10b | MUST | Optional `diagnostics.trace` on `ExtensionSimulateResult` MUST NOT be treated as projected convenience data or execution control, and MUST NOT change the observational purity of the extension seam |
-| SDK-EXT-11 | MUST | For `snapshot === app.getCanonicalSnapshot()` and an intent created from the same activated runtime, `projectSnapshot(result.snapshot)`, `result.status`, `result.requirements`, and `getAvailableActionsFor(result.snapshot)` from `simulateSync(snapshot, intent)` MUST match public `simulate()` semantics |
+| SDK-EXT-11 | MUST | For `snapshot === app.getCanonicalSnapshot()` and an intent created from the same activated runtime, `projectSnapshot(result.snapshot)`, `result.status`, `result.requirements`, and `getAvailableActionsFor(result.snapshot)` from `simulateSync(snapshot, intent)` MUST match public dry-run semantics |
 | SDK-EXT-12 | MUST | Observationally pure `ExtensionKernel` methods MUST remain callable after `dispose()` and MUST NOT reject solely because the source runtime has been disposed |
 | SDK-EXT-13 | MUST | `createSimulationSession()` MUST share the same safe substrate as `ExtensionKernel`; it MUST NOT require provider-only access or bypass the extension boundary with provider-only capabilities |
 | SDK-EXT-14 | MUST | The root `SimulationSession` MUST start from `getCanonicalSnapshot()` and expose both the projected `snapshot` and the canonical substrate explicitly as `canonicalSnapshot` |
@@ -1458,13 +1465,13 @@ An SDK v3.x implementation complies with this living contract only if all of the
 - `activate()` is one-shot and throws `AlreadyActivatedError` on repeat use.
 - `ManifestoConfig` does not exist in the v3 contract.
 - SDK no longer presents `@manifesto-ai/world` as part of its public story.
-- The base activated runtime exposes `createIntent`, `dispatchAsync`, `dispatchAsyncWithReport`, `subscribe`, `on`, `getSnapshot`, `getCanonicalSnapshot`, availability queries, dispatchability queries, intent explanation reads, `getSchemaGraph`, `simulate`, `MEL`, `schema`, and `dispose`.
+- The base activated runtime exposes `createIntent`, `dispatchAsync`, `dispatchAsyncWithReport`, `subscribe`, `on`, `getSnapshot`, `getCanonicalSnapshot`, availability queries, dispatchability queries, intent explanation reads, `getSchemaGraph`, `simulateIntent`, `simulate`, `MEL`, `schema`, and `dispose`.
 - `createIntent()` is keyed by `MEL.actions.*`, not raw string action names.
 - `dispatchAsync()` is FIFO per instance and evaluates availability, then input validation, then dispatchability at dequeue time.
 - `dispatchAsyncWithReport()` is additive, reuses the same legality ordering and projected diff semantics, and does not change `dispatchAsync()` publication behavior.
 - `createManifesto()` accepts MEL source or `DomainSchema`, but not tooling-only compiler artifacts such as `DomainModule`.
 - `getSchemaGraph()` exposes the projected static graph only and accepts refs as the canonical lookup surface.
-- `simulate()` is a pure dry-run that applies both `apply()` and `applySystemDelta()` and treats `changedPaths` as inspection/debug-only.
+- `simulateIntent()` is the bound-intent pure dry-run, and `simulate()` is the action-ref convenience form; both apply `apply()` and `applySystemDelta()` and treat `changedPaths` as inspection/debug-only.
 - `@manifesto-ai/sdk/extensions` exposes `getExtensionKernel()` with pure canonical-input arbitrary-snapshot helpers, including `explainIntentFor()`, and no runtime-control methods.
 - `explainIntent()`, `why()`, and `whyNot()` remain current-snapshot read-only conveniences layered over the same extension-kernel explanation substrate.
 - `INVALID_INPUT` is a stable rejection/error code across dispatch, explanation, and dry-run validation paths.

--- a/packages/sdk/src/__tests__/runtime.test.ts
+++ b/packages/sdk/src/__tests__/runtime.test.ts
@@ -1019,8 +1019,14 @@ describe("activated base runtime", () => {
     });
     if (admitted.kind === "admitted") {
       const simulated = world.simulate(world.MEL.actions.incrementGuarded, 1);
+      const simulatedIntent = world.simulateIntent(admittedIntent);
       const ext = getExtensionKernel(world);
       expect(admitted.snapshot).toEqual(simulated.snapshot);
+      expect(simulatedIntent.snapshot).toEqual(simulated.snapshot);
+      expect(simulatedIntent.changedPaths).toEqual(simulated.changedPaths);
+      expect(simulatedIntent.newAvailableActions).toEqual(simulated.newAvailableActions);
+      expect(simulatedIntent.requirements).toEqual(simulated.requirements);
+      expect(simulatedIntent.status).toBe(simulated.status);
       expect(ext.projectSnapshot(admitted.canonicalSnapshot)).toEqual(simulated.snapshot);
       expect(admitted.changedPaths).toEqual(simulated.changedPaths);
       expect(admitted.newAvailableActions).toEqual(simulated.newAvailableActions);
@@ -1164,6 +1170,13 @@ describe("activated base runtime", () => {
         code: "INTENT_NOT_DISPATCHABLE",
       }),
     );
+    expect(() => world.simulateIntent(
+      world.createIntent(world.MEL.actions.incrementGuarded, 1),
+    )).toThrowError(
+      expect.objectContaining<Partial<ManifestoError>>({
+        code: "INTENT_NOT_DISPATCHABLE",
+      }),
+    );
     expect(world.getSnapshot().data.count).toBe(1);
 
     world.dispose();
@@ -1185,6 +1198,11 @@ describe("activated base runtime", () => {
       world.getCanonicalSnapshot(),
       invalidIntent,
     )).toThrowError(
+      expect.objectContaining<Partial<ManifestoError>>({
+        code: "INVALID_INPUT",
+      }),
+    );
+    expect(() => world.simulateIntent(invalidIntent)).toThrowError(
       expect.objectContaining<Partial<ManifestoError>>({
         code: "INVALID_INPUT",
       }),
@@ -1288,6 +1306,13 @@ describe("activated base runtime", () => {
         code: "ACTION_UNAVAILABLE",
       }),
     );
+    expect(() => world.simulateIntent(
+      world.createIntent(world.MEL.actions.blockedInvalid),
+    )).toThrowError(
+      expect.objectContaining<Partial<ManifestoError>>({
+        code: "ACTION_UNAVAILABLE",
+      }),
+    );
 
     world.dispose();
   });
@@ -1326,11 +1351,17 @@ describe("activated base runtime", () => {
     const simulated = ext.simulateSync(ext.getCanonicalSnapshot(), intent);
     const projected = ext.projectSnapshot(simulated.snapshot);
     const publicSimulated = world.simulate(world.MEL.actions.increment);
+    const publicSimulatedIntent = world.simulateIntent(intent);
 
     expect(ext.MEL).toBe(world.MEL);
     expect(ext.schema).toBe(world.schema);
     expect(ext.getCanonicalSnapshot()).toEqual(beforeCanonical);
     expect(projected).toEqual(publicSimulated.snapshot);
+    expect(publicSimulatedIntent.snapshot).toEqual(publicSimulated.snapshot);
+    expect(publicSimulatedIntent.changedPaths).toEqual(publicSimulated.changedPaths);
+    expect(publicSimulatedIntent.newAvailableActions).toEqual(publicSimulated.newAvailableActions);
+    expect(publicSimulatedIntent.requirements).toEqual(publicSimulated.requirements);
+    expect(publicSimulatedIntent.status).toBe(publicSimulated.status);
     expect(simulated.status).toBe(publicSimulated.status);
     expect(simulated.requirements).toEqual(publicSimulated.requirements);
     expect(simulated.diagnostics?.trace).toEqual(publicSimulated.diagnostics?.trace);

--- a/packages/sdk/src/__tests__/types/helper-boundary.typecheck.ts
+++ b/packages/sdk/src/__tests__/types/helper-boundary.typecheck.ts
@@ -21,7 +21,7 @@ function prepareIntent<
   const intent = runtime.createIntent(action, ...intentArgs);
   const blockers = runtime.whyNot(intent);
   if (blockers === null) {
-    void runtime.simulate(action, ...intentArgs);
+    void runtime.simulateIntent(intent);
   }
   return intent;
 }

--- a/packages/sdk/src/__tests__/types/provider-seam.typecheck.ts
+++ b/packages/sdk/src/__tests__/types/provider-seam.typecheck.ts
@@ -59,6 +59,7 @@ const intent = kernel.createIntent(kernel.MEL.actions.ping);
 const isDispatchableFor: boolean = kernel.isIntentDispatchableFor(canonical, intent);
 const blockersFor: readonly DispatchBlocker[] = kernel.getIntentBlockersFor(canonical, intent);
 const simulation: SimulateResult<DemoDomain> = kernel.simulateSync(canonical, intent);
+const projectedSimulation = kernel.simulateIntent(intent);
 const simulationTrace = simulation.diagnostics?.trace;
 const baseRuntime: ManifestoBaseInstance<DemoDomain> = createBaseRuntimeInstance(kernel);
 
@@ -75,6 +76,7 @@ void blockersFor;
 void lineageFactory;
 void lineageKernel;
 void metadata;
+void projectedSimulation;
 void hostDispatchOptions;
 void simulation;
 void simulationTrace;

--- a/packages/sdk/src/__tests__/types/typed-intent.typecheck.ts
+++ b/packages/sdk/src/__tests__/types/typed-intent.typecheck.ts
@@ -1,6 +1,6 @@
 import type { Intent } from "@manifesto-ai/core";
 
-import type { DispatchBlocker, IntentExplanation } from "../../index.ts";
+import type { DispatchBlocker, IntentExplanation, SimulateResult } from "../../index.ts";
 import { createManifesto } from "../../index.ts";
 import { createForeignSchema, type ForeignDomain } from "../helpers/foreign-schema.ts";
 import { createCounterSchema, type CounterDomain } from "../helpers/schema.ts";
@@ -10,6 +10,7 @@ const typedIntent = world.createIntent(world.MEL.actions.increment);
 const explanation: IntentExplanation<CounterDomain> = world.explainIntent(typedIntent);
 const sameExplanation: IntentExplanation<CounterDomain> = world.why(typedIntent);
 const blockersOrNull: readonly DispatchBlocker[] | null = world.whyNot(typedIntent);
+const simulatedIntent: SimulateResult<CounterDomain> = world.simulateIntent(typedIntent);
 void world.createIntent(world.MEL.actions.add, { amount: 3 });
 
 void world.dispatchAsync(typedIntent);
@@ -21,12 +22,16 @@ const rawIntent: Intent = {
 
 // @ts-expect-error dispatchAsync only accepts typed intents created for this domain
 void world.dispatchAsync(rawIntent);
+// @ts-expect-error simulateIntent only accepts typed intents created for this domain
+void world.simulateIntent(rawIntent);
 
 const foreign = createManifesto<ForeignDomain>(createForeignSchema(), {}).activate();
 const foreignIntent = foreign.createIntent(foreign.MEL.actions.toggle);
 
 // @ts-expect-error dispatchAsync rejects intents branded for a different domain
 void world.dispatchAsync(foreignIntent);
+// @ts-expect-error simulateIntent rejects intents branded for a different domain
+void world.simulateIntent(foreignIntent);
 
 type TodoDomain = {
   actions: {
@@ -95,6 +100,7 @@ void actionMetadataList;
 void explanation;
 void sameExplanation;
 void blockersOrNull;
+void simulatedIntent;
 
 // @ts-expect-error getActionMetadata only accepts domain action names
 void todo.getActionMetadata("missing");

--- a/packages/sdk/src/compat/internal.ts
+++ b/packages/sdk/src/compat/internal.ts
@@ -41,6 +41,7 @@ import type {
   TypedMEL,
   TypedOn,
   TypedSimulate,
+  TypedSimulateIntent,
   TypedSubscribe,
 } from "../types.js";
 import type {
@@ -117,6 +118,7 @@ export interface RuntimeKernel<T extends ManifestoDomainShape> {
     intent: TypedIntent<T>,
   ) => SimulateResult<T>;
   readonly simulate: TypedSimulate<T>;
+  readonly simulateIntent: TypedSimulateIntent<T>;
   readonly dispose: () => void;
   readonly isDisposed: () => boolean;
   readonly getVisibleCoreSnapshot: () => CoreSnapshot;
@@ -182,6 +184,7 @@ type RuntimePublicReadFacet<T extends ManifestoDomainShape> = Pick<
   | "isActionAvailable"
   | "getSchemaGraph"
   | "simulate"
+  | "simulateIntent"
 >;
 
 type RuntimeLifecycleFacet<T extends ManifestoDomainShape> = Pick<

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -74,6 +74,7 @@ export type {
   TypedMEL,
   TypedOn,
   TypedSimulate,
+  TypedSimulateIntent,
   TypedSubscribe,
   Unsubscribe,
 } from "./types.js";

--- a/packages/sdk/src/runtime/base-runtime.ts
+++ b/packages/sdk/src/runtime/base-runtime.ts
@@ -99,6 +99,7 @@ export function createBaseRuntimeInstance<T extends ManifestoDomainShape>(
     isActionAvailable: kernel.isActionAvailable,
     getSchemaGraph: kernel.getSchemaGraph,
     simulate: kernel.simulate,
+    simulateIntent: kernel.simulateIntent,
     MEL: kernel.MEL,
     schema: kernel.schema,
     dispose: kernel.dispose,

--- a/packages/sdk/src/runtime/kernel.ts
+++ b/packages/sdk/src/runtime/kernel.ts
@@ -33,6 +33,7 @@ import type {
   TypedGetIntentBlockers,
   TypedIntent,
   TypedIsIntentDispatchable,
+  TypedSimulateIntent,
 } from "../types.js";
 import {
   cloneAndDeepFreeze,
@@ -278,14 +279,9 @@ export function createRuntimeKernel<T extends ManifestoDomainShape>({
     createIntent(action, ...args),
   )) as TypedGetIntentBlockers<T>;
   const simulateSync = simulation.simulateSync as RuntimeKernel<T>["simulateSync"];
-  const simulate = ((
-    action,
-    ...args
-  ) => {
-    const simulated = simulation.simulateSync(
-      getCanonicalSnapshot(),
-      createIntent(action, ...args),
-    );
+  function projectCurrentSimulationResult(
+    simulated: ReturnType<RuntimeKernel<T>["simulateSync"]>,
+  ): ProjectedSimulateResult<T> {
     const projectedSimulated = projectSnapshotFromCanonical(simulated.snapshot);
 
     return Object.freeze({
@@ -296,6 +292,19 @@ export function createRuntimeKernel<T extends ManifestoDomainShape>({
       status: simulated.status,
       diagnostics: simulated.diagnostics,
     }) as ProjectedSimulateResult<T>;
+  }
+
+  const simulateIntent = ((
+    intent,
+  ) => projectCurrentSimulationResult(
+    simulation.simulateSync(getCanonicalSnapshot(), intent),
+  )) as TypedSimulateIntent<T>;
+
+  const simulate = ((
+    action,
+    ...args
+  ) => {
+    return simulateIntent(createIntent(action, ...args));
   }) as RuntimeKernel<T>["simulate"];
 
   const extensionKernel = Object.freeze({
@@ -346,6 +355,7 @@ export function createRuntimeKernel<T extends ManifestoDomainShape>({
     },
     simulateSync,
     simulate,
+    simulateIntent,
     dispose,
     isDisposed,
     getCanonicalSnapshot,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -309,6 +309,12 @@ export type TypedSimulate<T extends ManifestoDomainShape> = <
   ...args: CreateIntentArgs<T, K>
 ) => SimulateResult<T>;
 
+export type TypedSimulateIntent<T extends ManifestoDomainShape> = <
+  K extends keyof T["actions"],
+>(
+  intent: TypedIntent<T, K>,
+) => SimulateResult<T>;
+
 export type TypedSubscribe<T extends ManifestoDomainShape> = <R>(
   selector: Selector<T["state"], R>,
   listener: (value: R) => void,
@@ -406,6 +412,7 @@ export type ManifestoBaseInstance<T extends ManifestoDomainShape> = {
   readonly isActionAvailable: (name: keyof T["actions"]) => boolean;
   readonly getSchemaGraph: () => SchemaGraph;
   readonly simulate: TypedSimulate<T>;
+  readonly simulateIntent: TypedSimulateIntent<T>;
   readonly MEL: TypedMEL<T>;
   readonly schema: DomainSchema;
   readonly dispose: () => void;
@@ -413,7 +420,7 @@ export type ManifestoBaseInstance<T extends ManifestoDomainShape> = {
 
 export type ManifestoLegalityRuntime<T extends ManifestoDomainShape> = Pick<
   ManifestoBaseInstance<T>,
-  "createIntent" | "whyNot" | "simulate" | "MEL"
+  "createIntent" | "whyNot" | "simulate" | "simulateIntent" | "MEL"
 >;
 
 export type ManifestoDispatchRuntime<T extends ManifestoDomainShape> = Pick<


### PR DESCRIPTION
## Summary

- Add `simulateIntent(intent)` as the bound-intent dry-run surface on the SDK runtime.
- Expose the same inherited read surface through lineage and governance runtimes.
- Update ACTS coverage, type checks, SDK specs, API docs, and the runtime tooling guide for the new public contract.

## Validation

- `pnpm --filter @manifesto-ai/sdk test`
- `pnpm --filter @manifesto-ai/activation-cts test`
- `pnpm --filter @manifesto-ai/lineage test`
- `pnpm --filter @manifesto-ai/governance test`
- `pnpm docs:check`
- `pnpm docs:build`
- `git diff --check`

## Linked Issues

Closes #444
Closes #445
Closes #446