### PR TITLE
docs: harden failure observation terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ When documents conflict, prefer higher-ranked sources.
 
 ### 1. Core Engineering Axiom
 
-**Manifesto computes what the world should become; Host makes it so.**
+**Manifesto computes what the Snapshot should become; Host makes declared work real.**
 
 The fundamental equation is:
 
@@ -100,8 +100,8 @@ When priorities conflict, higher-ranked priorities MUST prevail.
 1. **Determinism** — Same input MUST produce same output, always
 2. **Accountability** — Every state change MUST be traceable to Actor + Authority + Intent
 3. **Explainability** — Every value MUST answer "why?"
-4. **Separation of Concerns** — Core computes, Host executes, World governs
-5. **Immutability** — Snapshots and Worlds MUST NOT mutate after creation
+4. **Separation of Concerns** — Core computes, Host executes, SDK exposes runtime, Lineage records continuity, Governance authorizes legitimacy
+5. **Immutability** — Snapshots and Lineage Worlds MUST NOT mutate after creation
 6. **Schema-first** — All semantics MUST be expressible as JSON-serializable data
 7. **Type safety** — Zero string paths in user-facing APIs
 8. **Simplicity** — Minimum complexity for current requirements only
@@ -127,9 +127,9 @@ When priorities conflict, higher-ranked priorities MUST prevail.
 - Access wall-clock time (`Date.now()` is forbidden)
 - Execute effects
 - Have mutable state
-- Know about Host or World
+- Know about Host, SDK runtime assembly, Lineage, or Governance
 
-**Forbidden imports:** Host, World, network libraries
+**Forbidden imports:** Host, SDK runtime internals, Lineage, Governance, network libraries
 
 #### @manifesto-ai/host
 
@@ -144,27 +144,64 @@ When priorities conflict, higher-ranked priorities MUST prevail.
 - Compute semantic meaning
 - Make policy decisions
 - Suppress, alter, or reinterpret effects declared by Core
-- Know about World governance or Authority
+- Know about Governance policy, Lineage continuity, or Authority handlers
 - Define domain logic
 
-**Forbidden imports:** World governance types, React, Authority handlers
+**Forbidden imports:** Governance policy types, Lineage internals, React, Authority handlers
 
-#### @manifesto-ai/world
+#### @manifesto-ai/sdk
+
+**IS responsible for:**
+- Activation-first application runtime surface
+- Typed intent creation and dispatch verbs
+- Projected app-facing reads
+- Runtime legality/introspection helpers
+- Runtime events and additive write reports
+
+**MUST NOT:**
+- Compute semantic meaning
+- Execute effects directly
+- Own authority policy
+- Own lineage storage semantics
+- Re-export a retired world facade package
+
+**Forbidden imports:** Core internals, Host internals, Governance internals, Lineage internals
+
+#### @manifesto-ai/lineage
+
+**IS responsible for:**
+- Sealed continuity
+- World record creation and lookup
+- Branch/head history
+- Restore and stored canonical snapshot lookup
+- Additive lineage write reports
+
+**MUST NOT:**
+- Execute effects
+- Evaluate authority policy
+- Compute semantic state transitions
+- Apply patches outside the runtime/Host path
+- Reinterpret domain legality
+
+**Forbidden imports:** Host execution internals, Core compute internals, Governance policy internals
+
+#### @manifesto-ai/governance
 
 **IS responsible for:**
 - Proposal management
 - Authority evaluation
 - Decision recording
-- Lineage maintenance (DAG)
 - Actor registry
+- Governed settlement observation
 
 **MUST NOT:**
 - Execute effects
 - Apply patches
 - Compute state transitions
+- Seal lineage implicitly
 - Make implicit decisions
 
-**Forbidden imports:** Host execution internals, Core compute internals
+**Forbidden imports:** Host execution internals, Core compute internals, Lineage storage internals
 
 ---
 
@@ -220,10 +257,10 @@ type Snapshot = {
 #### 4.4 Data Flow Direction
 
 ```
-Actor submits Intent
+Actor submits typed Intent
       |
       v
-World Protocol (Proposal + Authority)
+SDK runtime
       |
       v
 Host (compute loop + effect execution)
@@ -233,9 +270,21 @@ Core (pure computation)
       |
       v
 New Snapshot (via patches)
+```
+
+Governed composition adds explicit legitimacy and continuity around the same runtime path:
+
+```text
+Actor proposes typed Intent
       |
       v
-New World (immutable)
+Governance (proposal + authority decision)
+      |
+      v
+SDK runtime -> Host -> Core -> terminal Snapshot
+      |
+      v
+Lineage (sealed immutable World record)
 ```
 
 **CRITICAL:** Information flows ONLY through Snapshot. There are no other channels.
@@ -414,7 +463,7 @@ type ComputedRef<T> = {
 
 - **Core tests:** Determinism (same input -> same output)
 - **Host tests:** Effect handler correctness, patch application
-- **World tests:** Governance invariants, lineage integrity
+- **Lineage/Governance tests:** continuity invariants, sealed World record integrity, legitimacy settlement
 - **Integration tests:** End-to-end flow correctness
 
 #### 9.2 Core Testing (No Mocks)
@@ -520,12 +569,13 @@ flow.onceNull(state.submittedAt, ({ patch, effect }) => {
 #### 10.6 Authority Bypass (FORBIDDEN)
 
 ```typescript
-// FORBIDDEN - Direct execution without governance
-host.execute(snapshot, intent);  // Skips World Protocol!
+// FORBIDDEN - Direct execution when governance is required
+host.execute(snapshot, intent);  // Bypasses Governance and Lineage!
 
-// REQUIRED - All intents through World Protocol
-world.submitProposal(actor, intentInstance);
-// Authority evaluates, then approved intents go to Host
+// REQUIRED - Governed intents enter through the governed runtime
+const proposal = await governed.proposeAsync(intent);
+await governed.approve(proposal.proposalId);
+// Governance authorizes, Host executes through the SDK runtime, Lineage seals the terminal Snapshot
 ```
 
 #### 10.7 Hidden Continuation State (FORBIDDEN)
@@ -570,7 +620,7 @@ Before producing any code change, mentally verify ALL of the following:
 
 - [ ] Does this change preserve determinism? (Same input -> same output)
 - [ ] Does this change maintain Snapshot as sole communication medium?
-- [ ] Does this change respect sovereignty boundaries? (Core computes, Host executes, World governs)
+- [ ] Does this change respect sovereignty boundaries? (Core computes, Host executes, SDK exposes runtime, Lineage records continuity, Governance authorizes)
 - [ ] Are all state changes expressed as Patches?
 - [ ] Are all errors expressed as values, not exceptions?
 
@@ -642,7 +692,9 @@ Reference these when making decisions:
 |------|--------|-------------|
 | **Actor** | Propose change | Mutate state, execute effects, govern |
 | **Authority** | Approve, reject, constrain scope | Execute, compute, apply patches, rewrite Intent |
-| **World** | Govern, audit, maintain lineage | Execute, apply patches, hidden channels |
+| **SDK** | Expose activated runtime, typed intents, projected reads, reports | Compute semantics, execute effects directly, own governance/lineage internals |
+| **Lineage** | Seal continuity, maintain World records, restore, branch/head history | Execute effects, evaluate authority, apply patches directly |
+| **Governance** | Govern legitimacy, evaluate authority, record decisions | Execute effects, seal lineage implicitly, compute state transitions |
 | **Core** | Compute meaning, declare effects | IO, execution, time-awareness |
 | **Host** | Execute effects, apply patches, report | Decide, interpret, suppress effects |
 
@@ -650,10 +702,12 @@ Reference these when making decisions:
 
 | Package | MUST NOT Import |
 |---------|-----------------|
-| core | host, world |
-| host | world governance |
-| world | host internals, core compute |
-| app | core internals, host internals, world internals |
+| core | host, sdk runtime internals, lineage, governance |
+| host | governance policy, lineage internals, React, authority handlers |
+| sdk | core internals, host internals, lineage internals, governance internals |
+| lineage | host internals, core compute internals, governance policy internals |
+| governance | host internals, core compute internals, lineage storage internals |
+| app | core internals, host internals, sdk internals, lineage internals, governance internals |
 
 #### Priority Decision Tree
 
@@ -753,11 +807,11 @@ When working with Claude Code agents on Manifesto:
    - Bad: "Add this to the docs"
 
 3. **Clarify mental model expectations**
-   - Good: "Explain World Protocol without implying it's a workflow engine"
-   - Bad: "Explain World Protocol"
+   - Good: "Explain governed composition by separating Governance legitimacy from Lineage continuity"
+   - Bad: "Explain the old governed layer"
 
 4. **Request architectural verification**
-   - Good: "Generate a sequence diagram showing Actor → World → Host flow"
+   - Good: "Generate a sequence diagram showing Actor -> Governance -> SDK/Host -> Lineage flow"
    - Bad: "Show how this works"
 
 ### Common Agent Pitfalls (and How to Avoid Them)
@@ -771,7 +825,7 @@ When working with Claude Code agents on Manifesto:
 
 ### Example: Full Agent Workflow
 
-**Task:** Add a new Authority type to @manifesto-ai/world
+**Task:** Add a new Authority type to @manifesto-ai/governance
 
 **Step 1: Verify constitutional compliance**
 ```bash
@@ -788,7 +842,7 @@ claude-code "Add a new DurationAuthority that rejects Intents older than N secon
 **Step 3: Document the change**
 ```bash
 claude-code --agent manifesto-docs-architect \
-  "Document DurationAuthority in packages/world/docs/SPEC.md (Layer 4)"
+  "Document DurationAuthority in packages/governance/docs/governance-SPEC.md (Layer 4)"
 ```
 
 **Step 4: Update tests**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ When documents conflict, prefer higher-ranked sources.
 
 ## 1. Core Engineering Axiom
 
-**Manifesto computes what the world should become; Host makes it so.**
+**Manifesto computes what the Snapshot should become; Host makes declared work real.**
 
 The fundamental equation is:
 
@@ -71,8 +71,8 @@ When priorities conflict, higher-ranked priorities MUST prevail.
 1. **Determinism** — Same input MUST produce same output, always
 2. **Accountability** — Every state change MUST be traceable to Actor + Authority + Intent
 3. **Explainability** — Every value MUST answer "why?"
-4. **Separation of Concerns** — Core computes, Host executes, World governs
-5. **Immutability** — Snapshots and Worlds MUST NOT mutate after creation
+4. **Separation of Concerns** — Core computes, Host executes, SDK exposes runtime, Lineage records continuity, Governance authorizes legitimacy
+5. **Immutability** — Snapshots and Lineage Worlds MUST NOT mutate after creation
 6. **Schema-first** — All semantics MUST be expressible as JSON-serializable data
 7. **Type safety** — Zero string paths in user-facing APIs
 8. **Simplicity** — Minimum complexity for current requirements only
@@ -98,9 +98,9 @@ When priorities conflict, higher-ranked priorities MUST prevail.
 - Access wall-clock time (`Date.now()` is forbidden)
 - Execute effects
 - Have mutable state
-- Know about Host or World
+- Know about Host, SDK runtime assembly, Lineage, or Governance
 
-**Forbidden imports:** Host, World, network libraries
+**Forbidden imports:** Host, SDK runtime internals, Lineage, Governance, network libraries
 
 ### @manifesto-ai/host
 
@@ -115,27 +115,64 @@ When priorities conflict, higher-ranked priorities MUST prevail.
 - Compute semantic meaning
 - Make policy decisions
 - Suppress, alter, or reinterpret effects declared by Core
-- Know about World governance or Authority
+- Know about Governance policy, Lineage continuity, or Authority handlers
 - Define domain logic
 
-**Forbidden imports:** World governance types, React, Authority handlers
+**Forbidden imports:** Governance policy types, Lineage internals, React, Authority handlers
 
-### @manifesto-ai/world
+### @manifesto-ai/sdk
+
+**IS responsible for:**
+- Activation-first application runtime surface
+- Typed intent creation and dispatch verbs
+- Projected app-facing reads
+- Runtime legality/introspection helpers
+- Runtime events and additive write reports
+
+**MUST NOT:**
+- Compute semantic meaning
+- Execute effects directly
+- Own authority policy
+- Own lineage storage semantics
+- Re-export a retired world facade package
+
+**Forbidden imports:** Core internals, Host internals, Governance internals, Lineage internals
+
+### @manifesto-ai/lineage
+
+**IS responsible for:**
+- Sealed continuity
+- World record creation and lookup
+- Branch/head history
+- Restore and stored canonical snapshot lookup
+- Additive lineage write reports
+
+**MUST NOT:**
+- Execute effects
+- Evaluate authority policy
+- Compute semantic state transitions
+- Apply patches outside the runtime/Host path
+- Reinterpret domain legality
+
+**Forbidden imports:** Host execution internals, Core compute internals, Governance policy internals
+
+### @manifesto-ai/governance
 
 **IS responsible for:**
 - Proposal management
 - Authority evaluation
 - Decision recording
-- Lineage maintenance (DAG)
 - Actor registry
+- Governed settlement observation
 
 **MUST NOT:**
 - Execute effects
 - Apply patches
 - Compute state transitions
+- Seal lineage implicitly
 - Make implicit decisions
 
-**Forbidden imports:** Host execution internals, Core compute internals
+**Forbidden imports:** Host execution internals, Core compute internals, Lineage storage internals
 
 ---
 
@@ -191,10 +228,10 @@ type Snapshot = {
 ### 4.4 Data Flow Direction
 
 ```
-Actor submits Intent
+Actor submits typed Intent
       |
       v
-World Protocol (Proposal + Authority)
+SDK runtime
       |
       v
 Host (compute loop + effect execution)
@@ -204,9 +241,21 @@ Core (pure computation)
       |
       v
 New Snapshot (via patches)
+```
+
+Governed composition adds explicit legitimacy and continuity around the same runtime path:
+
+```text
+Actor proposes typed Intent
       |
       v
-New World (immutable)
+Governance (proposal + authority decision)
+      |
+      v
+SDK runtime -> Host -> Core -> terminal Snapshot
+      |
+      v
+Lineage (sealed immutable World record)
 ```
 
 **CRITICAL:** Information flows ONLY through Snapshot. There are no other channels.
@@ -385,7 +434,7 @@ type ComputedRef<T> = {
 
 - **Core tests:** Determinism (same input -> same output)
 - **Host tests:** Effect handler correctness, patch application
-- **World tests:** Governance invariants, lineage integrity
+- **Lineage/Governance tests:** continuity invariants, sealed World record integrity, legitimacy settlement
 - **Integration tests:** End-to-end flow correctness
 
 ### 9.2 Core Testing (No Mocks)
@@ -491,12 +540,13 @@ flow.onceNull(state.submittedAt, ({ patch, effect }) => {
 ### 10.6 Authority Bypass (FORBIDDEN)
 
 ```typescript
-// FORBIDDEN - Direct execution without governance
-host.execute(snapshot, intent);  // Skips World Protocol!
+// FORBIDDEN - Direct execution when governance is required
+host.execute(snapshot, intent);  // Bypasses Governance and Lineage!
 
-// REQUIRED - All intents through World Protocol
-world.submitProposal(actor, intentInstance);
-// Authority evaluates, then approved intents go to Host
+// REQUIRED - Governed intents enter through the governed runtime
+const proposal = await governed.proposeAsync(intent);
+await governed.approve(proposal.proposalId);
+// Governance authorizes, Host executes through the SDK runtime, Lineage seals the terminal Snapshot
 ```
 
 ### 10.7 Hidden Continuation State (FORBIDDEN)
@@ -541,7 +591,7 @@ Before producing any code change, mentally verify ALL of the following:
 
 - [ ] Does this change preserve determinism? (Same input -> same output)
 - [ ] Does this change maintain Snapshot as sole communication medium?
-- [ ] Does this change respect sovereignty boundaries? (Core computes, Host executes, World governs)
+- [ ] Does this change respect sovereignty boundaries? (Core computes, Host executes, SDK exposes runtime, Lineage records continuity, Governance authorizes)
 - [ ] Are all state changes expressed as Patches?
 - [ ] Are all errors expressed as values, not exceptions?
 
@@ -613,7 +663,9 @@ Reference these when making decisions:
 |------|--------|-------------|
 | **Actor** | Propose change | Mutate state, execute effects, govern |
 | **Authority** | Approve, reject, constrain scope | Execute, compute, apply patches, rewrite Intent |
-| **World** | Govern, audit, maintain lineage | Execute, apply patches, hidden channels |
+| **SDK** | Expose activated runtime, typed intents, projected reads, reports | Compute semantics, execute effects directly, own governance/lineage internals |
+| **Lineage** | Seal continuity, maintain World records, restore, branch/head history | Execute effects, evaluate authority, apply patches directly |
+| **Governance** | Govern legitimacy, evaluate authority, record decisions | Execute effects, seal lineage implicitly, compute state transitions |
 | **Core** | Compute meaning, declare effects | IO, execution, time-awareness |
 | **Host** | Execute effects, apply patches, report | Decide, interpret, suppress effects |
 
@@ -621,10 +673,12 @@ Reference these when making decisions:
 
 | Package | MUST NOT Import |
 |---------|-----------------|
-| core | host, world |
-| host | world governance |
-| world | host internals, core compute |
-| app | core internals, host internals, world internals |
+| core | host, sdk runtime internals, lineage, governance |
+| host | governance policy, lineage internals, React, authority handlers |
+| sdk | core internals, host internals, lineage internals, governance internals |
+| lineage | host internals, core compute internals, governance policy internals |
+| governance | host internals, core compute internals, lineage storage internals |
+| app | core internals, host internals, sdk internals, lineage internals, governance internals |
 
 ### Priority Decision Tree
 

--- a/docs/api/governance.md
+++ b/docs/api/governance.md
@@ -51,7 +51,7 @@ Governed runtimes keep the lineage query surface, but remove direct execution:
 The root package also exposes additive settlement helpers:
 
 - `waitForProposal(app, proposalOrId, options?)` for normalized settlement state
-- `waitForProposalWithReport(app, proposalOrId, options?)` for world-anchored settlement outcome reports
+- `waitForProposalWithReport(app, proposalOrId, options?)` for Lineage World-anchored settlement outcome reports
 
 Neither helper replaces `proposeAsync()`.
 
@@ -65,6 +65,11 @@ Those inherited legality queries preserve the base SDK ordering and blocker mean
 - `getAvailableActions()` and `isActionAvailable()` remain current visible-snapshot reads, not durable capability grants for later proposal admission
 
 `dispatchAsync`, `dispatchAsyncWithReport`, `commitAsync`, and `commitAsyncWithReport` are intentionally absent. There is no governed `proposeAsyncWithReport()` in the current public surface.
+
+Failed governed settlements observe semantic failure from the stored terminal
+Snapshot's `system.lastError` and pending requirements when a `resultWorld`
+exists. Canonical `data.$host.lastError` remains Host diagnostic data for deep
+debugging and is not merged into settlement `ErrorInfo`.
 
 ## Lineage Guarantee
 

--- a/docs/api/lineage.md
+++ b/docs/api/lineage.md
@@ -59,6 +59,8 @@ If seal commit fails, the commit rejects and the new snapshot does not become vi
 
 `commitAsyncWithReport()` is the additive companion for tooling and agent callers that need admission data, before/after snapshots, projected diffs, and continuity metadata without changing the underlying seal/publication semantics.
 
+Failed lineage reports observe semantic failure from the sealed terminal Snapshot's `system.lastError` and pending requirements. Canonical `data.$host.lastError` remains Host/effect diagnostic state and is not, by itself, the lineage outcome.
+
 ## Relationship to SDK
 
 ```text

--- a/docs/api/runtime.md
+++ b/docs/api/runtime.md
@@ -67,7 +67,9 @@ Decorators change the write verb:
 
 Use the base runtime until approval, continuity, restore, branch/head history, or sealing is a product requirement.
 
-Legality query meaning is preserved across decorators. Base and lineage runtimes now expose first-party additive write-report companions for machine-readable call results, while event payloads remain the streaming lifecycle channel. Governed runtimes intentionally do not add a direct write-report companion on the runtime itself; they use root helpers from `@manifesto-ai/governance`: `waitForProposal()` for normalized settlement state and `waitForProposalWithReport()` for stored-world settlement outcome reports.
+Legality query meaning is preserved across decorators. Base and lineage runtimes now expose first-party additive write-report companions for machine-readable call results, while event payloads remain the streaming lifecycle channel. Governed runtimes intentionally do not add a direct write-report companion on the runtime itself; they use root helpers from `@manifesto-ai/governance`: `waitForProposal()` for normalized settlement state and `waitForProposalWithReport()` for Lineage World-anchored settlement outcome reports.
+
+For failure observation, use report helpers for per-attempt outcomes, `snapshot.system.lastError` for the current semantic Snapshot error state, and canonical `data.$host.lastError` only for Host/effect diagnostics.
 
 If a helper needs one shared runtime boundary, keep it on legality/preparation reads only. SDK now exports `ManifestoLegalityRuntime<T>` for that purpose. Execution helpers should stay verb-specific and use `ManifestoDispatchRuntime<T>`, `LineageCommitRuntime<T>`, or `GovernanceProposalRuntime<T>` instead of assuming a common `dispatchAsync()` surface.
 

--- a/docs/api/sdk.md
+++ b/docs/api/sdk.md
@@ -254,7 +254,7 @@ If `diagnostics.trace` is present, it is derived from the dry-run Core trace for
 
 Queued dispatches use the same legality split. If `dispatchAsync()` is rejected before publication, the runtime emits `dispatch:rejected` with a stable machine-readable `code` plus a human-readable `reason`. `ACTION_UNAVAILABLE` means the coarse action gate failed at dequeue time. `INVALID_INPUT` means the action stayed available, but the bound intent input failed SDK validation. `INTENT_NOT_DISPATCHABLE` means the action stayed available, input was valid, and the bound intent failed the fine gate.
 
-Base SDK and lineage runtimes keep event payloads plus stable rejection codes as streaming lifecycle telemetry. They now also expose additive write-report companions: base uses `dispatchAsyncWithReport()` and lineage uses `commitAsyncWithReport()`. Governed runtimes use root helpers from `@manifesto-ai/governance`: `waitForProposal()` for normalized settlement state and `waitForProposalWithReport()` for stored-world settlement outcome reports. Neither helper replaces `proposeAsync()`.
+Base SDK and lineage runtimes keep event payloads plus stable rejection codes as streaming lifecycle telemetry. They now also expose additive write-report companions: base uses `dispatchAsyncWithReport()` and lineage uses `commitAsyncWithReport()`. Governed runtimes use root helpers from `@manifesto-ai/governance`: `waitForProposal()` for normalized settlement state and `waitForProposalWithReport()` for Lineage World-anchored settlement outcome reports. Neither helper replaces `proposeAsync()`.
 
 ## Additive Write Report
 
@@ -276,6 +276,8 @@ if (report.kind === "rejected") {
 ```
 
 `dispatchAsyncWithReport()` is additive. It does not replace `dispatchAsync()`, and it does not change queueing, legality ordering, or publication behavior.
+
+For failure observation, use report helpers for per-attempt outcomes, `snapshot.system.lastError` for the current semantic Snapshot error state, and canonical `data.$host.lastError` only for Host/effect diagnostics.
 
 The report union gives tooling and agent callers:
 

--- a/docs/architecture/determinism.md
+++ b/docs/architecture/determinism.md
@@ -55,7 +55,7 @@ This separation enables:
 | **Time-travel debugging** | Step backward/forward through state without re-executing effects |
 | **Crash recovery** | Re-run computation from last snapshot—no lost context |
 
-These guarantees hold regardless of whether you run through the direct-dispatch SDK path or the governed World path. The runtime wrapper changes; the deterministic compute contract does not.
+These guarantees hold regardless of whether you run through the direct-dispatch SDK path or a Governance-decorated runtime with Lineage sealing. The runtime wrapper changes; the deterministic compute contract does not.
 
 ---
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -34,7 +34,7 @@ If you need explicit governance, actor approval, or lineage, decorate the same m
 1. [Data Flow](./data-flow)
 2. [Determinism](./determinism)
 3. [Failure Model](./failure-model)
-4. [World Concept](/concepts/world)
+4. [World Records and Governed Composition](/concepts/world)
 
 ## When To Read This Section
 

--- a/docs/architecture/layers.md
+++ b/docs/architecture/layers.md
@@ -112,9 +112,9 @@ MEL source -> Compiler -> DomainSchema -> SDK / Host / Core
 
 | Aspect | Definition |
 |--------|------------|
-| **Role** | Add sealing, restore, branch/head queries, and stored world snapshots |
+| **Role** | Add sealing, restore, branch/head queries, and stored Lineage World snapshots |
 | **Primary API** | `withLineage()`, `commitAsync()`, `restore()`, lineage queries |
-| **Owns** | World history, branch/head refs, seal records, stored canonical snapshots |
+| **Owns** | Lineage World history, branch/head refs, seal records, stored canonical snapshots |
 | **Does NOT Know** | Host execution micro-steps, approval policy semantics |
 
 ### Governance
@@ -179,7 +179,7 @@ The base activated instance lives in SDK and owns:
 When Lineage and Governance are composed in, they add:
 
 - continuity and sealing
-- restore and stored world snapshot lookup
+- restore and stored Lineage World snapshot lookup
 - branch/head queries
 - proposal lifecycle and authority decisions
 
@@ -268,7 +268,7 @@ An implementation is aligned with the current architecture only if:
 ## Related Documents
 
 - [Architecture Index](/architecture/)
-- [World Concept](/concepts/world)
+- [World Records and Governed Composition](/concepts/world)
 - [SDK API](/api/sdk)
 - [Lineage API](/api/lineage)
 - [Governance API](/api/governance)

--- a/docs/concepts/effect.md
+++ b/docs/concepts/effect.md
@@ -117,4 +117,4 @@ Handlers should still return a precise patch story. That is what makes the syste
 
 - [Effect Handlers](/guides/effect-handlers) for the implementation guide
 - [Debugging](/guides/debugging) for troubleshooting effect-driven flows
-- [World](./world) for the governed path that can approve and seal those effects
+- [World Records and Governed Composition](./world) for Governance approval and Lineage sealing

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -13,7 +13,7 @@ If you are still trying to get the first app running, go back to [Quick Start](/
 | [Intent](./intent.md) | Request to perform a domain action | Intents are proposals, not commands |
 | [Flow](./flow.md) | Declarative computation as data | Flows describe, they do not execute |
 | [Effect](./effect.md) | Declaration of external operation | Core declares, Host fulfills |
-| [World](./world.md) | Governed composition over governance + lineage | Governed composition makes legitimacy, continuity, and sealing explicit |
+| [World Records](./world.md) | Lineage records and governed composition | Lineage records preserve continuity; Governance authorizes legitimacy |
 
 ## Two Runtime Shapes
 

--- a/docs/concepts/intent.md
+++ b/docs/concepts/intent.md
@@ -159,4 +159,4 @@ You can construct the object yourself, but `createIntent()` is the safer and cle
 
 - [Tutorial](/tutorial/) for the first end-to-end examples
 - [Effect](./effect) for what happens when an action declares external work
-- [World](./world) for explicit governance and lineage
+- [World Records and Governed Composition](./world) for lineage records and governed runtime composition

--- a/docs/concepts/shared-semantic-model.md
+++ b/docs/concepts/shared-semantic-model.md
@@ -92,7 +92,7 @@ Sometimes the shared semantic model is enough. Sometimes you need stronger contr
 - proposal review
 - lineage and audit history
 
-That is where [World](./world) comes in. It is the explicit governed composition model built from Lineage and Governance on top of the same Snapshot and request model.
+That is where [World Records and Governed Composition](./world) comes in. Lineage provides sealed World records, while Governance authorizes and settles legitimacy on top of the same Snapshot and request model.
 
 ---
 
@@ -101,4 +101,4 @@ That is where [World](./world) comes in. It is the explicit governed composition
 - [Snapshot](./snapshot) for the projected read model and canonical substrate split
 - [Intent](./intent) for the unit of requested change
 - [Integration: AI Agents](../integration/ai-agents) for practical agent patterns
-- [World](./world) for explicit governance and lineage
+- [World Records and Governed Composition](./world) for lineage records and governed runtime composition

--- a/docs/concepts/snapshot.md
+++ b/docs/concepts/snapshot.md
@@ -98,5 +98,5 @@ In practice, that means lineage storage and governed-history APIs work with cano
 
 - [Intent](./intent.md) - How changes are requested
 - [Effect](./effect.md) - How external operations work
-- [World](./world) - How sealed history and governance wrap canonical snapshots
+- [World Records and Governed Composition](./world) - How Lineage seals canonical snapshots and Governance settles legitimacy
 - [Flow](./flow.md) - How computations modify canonical state

--- a/docs/concepts/world.md
+++ b/docs/concepts/world.md
@@ -1,24 +1,30 @@
-# World
+# World Records and Governed Composition
 
-> Governed composition for legitimacy, continuity, and sealing.
+> Lineage's sealed historical record model, plus the governed composition that can create those records under authority.
 
 ## What World Means Now
 
-World is no longer a top-level facade package. In the current hard-cut model, "world" means the governed state transition path created by composing:
+In the current contract, **World** is not a top-level package or governance layer. A World is a Lineage-owned, immutable record for a sealed canonical Snapshot, identified by `WorldId`.
 
-- governance for legitimacy
-- lineage for continuity
+Governed composition is the runtime path created by composing:
+
+- Governance for legitimacy
+- Lineage for continuity and sealed World records
 - the same SDK runtime for execution
 
-The underlying semantics live in explicit protocol packages. Governed composition is now expressed directly through `withLineage()` and `withGovernance()`.
+The underlying semantics live in explicit protocol packages. Governed composition is expressed directly through `withLineage()` and `withGovernance()`.
 
 ## When To Use It
 
-Choose World when you need one or more of these:
+Use Lineage World records when you need one or more of these:
+
+- immutable history and branch/head semantics
+- seal-aware publication and restore
+- stored canonical Snapshot lookup by `WorldId`
+
+Add Governance when you also need:
 
 - explicit proposal and authority flow
-- immutable world history and branch/head semantics
-- seal-aware publication and restore
 - approval and decision visibility without bypassing runtime boundaries
 
 If you only need direct-dispatch application runtime, stay on `@manifesto-ai/sdk`.
@@ -28,18 +34,19 @@ If you only need direct-dispatch application runtime, stay on `@manifesto-ai/sdk
 ```text
 actor
   -> typed intent
-  -> governance decides legitimacy
-  -> host executes approved intent
-  -> lineage seals result
-  -> governed history advances
+  -> Governance decides legitimacy
+  -> SDK runtime submits approved work
+  -> Host executes declared requirements
+  -> Core computes terminal Snapshot
+  -> Lineage seals a World record
 ```
 
 More concretely:
 
 1. A caller creates a typed intent from the activated runtime.
 2. Governance creates and advances a proposal.
-3. Host executes the approved intent against a base snapshot.
-4. Lineage seals the result and exposes it as visible history.
+3. SDK and Host execute the approved intent against the current visible canonical Snapshot.
+4. Lineage seals the terminal Snapshot as a World record and advances visible history only when continuity rules allow it.
 
 ## Public Assembly
 
@@ -56,8 +63,8 @@ const governed = withGovernance(
 
 ## Key Properties
 
-- Worlds are immutable.
-- Governance and lineage stay explicit protocol packages.
+- Lineage Worlds are immutable sealed records.
+- Governance and Lineage stay explicit protocol packages.
 - Sealing is ordered and publication-aware.
 - Legitimacy and continuity are explicit, not hidden in a facade.
 

--- a/docs/integration/ai-agents.md
+++ b/docs/integration/ai-agents.md
@@ -2,7 +2,7 @@
 
 > Let agents see the current Snapshot, see the actions that are available now, and submit domain changes through the runtime.
 >
-> **Current Contract Note:** This page uses the activation-first SDK surface: activate a `createManifesto(...)` app, then call `getSnapshot`, `getAvailableActions`, `getActionMetadata`, `createIntent`, and `dispatchAsync()`. When tooling needs in-band admission or diff data, base runtimes may use `dispatchAsyncWithReport()` and lineage runtimes may use `commitAsyncWithReport()`. Governed examples use the current `withLineage(...) -> withGovernance(...) -> activate()` surface, with optional settlement observation through `waitForProposal()` or world-anchored settlement reports through `waitForProposalWithReport()`.
+> **Current Contract Note:** This page uses the activation-first SDK surface: activate a `createManifesto(...)` app, then call `getSnapshot`, `getAvailableActions`, `getActionMetadata`, `createIntent`, and `dispatchAsync()`. When tooling needs in-band admission or diff data, base runtimes may use `dispatchAsyncWithReport()` and lineage runtimes may use `commitAsyncWithReport()`. Governed examples use the current `withLineage(...) -> withGovernance(...) -> activate()` surface, with optional settlement observation through `waitForProposal()` or Lineage World-anchored settlement reports through `waitForProposalWithReport()`.
 
 An agent should not guess your domain API from prompt text. It should read the current state, read the currently legal actions, call an app-owned tool, and receive a Snapshot view back.
 
@@ -265,7 +265,7 @@ export async function approveAgentProposal(proposalId: string) {
 }
 ```
 
-That is the upgrade path: direct tools use `dispatchAsync()`. Reviewable tools use `proposeAsync()`, optionally observe settlement with `waitForProposal()`, optionally inspect a stored-world settlement outcome with `waitForProposalWithReport()`, and a reviewer calls `approve()` when policy requires it.
+That is the upgrade path: direct tools use `dispatchAsync()`. Reviewable tools use `proposeAsync()`, optionally observe settlement with `waitForProposal()`, optionally inspect a Lineage World-anchored settlement outcome with `waitForProposalWithReport()`, and a reviewer calls `approve()` when policy requires it.
 
 ---
 

--- a/docs/integration/index.md
+++ b/docs/integration/index.md
@@ -75,5 +75,5 @@ That flow is introduced in [When You Need Approval or History](/guides/approval-
 - [Developer Tooling](/guides/developer-tooling) for CLI, editor, Studio, and skill setup
 - [Code Generation](/guides/code-generation) for generated TS and Zod artifacts
 - [AI Agents](./ai-agents) for automation wiring
-- [World](../concepts/world) for advanced runtime composition
+- [World Records and Governed Composition](../concepts/world) for Lineage records and Governance composition
 - [Architecture](/architecture/) for the broader system model

--- a/docs/internals/documentation-governance.md
+++ b/docs/internals/documentation-governance.md
@@ -104,11 +104,11 @@ Other statuses: `Deprecated`, `Superseded`, `Withdrawn`
 Operational checks for maintained docs:
 
 1. `pnpm docs:governance-check`
-   - verifies the core governance/index documents exist and still contain required policy tokens.
+   - verifies the core governance/index documents exist, current package docs keep accepted status labels, retired World terminology stays out of current-surface docs, and failure-observation anchors remain present.
 2. `pnpm docs:check:maintained`
    - verifies maintained docs do not mention removed APIs, compatibility aliases, or stale example signatures.
 3. `pnpm docs:check`
-   - runs both governance and maintained-doc checks before a docs build.
+   - runs governance, API surface, and maintained-doc checks before a docs build.
 4. `pnpm docs:build`
    - remains the rendering/link smoke test for the published site.
 

--- a/docs/internals/fdr/index.md
+++ b/docs/internals/fdr/index.md
@@ -24,9 +24,9 @@ FDR documents explain **why** design decisions were made. They complement SPECs 
 |---------|------------|-------|--------------|
 | **App facade (retired)** | Removed (R2) | Legacy compatibility rationale | [Retired Page](/internals/retired/app) |
 | **@manifesto-ai/compiler** | v0.5.0 | MEL syntax, IR design | [FDR-v0.5.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/FDR-v0.5.0.md) |
-| **@manifesto-ai/sdk** | v3.1.0 (draft) | Projected schema graph, full-transition dry-run simulation, and introspection rationale staged into the living SDK spec | [FDR-v3.1.0-draft.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/FDR-v3.1.0-draft.md) |
+| **@manifesto-ai/sdk** | v3.1.0 (accepted companion) | Projected schema graph, full-transition dry-run simulation, and introspection rationale staged into the living SDK spec | [FDR-v3.1.0.md](https://github.com/manifesto-ai/core/blob/main/packages/sdk/docs/FDR-v3.1.0.md) |
 
-> Core/Host rationale is primarily available in each package SPEC `Rationale` block. The former `@manifesto-ai/world` rationale is retained only as historical split context. SDK currently has a draft additive rationale track for projected introspection APIs; its accepted contract now also appears in the living SDK spec.
+> Core/Host rationale is primarily available in each package SPEC `Rationale` block. The former `@manifesto-ai/world` rationale is retained only as historical split context. SDK currently has an accepted rationale companion for projected introspection APIs; its normative contract appears in the living SDK spec.
 
 ---
 
@@ -51,7 +51,7 @@ App-era rationale remains part of project history and ADR context (see ADR-007, 
 - FDR-H023: Context determinism
 - FDR-H024~H027: Snapshot type alignment
 
-**SDK v3.1.0 (draft)** - Introspection expansion
+**SDK v3.1.0 (accepted companion)** - Introspection expansion
 - FDR-SDK-001: Projected SchemaGraph influence graph
 - FDR-SDK-002: Full-transition `simulate()` dry-run
 

--- a/docs/internals/spec/current-contract.md
+++ b/docs/internals/spec/current-contract.md
@@ -1,7 +1,7 @@
 # Current Contract
 
 > **Status:** Living Document
-> **Last Updated:** 2026-04-23
+> **Last Updated:** 2026-04-24
 > **Purpose:** Single-source current contract for external consumers, canonical-doc exports, and current-surface onboarding
 
 This document is the current-only contract summary for the active Manifesto workspace.
@@ -72,6 +72,7 @@ Current contract highlights:
 - Host executes effect requirements and applies the resulting patches.
 - Host does not reinterpret domain legality or policy.
 - Host remains aligned to the current Core snapshot contract and does not use accumulated `system.errors`.
+- Host-owned execution diagnostics live under canonical `data.$host.*`. In particular, `data.$host.lastError` is a canonical-only diagnostic, not the semantic Snapshot error surface.
 
 ## SDK Contract
 
@@ -90,6 +91,13 @@ Current contract highlights:
 - `isActionAvailable()` remains the coarse gate query.
 - `isIntentDispatchable()` and `getIntentBlockers()` are the fine legality/introspection queries.
 - helper-safe shared activated-runtime surface is legality/read/introspection only; there is no cross-decorator common write verb.
+
+Current failure observation:
+
+- Use write-report companions for per-attempt call outcomes: base `dispatchAsyncWithReport()`, lineage `commitAsyncWithReport()`, and governed `waitForProposalWithReport()`.
+- Use `snapshot.system.lastError` to read the current semantic error state of the canonical or projected Snapshot.
+- Use canonical `data.$host.lastError` only for Host-owned effect/execution diagnostics during deep debugging.
+- The runtime MUST NOT automatically promote `data.$host.lastError` into `system.lastError`; such promotion would turn Host diagnostics into semantic Snapshot state without domain or governance authority.
 
 Current rejection split:
 
@@ -160,6 +168,7 @@ Current contract highlights:
 
 - lineage owns sealed continuity and stored canonical snapshot lookup
 - lineage promotes the base write verb to `commitAsync()` and the additive report companion to `commitAsyncWithReport()`
+- lineage derives sealed failure outcome from the terminal Snapshot's `system.lastError` and pending requirements, not from Host-owned `data.$host.lastError` alone
 - governance composes on top of lineage, not beside it
 - decorated runtimes inherit the base read-only legality surface, including `isActionAvailable()`, `isIntentDispatchable()`, and `getIntentBlockers()`
 - inherited decorator-runtime legality queries preserve the base SDK ordering: availability first, dispatchability second
@@ -167,6 +176,7 @@ Current contract highlights:
 - helper authors may share legality helpers across decorators, but execution helpers must stay verb-specific: base `dispatchAsync()`, lineage `commitAsync()`, governance `proposeAsync()`
 - the active governed path is `withLineage(...)->withGovernance(...)->activate()`
 - governed runtimes intentionally omit direct base/lineage execution verbs and their report companions, and use `waitForProposal()` / `waitForProposalWithReport()` as additive settlement observers
+- governance settlement failure reports read semantic failure from terminal Snapshot state when a `resultWorld` exists; Host-owned diagnostics remain canonical-substrate debugging data
 - there is no separate current `@manifesto-ai/world` package surface
 
 ## What External Consumers Should Read

--- a/docs/internals/spec/index.md
+++ b/docs/internals/spec/index.md
@@ -7,7 +7,7 @@ If you need a single current-surface document without version-history context, s
 :::
 
 ::: tip Single Source of Truth
-Specifications are maintained in canonical package docs with version indexes. The current hard-cut surface is: `@manifesto-ai/core` v4.2.0, `@manifesto-ai/host` v4.0.0, `@manifesto-ai/sdk` v3.5.0 activation-first plus `sdk/extensions`, and `@manifesto-ai/compiler` v1.2.0 as the rolled-up MEL compiler contract, with `@manifesto-ai/lineage` / `@manifesto-ai/governance` as the governed decorator packages. Draft package work that is not yet implemented is listed separately below.
+Specifications are maintained in canonical package docs with version indexes. The current hard-cut surface is: `@manifesto-ai/core` v4.2.0, `@manifesto-ai/host` v4.0.0, `@manifesto-ai/sdk` v3.5.0 activation-first plus `sdk/extensions`, `@manifesto-ai/compiler` v1.2.0 as the rolled-up MEL compiler contract, and `@manifesto-ai/codegen` as the normative build-time code generation baseline, with `@manifesto-ai/lineage` / `@manifesto-ai/governance` as the governed decorator packages. Draft package work that is not yet implemented is listed separately below.
 :::
 
 If you want the governing documentation rules, see [Documentation Governance](../documentation-governance.md).
@@ -40,6 +40,7 @@ If an older ADR conflicts with a current package SPEC on runtime surface details
 | **@manifesto-ai/runtime** | Retired | Superseded (ADR-010, no successor) — package removed from workspace | — |
 | **App facade (retired)** | Removed (R2) | Historical reference only | [Retired Page](/internals/retired/app) |
 | **@manifesto-ai/compiler** | [SPEC-v1.2.0.md](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/SPEC-v1.2.0.md) | Normative full MEL compiler contract | [VERSION-INDEX](https://github.com/manifesto-ai/core/blob/main/packages/compiler/docs/VERSION-INDEX.md) |
+| **@manifesto-ai/codegen** | [SPEC-v0.1.1.md](https://github.com/manifesto-ai/core/blob/main/packages/codegen/docs/SPEC-v0.1.1.md) | Normative baseline for build-time code generation tooling | [VERSION-INDEX](https://github.com/manifesto-ai/core/blob/main/packages/codegen/docs/VERSION-INDEX.md) |
 
 > **Current Governed Direction:** `createManifesto() -> withLineage() -> withGovernance() -> activate()`
 
@@ -159,7 +160,7 @@ The `@manifesto-ai/runtime` package is **retired**. Its responsibilities are abs
 
 ## Living Documents
 
-Core, Host, SDK, Governance, and Lineage are maintained as **Living Documents** for their active package scopes. Compiler remains versioned full specs with companion addenda when a narrower extension is sufficient.
+Core, Host, SDK, Governance, and Lineage are maintained as **Living Documents** for their active package scopes. Compiler and Codegen remain versioned package specs.
 
 Each Living Document includes:
 - A **Changelog** table in the header tracking all version history

--- a/packages/codegen/docs/SPEC-v0.1.1.md
+++ b/packages/codegen/docs/SPEC-v0.1.1.md
@@ -1,6 +1,6 @@
 # Manifesto Codegen Specification v0.1.1
 
-> **Status:** Draft
+> **Status:** Normative Baseline
 > **Version:** 0.1.1
 > **Date:** 2026-02-05
 > **Scope:** `@manifesto-ai/codegen` (build-time code generation tooling)
@@ -122,8 +122,8 @@ Codegen operates **outside** the Manifesto runtime stack. It is a build-time too
        │  (runtime)                │  (build-time)
        ▼                           ▼
 ┌──────────────┐          ┌───────────────────┐
-│ Core/Host/   │          │  @manifesto-ai/   │
-│ World/App    │          │  codegen           │
+│ Runtime/App  │          │  @manifesto-ai/   │
+│ packages     │          │  codegen           │
 │ (runtime     │          │                   │
 │  stack)      │          │  plugins:         │
 └──────────────┘          │   ├ plugin-ts     │
@@ -143,7 +143,7 @@ Codegen operates **outside** the Manifesto runtime stack. It is a build-time too
 
 | Package | Depends On | Does NOT Depend On |
 |---------|------------|-------------------|
-| `@manifesto-ai/codegen` | `@manifesto-ai/core` (peerDep, types only) | Host, World, App, Compiler impl |
+| `@manifesto-ai/codegen` | `@manifesto-ai/core` (peerDep, types only) | Host, SDK, Lineage, Governance, App, Compiler impl |
 | `@manifesto-ai/codegen-plugin-ts` | `@manifesto-ai/codegen` | Zod, any runtime library |
 | `@manifesto-ai/codegen-plugin-zod` | `@manifesto-ai/codegen`, `zod` (peerDep) | Host, any runtime library |
 

--- a/packages/codegen/docs/VERSION-INDEX.md
+++ b/packages/codegen/docs/VERSION-INDEX.md
@@ -1,13 +1,13 @@
 # Codegen Documentation Index
 
 > **Package:** `@manifesto-ai/codegen`
-> **Last Updated:** 2026-02-08
+> **Last Updated:** 2026-04-24
 
 ---
 
 ## Latest Version
 
-- **SPEC:** [v0.1.1](SPEC-v0.1.1.md) (Draft)
+- **SPEC:** [v0.1.1](SPEC-v0.1.1.md) (Normative Baseline)
 - **ADR:** [ADR-CODEGEN-001](ADR-CODEGEN-001.md) (Accepted)
 
 ---
@@ -16,7 +16,7 @@
 
 | Version | SPEC | ADR | Type | Status |
 |---------|------|-----|------|--------|
-| v0.1.1 | [SPEC](SPEC-v0.1.1.md) | [ADR-CODEGEN-001](ADR-CODEGEN-001.md) | Full | Draft |
+| v0.1.1 | [SPEC](SPEC-v0.1.1.md) | [ADR-CODEGEN-001](ADR-CODEGEN-001.md) | Full | Normative Baseline |
 
 ---
 

--- a/packages/compiler/docs/FDR-v0.5.0.md
+++ b/packages/compiler/docs/FDR-v0.5.0.md
@@ -1,7 +1,7 @@
 # MEL (Manifesto Expression Language) — Foundational Design Rationale (FDR)
 
 > **Version:** 0.5.0  
-> **Status:** Draft  
+> **Status:** Accepted Rationale
 > **Purpose:** Document the "Why" behind every major design decision in MEL  
 > **Changelog:**
 > - v0.2: AI-Native design principles and reviewer feedback integration

--- a/packages/compiler/docs/SPEC-v0.8.0.md
+++ b/packages/compiler/docs/SPEC-v0.8.0.md
@@ -7,7 +7,7 @@
 > **Base:** v0.7.0 (REQUIRED - read [SPEC-v0.7.0.md](SPEC-v0.7.0.md) first)
 > **Scope:** `SchemaGraph` extraction for projected SDK introspection
 > **Compatible with:** Core SPEC v4.0.0, SDK living spec v3.1.0 current surface
-> **Related:** [SDK FDR v3.1.0](../../sdk/docs/FDR-v3.1.0-draft.md), ADR-015 Snapshot Ontological Purification
+> **Related:** [SDK FDR v3.1.0](../../sdk/docs/FDR-v3.1.0.md), ADR-015 Snapshot Ontological Purification
 
 ---
 
@@ -232,5 +232,5 @@ action finalize() available when gt(todoCount, 0) {
 - [Compiler Version Index](VERSION-INDEX.md)
 - [Compiler SPEC v0.7.0](SPEC-v0.7.0.md)
 - [SDK SPEC (Living)](../../sdk/docs/sdk-SPEC.md)
-- [SDK FDR v3.1.0](../../sdk/docs/FDR-v3.1.0-draft.md)
+- [SDK FDR v3.1.0](../../sdk/docs/FDR-v3.1.0.md)
 - [Core SPEC v4.0.0](../../core/docs/core-SPEC.md)

--- a/packages/compiler/docs/VERSION-INDEX.md
+++ b/packages/compiler/docs/VERSION-INDEX.md
@@ -23,11 +23,11 @@
 | v1.2.0 | [SPEC](SPEC-v1.2.0.md) | [FDR](FDR-v0.5.0.md) | Full | Current |
 | v1.1.0 | [SPEC](SPEC-v1.1.0.md) | [FDR](FDR-v0.5.0.md) | Historical Full Predecessor | Superseded |
 | v1.0.0 | [SPEC](SPEC-v1.0.0.md) | [FDR](FDR-v0.5.0.md) | Historical Full Predecessor | Superseded |
-| v0.9.0 | [SPEC](SPEC-v0.9.0.md) | [FDR](../../sdk/docs/FDR-v3.1.0-draft.md) | Historical Addendum (merged into v1.0.0) | Superseded |
-| v0.8.0 | [SPEC](SPEC-v0.8.0.md) | [FDR](../../sdk/docs/FDR-v3.1.0-draft.md) | Historical Addendum (merged into v1.0.0) | Superseded |
+| v0.9.0 | [SPEC](SPEC-v0.9.0.md) | [FDR](../../sdk/docs/FDR-v3.1.0.md) | Historical Addendum (merged into v1.0.0) | Superseded |
+| v0.8.0 | [SPEC](SPEC-v0.8.0.md) | [FDR](../../sdk/docs/FDR-v3.1.0.md) | Historical Addendum (merged into v1.0.0) | Superseded |
 | v0.7.0 | [SPEC](SPEC-v0.7.0.md) | [FDR](FDR-v0.5.0.md) | Historical Full Baseline | Superseded |
 | v0.6.0 | — (historical baseline; no standalone file in repo) | [FDR](FDR-v0.5.0.md) | Full | Superseded by v0.7.0 |
-| v0.5.0 | [SPEC](SPEC-v0.5.0.md) | [FDR](FDR-v0.5.0.md) | Full | Draft |
+| v0.5.0 | [SPEC](SPEC-v0.5.0.md) | [FDR](FDR-v0.5.0.md) | Historical Full Baseline | Superseded |
 | v0.5.0 | [SPEC](SPEC-v0.5.0-patch.md) | [FDR](FDR-v0.5.0-patch.md) | Patch (Base: v0.4.0) | Merged |
 | v0.4.0 | [SPEC](SPEC-v0.4.0-patch.md) | [FDR](FDR-v0.4.0-patch.md) | Patch (Base: v0.3.3) | Merged |
 | v0.3.3 | [SPEC](SPEC-v0.3.3.md) | [FDR](FDR-v0.3.3.md) | Full | Final |

--- a/packages/governance/docs/GUIDE.md
+++ b/packages/governance/docs/GUIDE.md
@@ -85,6 +85,11 @@ if (report.kind === "completed") {
 
 `waitForProposalWithReport()` stays observational. It does not replace `proposeAsync()`, and it does not turn governed runtime submission into a direct execution verb.
 
+For failed settlements with a `resultWorld`, the report reflects the stored
+terminal Snapshot's semantic failure state (`system.lastError` and pending
+requirements). Canonical `data.$host.lastError` remains a Host diagnostic for
+deep debugging, not the governed settlement error surface.
+
 ## 4. Pending Human Resolution
 
 HITL and tribunal bindings keep the proposal in `evaluating` until a later decision resolves it.

--- a/packages/governance/docs/governance-SPEC.md
+++ b/packages/governance/docs/governance-SPEC.md
@@ -6,7 +6,7 @@
 
 ## 1. Scope
 
-This draft defines the governed decorator runtime for Manifesto.
+This living specification defines the governed decorator runtime for Manifesto.
 
 Governance v3 owns:
 
@@ -114,6 +114,7 @@ The inherited read surfaces keep their lineage/SDK meanings:
 - `failed` MUST include `ErrorInfo` and MUST NOT fabricate a visible snapshot
 - `failed` SHOULD include `resultWorld` when a sealed failed world exists; when execution fails before a result world is recorded, `failed` MAY omit `resultWorld` and return summary-only `ErrorInfo`
 - when `resultWorld` exists, failed-branch `ErrorInfo` MUST follow the same shape as governance `execution:failed` events: `summary`, optional `currentError`, optional `pendingRequirements`
+- when `resultWorld` exists, `currentError` MUST be derived from the stored terminal Snapshot's `system.lastError`; Host-owned `data.$host.lastError` is canonical diagnostic state and MUST NOT be merged into settlement `ErrorInfo`
 - callers that need the stored failed world MUST use `getWorldSnapshot(resultWorld)` directly when `resultWorld` is present
 
 ### 5.2 `waitForProposalWithReport()`
@@ -154,6 +155,7 @@ Normative rules:
 - for `completed`, the report MUST derive `ExecutionOutcome<T>` from `proposal.baseWorld -> proposal.resultWorld`
 - for `completed`, the report MUST NOT use the current visible runtime head as the settlement `after` truth
 - for `failed` with `resultWorld`, the report MUST include `published: false` and MAY include `sealedOutcome` derived from `proposal.baseWorld -> proposal.resultWorld`
+- for `failed` with `resultWorld`, the semantic failure state comes from the stored terminal Snapshot's `system.lastError` and pending requirements; Host-owned `data.$host.lastError` remains canonical-substrate diagnostic data only
 - for `failed` without `resultWorld`, the report MUST remain summary-only and MUST NOT fabricate `sealedOutcome`
 - `rejected`, `superseded`, `pending`, and `timed_out` reports MUST remain proposal-state observations only and MUST NOT fabricate execution diffs
 - governance settlement report derivation MUST reuse the same projected snapshot, changed-path, and availability-delta semantics already used by SDK/Lineage report companions
@@ -220,7 +222,7 @@ They are valid low-level seams but are no longer the canonical application entry
 Governance v3 no longer teaches:
 
 - service-first assembly as the package’s primary entry path
-- `@manifesto-ai/world` as the canonical governed composition surface
+- the retired world facade package as the canonical governed composition surface
 - any governed runtime that still exposes direct `dispatchAsync` or `commitAsync`
 
 ## 11. Normative Rules
@@ -244,3 +246,4 @@ Governance v3 no longer teaches:
 | GOV-V3-15 | MUST | `waitForProposalWithReport()` anchor completed settlement outcomes on `proposal.baseWorld -> proposal.resultWorld`, not on the current visible head |
 | GOV-V3-16 | MUST NOT | `waitForProposalWithReport()` fabricate execution outcome or diff data for `rejected`, `superseded`, `pending`, or `timed_out` settlements |
 | GOV-V3-17 | MUST | failed settlement reports with no `resultWorld` remain summary-only with `published: false` |
+| GOV-V3-18 | MUST NOT | governance settlement `ErrorInfo` MUST NOT merge Host-owned `data.$host.lastError` into semantic failure observation |

--- a/packages/host/docs/host-SPEC-v4.0.0-draft.md
+++ b/packages/host/docs/host-SPEC-v4.0.0-draft.md
@@ -151,10 +151,10 @@ import type { Snapshot, SystemState, SnapshotMeta, ErrorValue, SystemDelta } fro
 | Field | Owner | Host Reads | Host Writes | Description |
 |-------|-------|------------|-------------|-------------|
 | `data.*` | Core | Yes | via Patch | Domain state |
-| `data.$host.*` | **Host** | Yes | Yes | Host-owned namespace at runtime; restore normalization resets transient execution residue before resume |
+| `data.$host.*` | **Host** | Yes | Yes | Host-owned canonical diagnostics/bookkeeping namespace at runtime; restore normalization resets transient execution residue before resume |
 | `computed.*` | Core | Yes | No | Derived values |
 | `system.status` | Core | Yes | No | Core sets via compute() |
-| `system.lastError` | Core | Yes | No | Current error state |
+| `system.lastError` | Core | Yes | No | Current semantic error state |
 | `system.pendingRequirements` | Core | Yes | via `core.applySystemDelta()` | Requirement lifecycle |
 | `system.currentAction` | Core | Yes | No | Core sets during compute |
 | `meta.schemaHash` | Core | Yes | No | Domain schema identity |
@@ -174,6 +174,8 @@ Rather than extending Core's `SystemState`, Host uses a **reserved namespace in 
 type HostOwnedState = {
   /** Intent-scoped effect data */
   intentSlots?: Record<string, Record<string, unknown>>;
+  /** Host-owned effect/execution diagnostic, canonical-only */
+  lastError?: ErrorValue | null;
   /** Other Host-specific state */
   [key: string]: unknown;
 };
@@ -185,6 +187,12 @@ const hostState = snapshot.data.$host as HostOwnedState | undefined;
 **Note:** Patch paths are rooted at `data` by default. Use `$host.*` to target
 the Host-owned namespace. Core reserves `$host` as opaque Host-owned state and
 accepts `$host` patches even when StateSpec does not declare `$host` (Core SPEC §5.5).
+
+`$host.lastError` is an execution diagnostic owned by Host. It is not the
+semantic Snapshot error surface and MUST NOT be automatically promoted into
+`system.lastError`. Application and tooling callers that need per-attempt
+outcomes should use the SDK/Lineage/Governance report helpers; callers that
+need the current semantic error state should read `snapshot.system.lastError`.
 
 | Rule ID | Description |
 |---------|-------------|
@@ -256,7 +264,7 @@ An opaque identifier for execution serialization.
 ```typescript
 /**
  * ExecutionKey is opaque to Host.
- * World/App layer determines the mapping policy.
+ * SDK/Lineage/Governance integration determines the mapping policy.
  */
 type ExecutionKey = string;
 ```
@@ -572,8 +580,8 @@ This section defines the enforcement mechanism for single-writer concurrency.
 
 Host MUST maintain a single-writer mailbox per `ExecutionKey`.
 
-> **Rationale (FDR-H018):** Host MUST maintain a single-writer mailbox per ExecutionKey, where ExecutionKey is opaque to Host. World Protocol (FDR-W017) permits parallel branch execution — if mailbox were keyed by baseWorld, permitted parallelism would be artificially serialized. Keeping ExecutionKey opaque preserves the layer boundary: Host provides serialization mechanism, World/App provides key mapping policy.
-> **Alternatives rejected:** Global single mailbox (blocks W017 parallelism); baseWorld as key (same); no mailbox (no enforcement).
+> **Rationale (FDR-H018):** Host MUST maintain a single-writer mailbox per ExecutionKey, where ExecutionKey is opaque to Host. Lineage and Governance may need parallel branch or proposal execution, and Host must not infer that policy from continuity identifiers such as `baseWorld`. Keeping ExecutionKey opaque preserves the layer boundary: Host provides serialization mechanism; SDK/Lineage/Governance provide key mapping policy.
+> **Alternatives rejected:** Global single mailbox (blocks permitted parallelism); `baseWorld` as key (same); no mailbox (no enforcement).
 > **Consequences:** Single-writer serialization per opaque key; parallel branch execution preserved; clear layer boundary.
 
 #### 9.1.1 Rules (MUST)
@@ -582,7 +590,7 @@ Host MUST maintain a single-writer mailbox per `ExecutionKey`.
 |---------|-------------|
 | MAIL-1 | Host MUST maintain one mailbox per ExecutionKey |
 | MAIL-2 | ExecutionKey MUST be opaque to Host |
-| MAIL-3 | World/App layer determines ExecutionKey mapping policy |
+| MAIL-3 | SDK/Lineage/Governance layer determines ExecutionKey mapping policy |
 | MAIL-4 | All state mutations MUST go through the mailbox |
 
 #### 9.1.2 Type Definition
@@ -601,17 +609,17 @@ interface ExecutionMailbox {
 | Layer | Knows | Provides |
 |-------|-------|----------|
 | **Host** | ExecutionKey (opaque), intentId, Snapshot | Single-writer serialization |
-| **World** | proposalId, baseWorldId, branch | ExecutionKey mapping |
+| **Lineage/Governance** | proposalId, lineage WorldId anchors, branch | ExecutionKey mapping |
 | **App** | User intent, UI state | Orchestration policy |
 
 ```typescript
-// Correct: World/App maps proposalId -> ExecutionKey
+// Correct: Governance/App maps proposalId -> ExecutionKey
 function getExecutionKey(proposalId: string): ExecutionKey {
   return proposalId;
 }
 
-// Wrong: Host directly uses World concepts
-// Host should not import ProposalId type from World
+// Wrong: Host directly uses Governance or Lineage concepts
+// Host should not import ProposalId or WorldId types from Governance/Lineage
 ```
 
 ### 9.2 Run-to-Completion Job Model
@@ -1375,6 +1383,13 @@ Effect handlers MUST NOT throw. Errors are expressed as patches.
 Host-generated error patches MUST target `$host` or domain-owned paths.
 `system.*` is structurally non-patchable at Core boundary. Host MUST use `core.applySystemDelta()` for system transitions.
 
+Host-generated `$host.lastError` records are best-effort Host execution
+diagnostics. They help canonical-substrate debugging for effect handler
+failure, unknown effects, or fulfillment/apply failure. They do not by
+themselves make a terminal Snapshot semantically failed; semantic failure is
+represented by `system.lastError` or domain state through Core-owned
+transitions.
+
 ### 12.2 Mailbox Processing Errors
 
 | Error Type | Handling |
@@ -1501,7 +1516,7 @@ function escalateToFatal(intentId: string, error: Error) {
   // 2. Mark execution as failed
   markExecutionFailed(ctx.executionKey, error);
   
-  // 3. Emit failure to observers (World Protocol)
+  // 3. Emit failure to observers (runtime/governance integration)
   emitExecutionFailure(ctx.executionKey, 'requirement_clear_failed');
   
   // 4. Stop processing this mailbox
@@ -1518,8 +1533,7 @@ function escalateToFatal(intentId: string, error: Error) {
 | Spec | Relationship |
 |------|--------------|
 | Core SPEC | Host executes Core's computation results |
-| World Protocol SPEC | World provides ExecutionKey mapping |
-| App SPEC | App orchestrates Host and provides scheduling policy |
+| SDK/Lineage/Governance SPECS | Runtime and decorator layers provide ExecutionKey mapping policy |
 
 ### 13.2 FDR References
 
@@ -1590,7 +1604,7 @@ This SPEC (v2.0) provides the **mechanism** for single-writer serialization, whi
 ### A.3 Implementation Checklist
 
 - [ ] Mailbox per ExecutionKey
-- [ ] ExecutionKey opaque (no World/Proposal types in Host)
+- [ ] ExecutionKey opaque (no Governance proposal or Lineage WorldId types in Host)
 - [ ] Job handlers synchronous (no await)
 - [ ] Single-runner guard with Set<ExecutionKey>
 - [ ] **Blocked kick remembered in runnerKickRequested set (LIVE-4)**

--- a/packages/host/docs/host-SPEC.md
+++ b/packages/host/docs/host-SPEC.md
@@ -149,10 +149,10 @@ import type { Snapshot, SystemState, SnapshotMeta, ErrorValue, SystemDelta } fro
 | Field | Owner | Host Reads | Host Writes | Description |
 |-------|-------|------------|-------------|-------------|
 | `data.*` | Core | Yes | via Patch | Domain state |
-| `data.$host.*` | **Host** | Yes | Yes | Host-owned namespace (see below) |
+| `data.$host.*` | **Host** | Yes | Yes | Host-owned canonical diagnostics/bookkeeping namespace (see below) |
 | `computed.*` | Core | Yes | No | Derived values |
 | `system.status` | Core | Yes | No | Core sets via compute() |
-| `system.lastError` | Core | Yes | No | Current error state |
+| `system.lastError` | Core | Yes | No | Current semantic error state |
 | `system.pendingRequirements` | Core | Yes | via `core.applySystemDelta()` | Requirement lifecycle |
 | `system.currentAction` | Core | Yes | No | Core sets during compute |
 | `meta.schemaHash` | Core | Yes | No | Domain schema identity |
@@ -170,6 +170,8 @@ Rather than extending Core's `SystemState`, Host uses a **reserved namespace in 
 type HostOwnedState = {
   /** Intent-scoped effect data */
   intentSlots?: Record<string, Record<string, unknown>>;
+  /** Host-owned effect/execution diagnostic, canonical-only */
+  lastError?: ErrorValue | null;
   /** Other Host-specific state */
   [key: string]: unknown;
 };
@@ -181,6 +183,12 @@ const hostState = snapshot.data.$host as HostOwnedState | undefined;
 **Note:** Patch paths are rooted at `data` by default. Use `$host.*` to target
 the Host-owned namespace. Core reserves `$host` as opaque Host-owned state and
 accepts `$host` patches even when StateSpec does not declare `$host` (Core SPEC §5.5).
+
+`$host.lastError` is an execution diagnostic owned by Host. It is not the
+semantic Snapshot error surface and MUST NOT be automatically promoted into
+`system.lastError`. Application and tooling callers that need per-attempt
+outcomes should use the SDK/Lineage/Governance report helpers; callers that
+need the current semantic error state should read `snapshot.system.lastError`.
 
 | Rule ID | Description |
 |---------|-------------|
@@ -229,7 +237,7 @@ An opaque identifier for execution serialization.
 ```typescript
 /**
  * ExecutionKey is opaque to Host.
- * World/App layer determines the mapping policy.
+ * SDK/Lineage/Governance integration determines the mapping policy.
  */
 type ExecutionKey = string;
 ```
@@ -513,8 +521,8 @@ This section defines the enforcement mechanism for single-writer concurrency.
 
 Host MUST maintain a single-writer mailbox per `ExecutionKey`.
 
-> **Rationale (FDR-H018):** Host MUST maintain a single-writer mailbox per ExecutionKey, where ExecutionKey is opaque to Host. World Protocol (FDR-W017) permits parallel branch execution — if mailbox were keyed by baseWorld, permitted parallelism would be artificially serialized. Keeping ExecutionKey opaque preserves the layer boundary: Host provides serialization mechanism, World/App provides key mapping policy.
-> **Alternatives rejected:** Global single mailbox (blocks W017 parallelism); baseWorld as key (same); no mailbox (no enforcement).
+> **Rationale (FDR-H018):** Host MUST maintain a single-writer mailbox per ExecutionKey, where ExecutionKey is opaque to Host. Lineage and Governance may need parallel branch or proposal execution, and Host must not infer that policy from continuity identifiers such as `baseWorld`. Keeping ExecutionKey opaque preserves the layer boundary: Host provides serialization mechanism; SDK/Lineage/Governance provide key mapping policy.
+> **Alternatives rejected:** Global single mailbox (blocks permitted parallelism); `baseWorld` as key (same); no mailbox (no enforcement).
 > **Consequences:** Single-writer serialization per opaque key; parallel branch execution preserved; clear layer boundary.
 
 #### 9.1.1 Rules (MUST)
@@ -523,7 +531,7 @@ Host MUST maintain a single-writer mailbox per `ExecutionKey`.
 |---------|-------------|
 | MAIL-1 | Host MUST maintain one mailbox per ExecutionKey |
 | MAIL-2 | ExecutionKey MUST be opaque to Host |
-| MAIL-3 | World/App layer determines ExecutionKey mapping policy |
+| MAIL-3 | SDK/Lineage/Governance integration determines ExecutionKey mapping policy |
 | MAIL-4 | All state mutations MUST go through the mailbox |
 
 #### 9.1.2 Type Definition
@@ -542,17 +550,17 @@ interface ExecutionMailbox {
 | Layer | Knows | Provides |
 |-------|-------|----------|
 | **Host** | ExecutionKey (opaque), intentId, Snapshot | Single-writer serialization |
-| **World** | proposalId, baseWorldId, branch | ExecutionKey mapping |
+| **Lineage/Governance** | proposalId, lineage WorldId anchors, branch | ExecutionKey mapping |
 | **App** | User intent, UI state | Orchestration policy |
 
 ```typescript
-// Correct: World/App maps proposalId -> ExecutionKey
+// Correct: Governance/App maps proposalId -> ExecutionKey
 function getExecutionKey(proposalId: string): ExecutionKey {
   return proposalId;
 }
 
-// Wrong: Host directly uses World concepts
-// Host should not import ProposalId type from World
+// Wrong: Host directly uses Governance or Lineage concepts
+// Host should not import ProposalId or WorldId types from Governance/Lineage
 ```
 
 ### 9.2 Run-to-Completion Job Model
@@ -1318,6 +1326,13 @@ Effect handlers MUST NOT throw. Errors are expressed as patches.
 Host-generated error patches MUST target `$host` or domain-owned paths.
 `system.*` is structurally non-patchable at Core boundary. Host MUST use `core.applySystemDelta()` for system transitions.
 
+Host-generated `$host.lastError` records are best-effort Host execution
+diagnostics. They help canonical-substrate debugging for effect handler
+failure, unknown effects, or fulfillment/apply failure. They do not by
+themselves make a terminal Snapshot semantically failed; semantic failure is
+represented by `system.lastError` or domain state through Core-owned
+transitions.
+
 ### 12.2 Mailbox Processing Errors
 
 | Error Type | Handling |
@@ -1444,7 +1459,7 @@ function escalateToFatal(intentId: string, error: Error) {
   // 2. Mark execution as failed
   markExecutionFailed(ctx.executionKey, error);
   
-  // 3. Emit failure to observers (World Protocol)
+  // 3. Emit failure to observers (runtime/governance integration)
   emitExecutionFailure(ctx.executionKey, 'requirement_clear_failed');
   
   // 4. Stop processing this mailbox
@@ -1461,8 +1476,7 @@ function escalateToFatal(intentId: string, error: Error) {
 | Spec | Relationship |
 |------|--------------|
 | Core SPEC | Host executes Core's computation results |
-| World Protocol SPEC | World provides ExecutionKey mapping |
-| App SPEC | App orchestrates Host and provides scheduling policy |
+| SDK/Lineage/Governance SPECS | Runtime and decorator layers provide ExecutionKey mapping policy |
 
 ### 13.2 FDR References
 
@@ -1533,7 +1547,7 @@ This SPEC (v2.0) provides the **mechanism** for single-writer serialization, whi
 ### A.3 Implementation Checklist
 
 - [ ] Mailbox per ExecutionKey
-- [ ] ExecutionKey opaque (no World/Proposal types in Host)
+- [ ] ExecutionKey opaque (no Governance proposal or Lineage WorldId types in Host)
 - [ ] Job handlers synchronous (no await)
 - [ ] Single-runner guard with Set<ExecutionKey>
 - [ ] **Blocked kick remembered in runnerKickRequested set (LIVE-4)**

--- a/packages/lineage/docs/GUIDE.md
+++ b/packages/lineage/docs/GUIDE.md
@@ -50,6 +50,11 @@ It keeps the same seal/publication law and packages the result as data.
 - `rejected` reports include the first failing admission layer plus before snapshots
 - `failed` reports always keep `published: false`; if a failed world was sealed, they may also include `resultWorld`, `branchId`, and `sealedOutcome`
 
+Failed lineage outcomes are derived from the sealed terminal Snapshot's
+`system.lastError` and pending requirements. Canonical `data.$host.lastError`
+is Host-owned diagnostic state and is not, by itself, the lineage terminal
+outcome.
+
 ## 4. Read Heads, Branches, Worlds, And Lineage
 
 ```ts
@@ -69,7 +74,7 @@ These APIs project the backing continuity truth through the activated runtime.
 The activated lineage runtime also keeps the inherited SDK legality queries: `getAvailableActions()`, `isActionAvailable()`, `isIntentDispatchable()`, and `getIntentBlockers()`.
 Those inherited legality queries keep the same ordering as the base SDK: availability short-circuits dispatchability, and `getIntentBlockers()` returns the first failing layer instead of stacking coarse and fine blockers together.
 
-## 5. Restore A Sealed World
+## 5. Restore A Sealed Lineage World
 
 ```ts
 const head = await lineage.getLatestHead();

--- a/packages/lineage/docs/lineage-SPEC.md
+++ b/packages/lineage/docs/lineage-SPEC.md
@@ -171,11 +171,16 @@ It does not replace `commitAsync()`, and it does not change lineage seal/publica
 | LIN-V3-DISPATCH-4 | MUST | a completed terminal snapshot prepare and commit a next lineage seal before publication |
 | LIN-V3-DISPATCH-5 | MUST | `commitAsync()` resolve only after seal commit succeeds |
 | LIN-V3-DISPATCH-6 | MUST | subscribers and `dispatch:completed` fire only after seal commit succeeds |
-| LIN-V3-DISPATCH-7 | MUST | the visible runtime snapshot and the active branch head refer to the same completed World after resolution |
+| LIN-V3-DISPATCH-7 | MUST | the visible runtime snapshot and the active branch head refer to the same completed Lineage World after resolution |
 
 ### 4.3 Failed or Pending Terminal Commit
 
 Lineage still seals failed terminal snapshots. However failed continuity does not become the active head.
+
+A sealed failed outcome is derived from the terminal canonical Snapshot's
+semantic state: non-empty `system.pendingRequirements` or non-null
+`system.lastError`. Host-owned `data.$host.lastError` is canonical diagnostic
+state only; by itself it does not define the sealed terminal outcome.
 
 | Rule ID | Level | Description |
 |---------|-------|-------------|
@@ -258,6 +263,8 @@ Normative rules:
 | LIN-V3-REPORT-9 | MUST | `commitAsyncWithReport()` resolve report unions for normal operational outcomes (`completed`, `rejected`, `failed`) instead of rejecting for those outcomes |
 | LIN-V3-REPORT-10 | MUST | calls made after dispose continue to reject with `DisposedError` rather than being remapped into a report union |
 | LIN-V3-REPORT-11 | MUST NOT | `commitAsyncWithReport()` reintroduce base `dispatchAsync` or `dispatchAsyncWithReport` semantics into a lineage runtime |
+| LIN-V3-REPORT-12 | SHOULD | callers that need per-attempt lineage execution outcome SHOULD use `commitAsyncWithReport()` instead of combining thrown errors, events, and Snapshot probing |
+| LIN-V3-REPORT-13 | MUST NOT | lineage MUST NOT derive sealed failed outcome from Host-owned `data.$host.lastError` alone |
 
 ---
 
@@ -307,7 +314,7 @@ Normative rules:
 
 The service/store/hash contract from v2 remains lineage-owned.
 
-`LineageStore`, `LineageService`, `PreparedLineageCommit`, `World`, `WorldHead`, `BranchInfo`, restore normalization, snapshot hashing, `head` / `tip` / `epoch` semantics, and idempotent reuse rules continue to be normative. This v3 draft layers the decorator runtime on top of that substrate; it does not replace it.
+`LineageStore`, `LineageService`, `PreparedLineageCommit`, `World`, `WorldHead`, `BranchInfo`, restore normalization, snapshot hashing, `head` / `tip` / `epoch` semantics, and idempotent reuse rules continue to be normative. This v3 living specification layers the decorator runtime on top of that substrate; it does not replace it.
 
 ---
 

--- a/packages/sdk/docs/FDR-v3.1.0.md
+++ b/packages/sdk/docs/FDR-v3.1.0.md
@@ -1,7 +1,7 @@
 # Manifesto SDK - Foundational Design Rationale (FDR)
 
 > **Version:** 3.1.0
-> **Status:** Draft
+> **Status:** Accepted Rationale Companion
 > **Purpose:** Document the rationale for projected additive SDK introspection APIs
 > **Scope:** SDK, with compiler-produced schema graph metadata consumed by the SDK
 > **Related:** ADR-015 Snapshot Ontological Purification, PROJ-COMP-1/2, Core `explain()`, Core `computeSync()`, Core `applySystemDelta()`
@@ -12,7 +12,7 @@
 
 ## Scope
 
-This document is the draft rationale track for projected additive SDK v3.1.0 introspection work.
+This document is the accepted rationale companion for projected additive SDK v3.1.0 introspection work.
 
 The current normative SDK contract lives in [`sdk-SPEC.md`](sdk-SPEC.md). The living spec now stages the accepted v3.1.0 introspection additions; this document remains the rationale companion for why those additions exist and how the design was chosen.
 
@@ -28,7 +28,7 @@ The current normative SDK contract lives in [`sdk-SPEC.md`](sdk-SPEC.md). The li
 
 ## FDR-SDK-001: SchemaGraph - Schema-level Static Introspection
 
-> **Status:** Proposed - GO (Rev 4)
+> **Status:** Accepted (Rev 4)
 > **Date:** 2026-04-06
 > **Scope:** Compiler (producer), SDK (consumer)
 > **Related:** COMP-DEP-1~6, PROJ-COMP-1/2, Core `explain()`, ADR-015 Snapshot Ontological Purification
@@ -359,7 +359,7 @@ Kind-prefixed string node ids remain useful for debugging, REPL work, and serial
 
 ## FDR-SDK-002: Simulate - Pure Dry-Run via Core Determinism
 
-> **Status:** Proposed - GO (Rev 2)
+> **Status:** Accepted (Rev 2)
 > **Date:** 2026-04-06
 > **Scope:** SDK
 > **Related:** Core `computeSync()`, `apply()`, `applySystemDelta()`, FDR-C001 Pure Compute Equation, ADR-015 Snapshot Ontological Purification

--- a/packages/sdk/docs/GUIDE.md
+++ b/packages/sdk/docs/GUIDE.md
@@ -146,6 +146,12 @@ It is the additive write companion for callers that need:
 
 The report surface reuses the same dequeue-time legality ordering and publication semantics as `dispatchAsync()`.
 
+For failure observation, keep the surfaces distinct:
+
+- use `dispatchAsyncWithReport()` for the result of this execution attempt
+- use `snapshot.system.lastError` for the current semantic error state
+- use canonical `data.$host.lastError` only for deep Host/effect diagnostics
+
 ---
 
 ## 6. Dispatch, Observe, And Read
@@ -363,5 +369,5 @@ Those runtime contracts belong to the owning Lineage and Governance packages. Th
 - [SDK Version Index](VERSION-INDEX.md)
 - [SDK API](../../../docs/api/sdk.md)
 - [API Index](../../../docs/api/index.md)
-- [World Concept](../../../docs/concepts/world.md)
+- [World Records and Governed Composition](../../../docs/concepts/world.md)
 - [Tutorial](../../../docs/tutorial/)

--- a/packages/sdk/docs/VERSION-INDEX.md
+++ b/packages/sdk/docs/VERSION-INDEX.md
@@ -9,11 +9,11 @@
 |---------|----------|-----|-------|--------|
 | v3.x | [SPEC](sdk-SPEC.md) | [ADR-017](../../../docs/internals/adr/017-capability-decorator-pattern.md), [ADR-019](../../../docs/internals/adr/019-post-activation-extension-kernel.md), [ADR-020](../../../docs/internals/adr/020-intent-level-dispatchability.md) | Activation-first SDK with `activate()`, typed `createIntent()` including non-ambiguous single-parameter object binding, dequeue-time rejection codes for coarse vs fine legality, current-snapshot blocker explanations, projected `SchemaGraph`, bound-intent `simulateIntent(intent)` plus action-ref `simulate()` with optional debug-grade `diagnostics.trace`, the additive base write-report companion `dispatchAsyncWithReport()`, the `@manifesto-ai/sdk/extensions` Extension Kernel including arbitrary-snapshot `isIntentDispatchableFor()`, the first-party `createSimulationSession()` helper, and the public provider authoring seam including `createBaseRuntimeInstance()` | Current |
 
-## Draft Rationale Track
+## Accepted Rationale Companion
 
 | Version | Document | Related ADR | Notes | Status |
 |---------|----------|-------------|-------|--------|
-| v3.1.0 | [FDR](FDR-v3.1.0-draft.md) | [ADR-015](../../../docs/internals/adr/015-snapshot-ontological-purification.md) | Rationale companion for the current v3.1.0 introspection surface: `SchemaGraph` (`feeds` / `mutates` / `unlocks`) and full-transition `simulate()` | Draft |
+| v3.1.0 | [FDR](FDR-v3.1.0.md) | [ADR-015](../../../docs/internals/adr/015-snapshot-ontological-purification.md) | Rationale companion for the current v3.1.0 introspection surface: `SchemaGraph` (`feeds` / `mutates` / `unlocks`) and full-transition `simulate()` | Accepted |
 
 The companion compiler contract now lives in [../../compiler/docs/SPEC-v1.1.0.md](../../compiler/docs/SPEC-v1.1.0.md). Historical addenda remain available in [../../compiler/docs/SPEC-v0.8.0.md](../../compiler/docs/SPEC-v0.8.0.md) and [../../compiler/docs/SPEC-v0.9.0.md](../../compiler/docs/SPEC-v0.9.0.md).
 
@@ -22,7 +22,7 @@ The companion compiler contract now lives in [../../compiler/docs/SPEC-v1.1.0.md
 1. Read [../README.md](../README.md) for package entrypoint guidance.
 2. Read [GUIDE.md](GUIDE.md) for current usage and decorator/provider authoring boundaries.
 3. Read [sdk-SPEC.md](sdk-SPEC.md) for the current living SDK contract.
-4. If you are studying the current introspection surface, read [sdk-SPEC.md](sdk-SPEC.md) §5.5 and §7.4-§7.5, then [../../compiler/docs/SPEC-v1.1.0.md](../../compiler/docs/SPEC-v1.1.0.md), then [FDR-v3.1.0-draft.md](FDR-v3.1.0-draft.md).
+4. If you are studying the current introspection surface, read [sdk-SPEC.md](sdk-SPEC.md) §5.5 and §7.4-§7.5, then [../../compiler/docs/SPEC-v1.1.0.md](../../compiler/docs/SPEC-v1.1.0.md), then [FDR-v3.1.0.md](FDR-v3.1.0.md).
 5. If you are building helper/tooling work against arbitrary snapshots, read [ADR-019](../../../docs/internals/adr/019-post-activation-extension-kernel.md) and [sdk-SPEC.md](sdk-SPEC.md) §7.10 + §8. This is the canonical home for post-activation branching helpers and simulation-session work.
 6. If you need input-aware legality checks, read [ADR-020](../../../docs/internals/adr/020-intent-level-dispatchability.md), [sdk-SPEC.md](sdk-SPEC.md) §7.2-§7.5, and [../../compiler/docs/SPEC-v1.1.0.md](../../compiler/docs/SPEC-v1.1.0.md).
 7. If you need first-party write reports for tooling or agent callers, read [sdk-SPEC.md](sdk-SPEC.md) §7.2-§7.2.2 and [GUIDE.md](GUIDE.md) §5 before reaching for custom wrappers.

--- a/packages/sdk/docs/sdk-SPEC.md
+++ b/packages/sdk/docs/sdk-SPEC.md
@@ -857,6 +857,23 @@ If Host execution produces a terminal error result that also carries a new publi
 
 If execution fails before a new terminal snapshot exists, `dispatchAsyncWithReport()` MUST resolve a failed report with `published: false` and MUST NOT fabricate `outcome`.
 
+### 7.2.3 Failure Observation Surfaces
+
+`dispatchAsyncWithReport()` is the recommended SDK path when a caller needs a
+first-party per-attempt execution result. Callers SHOULD prefer it over
+combining `try/catch`, runtime events, `snapshot.system.lastError`, and
+canonical substrate probing.
+
+`snapshot.system.lastError` is the current semantic error surface of the
+Snapshot. It is present on both projected `getSnapshot()` reads and canonical
+`getCanonicalSnapshot()` reads.
+
+`data.$host.lastError` is Host-owned execution diagnostic state. It is visible
+only on the canonical substrate, is omitted from projected app-facing
+Snapshots, and exists for deep debugging of effect/Host execution. SDK MUST NOT
+automatically promote `data.$host.lastError` into `system.lastError` and MUST
+NOT add a second generic `getLastError()` helper that merges those surfaces.
+
 ### 7.3 Availability, Dispatchability, Explanation, and Metadata Queries
 
 `getAvailableActions()`, `isActionAvailable()`, `isIntentDispatchable()`, `getIntentBlockers()`, `explainIntent()`, `why()`, `whyNot()`, and `getActionMetadata()` are observational reads over the current visible snapshot plus the activated schema metadata.
@@ -1010,7 +1027,7 @@ The returned value MUST be protected from external mutation. The implementation 
 
 `getCanonicalSnapshot()` returns the current visible **canonical** runtime substrate synchronously.
 
-This is the explicit inspection seam for persistence-aware tooling, stored-world alignment, and low-level debugging. It is not the default application-facing read surface.
+This is the explicit inspection seam for persistence-aware tooling, Lineage World snapshot alignment, and low-level debugging. It is not the default application-facing read surface.
 
 ### 7.10 `@manifesto-ai/sdk/extensions`
 
@@ -1249,6 +1266,10 @@ Dispose MUST release all SDK-owned resources for the activated base instance, in
 | SDK-REPORT-9 | MUST | `dispatchAsyncWithReport()` MUST resolve report unions for normal operational outcomes (`completed`, `rejected`, `failed`) instead of rejecting for those outcomes |
 | SDK-REPORT-10 | MUST | Calls made after disposal MUST continue to reject with `DisposedError` rather than being remapped into a report union |
 | SDK-REPORT-11 | MUST NOT | This additive report surface MUST NOT expose provider-only runtime-control helpers or become a new execution-control seam |
+| SDK-FAILOBS-1 | SHOULD | Callers that need per-attempt execution outcome SHOULD use `dispatchAsyncWithReport()` instead of combining `try/catch`, events, and Snapshot probing |
+| SDK-FAILOBS-2 | MUST | `snapshot.system.lastError` remains the current semantic Snapshot error surface on projected and canonical reads |
+| SDK-FAILOBS-3 | MUST | `data.$host.lastError` remains canonical-only Host-owned diagnostic state and MUST NOT appear in projected app-facing Snapshots |
+| SDK-FAILOBS-4 | MUST NOT | SDK MUST NOT automatically promote `data.$host.lastError` into `system.lastError` or expose a generic helper that merges the two surfaces |
 | SDK-GRAPH-1 | MUST | `getSchemaGraph()` MUST expose a static graph derived from the activated `DomainSchema` alone, with no snapshot dependency |
 | SDK-GRAPH-2 | MUST | the public graph MUST exclude `data.$*` nodes, edges touching excluded `$*` nodes, and computed nodes tainted by transitive `$*` dependencies |
 | SDK-GRAPH-3 | SHOULD | the SDK SHOULD compute the graph once at activation time and cache it for the instance lifetime |
@@ -1469,6 +1490,7 @@ An SDK v3.x implementation complies with this living contract only if all of the
 - `createIntent()` is keyed by `MEL.actions.*`, not raw string action names.
 - `dispatchAsync()` is FIFO per instance and evaluates availability, then input validation, then dispatchability at dequeue time.
 - `dispatchAsyncWithReport()` is additive, reuses the same legality ordering and projected diff semantics, and does not change `dispatchAsync()` publication behavior.
+- Failure observation keeps per-attempt reports, semantic `system.lastError`, and canonical-only `$host.lastError` diagnostics distinct.
 - `createManifesto()` accepts MEL source or `DomainSchema`, but not tooling-only compiler artifacts such as `DomainModule`.
 - `getSchemaGraph()` exposes the projected static graph only and accepts refs as the canonical lookup surface.
 - `simulateIntent()` is the bound-intent pure dry-run, and `simulate()` is the action-ref convenience form; both apply `apply()` and `applySystemDelta()` and treat `changedPaths` as inspection/debug-only.
@@ -1487,4 +1509,4 @@ An SDK v3.x implementation complies with this living contract only if all of the
 - [Core SPEC v4.2.0](../../core/docs/core-SPEC.md)
 - [Host Contract v4.0.0](../../host/docs/host-SPEC.md)
 - [Compiler SPEC v1.1.0](../../compiler/docs/SPEC-v1.1.0.md)
-- [SDK FDR v3.1.0 Rationale Track](FDR-v3.1.0-draft.md)
+- [SDK FDR v3.1.0 Rationale Companion](FDR-v3.1.0.md)

--- a/scripts/check-doc-governance.mjs
+++ b/scripts/check-doc-governance.mjs
@@ -1,6 +1,12 @@
 import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const targets = [
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const policyTargets = [
   {
     path: "docs/internals/documentation-governance.md",
     label: "documentation governance policy",
@@ -27,12 +33,202 @@ const targets = [
   },
 ];
 
+const statusExpectations = [
+  {
+    path: "docs/internals/spec/current-contract.md",
+    status: "> **Status:** Living Document",
+  },
+  {
+    path: "packages/core/docs/core-SPEC.md",
+    status: "> **Status:** Normative (Living Document)",
+  },
+  {
+    path: "packages/host/docs/host-SPEC.md",
+    status: "> **Status:** Normative (Living Document)",
+  },
+  {
+    path: "packages/sdk/docs/sdk-SPEC.md",
+    status: "> **Status:** Normative (Living Document)",
+  },
+  {
+    path: "packages/lineage/docs/lineage-SPEC.md",
+    status: "> **Status:** Normative (Living Document)",
+  },
+  {
+    path: "packages/governance/docs/governance-SPEC.md",
+    status: "> **Status:** Normative (Living Document)",
+  },
+  {
+    path: "packages/compiler/docs/SPEC-v1.2.0.md",
+    status: "> **Status:** Normative",
+  },
+  {
+    path: "packages/codegen/docs/SPEC-v0.1.1.md",
+    status: "> **Status:** Normative Baseline",
+  },
+  {
+    path: "packages/sdk/docs/FDR-v3.1.0.md",
+    status: "> **Status:** Accepted Rationale Companion",
+  },
+  {
+    path: "packages/compiler/docs/FDR-v0.5.0.md",
+    status: "> **Status:** Accepted Rationale",
+  },
+];
+
+const currentContractDocs = [
+  "CLAUDE.md",
+  "AGENTS.md",
+  "docs/internals/spec/current-contract.md",
+  "docs/internals/spec/index.md",
+  "docs/internals/fdr/index.md",
+  "docs/architecture/layers.md",
+  "docs/concepts/world.md",
+  "docs/api/runtime.md",
+  "docs/api/sdk.md",
+  "docs/api/lineage.md",
+  "docs/api/governance.md",
+  "docs/integration/ai-agents.md",
+  "packages/sdk/docs/sdk-SPEC.md",
+  "packages/sdk/docs/VERSION-INDEX.md",
+  "packages/sdk/docs/FDR-v3.1.0.md",
+  "packages/host/docs/host-SPEC.md",
+  "packages/lineage/docs/lineage-SPEC.md",
+  "packages/governance/docs/governance-SPEC.md",
+  "packages/codegen/docs/SPEC-v0.1.1.md",
+  "packages/codegen/docs/VERSION-INDEX.md",
+  "packages/compiler/docs/VERSION-INDEX.md",
+];
+
+const forbiddenCurrentPatterns = [
+  {
+    label: "retired World Protocol terminology",
+    pattern: /\bWorld Protocol\b/g,
+  },
+  {
+    label: "retired World governs terminology",
+    pattern: /\bWorld governs\b/g,
+  },
+  {
+    label: "retired World governance terminology",
+    pattern: /\bWorld governance\b/g,
+  },
+  {
+    label: "retired World/App layer terminology",
+    pattern: /\bWorld\/App\b/g,
+  },
+  {
+    label: "retired world-anchored wording",
+    pattern: /\bworld-anchored\b/g,
+  },
+  {
+    label: "retired stored-world wording",
+    pattern: /\bstored-world\b/g,
+  },
+  {
+    label: "retired governed World path wording",
+    pattern: /\bgoverned World path\b/g,
+  },
+  {
+    label: "stale SDK FDR draft filename",
+    pattern: /FDR-v3\.1\.0-draft(?:\.md)?/g,
+  },
+  {
+    label: "draft status on current document",
+    pattern: />\s*\*\*Status:\*\*\s*Draft\b/g,
+  },
+  {
+    label: "draft rationale track on current document",
+    pattern: /\bDraft Rationale Track\b|\bdraft rationale track\b/g,
+  },
+  {
+    label: "current spec described as draft",
+    pattern: /\bThis draft defines\b|\bv3 draft layers\b|\bv3\.1\.0 \(draft\)/g,
+  },
+];
+
+const requiredAnchors = [
+  {
+    path: "docs/internals/spec/current-contract.md",
+    tokens: [
+      "dispatchAsyncWithReport()",
+      "commitAsyncWithReport()",
+      "waitForProposalWithReport()",
+      "snapshot.system.lastError",
+      "data.$host.lastError",
+      "MUST NOT automatically promote",
+    ],
+  },
+  {
+    path: "packages/sdk/docs/sdk-SPEC.md",
+    tokens: [
+      "### 7.2.3 Failure Observation Surfaces",
+      "`snapshot.system.lastError` is the current semantic error surface",
+      "`data.$host.lastError` is Host-owned execution diagnostic state",
+      "getLastError()",
+    ],
+  },
+  {
+    path: "packages/host/docs/host-SPEC.md",
+    tokens: [
+      "`$host.lastError` is an execution diagnostic owned by Host",
+      "MUST NOT be automatically promoted",
+      "SDK/Lineage/Governance report helpers",
+    ],
+  },
+  {
+    path: "packages/lineage/docs/lineage-SPEC.md",
+    tokens: [
+      "commitAsyncWithReport()",
+      "Host-owned `data.$host.lastError` is canonical diagnostic",
+      "MUST NOT | lineage MUST NOT derive sealed failed outcome",
+    ],
+  },
+  {
+    path: "packages/governance/docs/governance-SPEC.md",
+    tokens: [
+      "waitForProposalWithReport()",
+      "Host-owned `data.$host.lastError` is canonical diagnostic state",
+      "MUST NOT | governance settlement `ErrorInfo` MUST NOT merge",
+    ],
+  },
+  {
+    path: "docs/concepts/world.md",
+    tokens: [
+      "not a top-level package or governance layer",
+      "Lineage-owned, immutable record",
+      "withLineage()",
+      "withGovernance()",
+    ],
+  },
+];
+
 const failures = [];
 
-for (const target of targets) {
-  const content = fs.readFileSync(target.path, "utf8");
-  if (!content) {
-    failures.push(`[missing] ${target.path} (${target.label})`);
+function readDoc(relativePath, label = relativePath) {
+  try {
+    return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+  } catch {
+    failures.push(`[missing] ${relativePath} (${label})`);
+    return null;
+  }
+}
+
+function collectMatches(content, pattern) {
+  const matches = [];
+  const lines = content.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    if (pattern.test(lines[index])) {
+      matches.push(index + 1);
+    }
+    pattern.lastIndex = 0;
+  }
+  return matches;
+}
+
+for (const target of policyTargets) {
+  const content = readDoc(target.path, target.label);
+  if (content == null) {
     continue;
   }
   for (const expected of target.expects ?? []) {
@@ -40,6 +236,38 @@ for (const target of targets) {
       failures.push(
         `[missing token] ${target.label}: expected "${expected}" in ${target.path}`,
       );
+    }
+  }
+}
+
+for (const expectation of statusExpectations) {
+  const content = readDoc(expectation.path);
+  if (content != null && !content.includes(expectation.status)) {
+    failures.push(`${expectation.path}: missing required status "${expectation.status}"`);
+  }
+}
+
+for (const file of currentContractDocs) {
+  const content = readDoc(file);
+  if (content == null) {
+    continue;
+  }
+  for (const { label, pattern } of forbiddenCurrentPatterns) {
+    const lines = collectMatches(content, pattern);
+    if (lines.length > 0) {
+      failures.push(`${file}: ${label} at line ${lines.join(", ")}`);
+    }
+  }
+}
+
+for (const anchor of requiredAnchors) {
+  const content = readDoc(anchor.path);
+  if (content == null) {
+    continue;
+  }
+  for (const token of anchor.tokens) {
+    if (!content.includes(token)) {
+      failures.push(`${anchor.path}: missing required anchor "${token}"`);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Clarify the current failure-observation contract for #364 across SDK, Host, Lineage, Governance, API docs, and the current contract page.
- Retire current-doc uses of the old top-level World framing, keeping `World` only as Lineage sealed record/API terminology or explicit retired-facade notes.
- Update latest/current document statuses and fold the new hardening checks into the existing documentation governance check instead of adding a separate script.

Closes #364

## Validation

- `pnpm docs:governance-check`
- `pnpm docs:check`
- `pnpm docs:build`
- `git diff --check`

`docs:build` still emits the existing VitePress `ebnf` syntax fallback and chunk-size warnings, but completes successfully.