### PR TITLE
fix(lineage): export createLineageRuntimeInstance from the provider seam

### DIFF
--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -1018,6 +1018,7 @@ _Source: `packages/lineage/src/provider.ts`_
 - `attachLineageDecoration`
 - `createInMemoryLineageStore`
 - `createLineageRuntimeController`
+- `createLineageRuntimeInstance`
 - `createLineageService`
 - `DefaultLineageService`
 - `getLineageDecoration`

--- a/packages/lineage/src/__tests__/provider-exports.test.ts
+++ b/packages/lineage/src/__tests__/provider-exports.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import * as provider from "../provider.js";
+
+/**
+ * Regression test for #491: the dist types declared
+ * createLineageRuntimeInstance but no JS entrypoint exported it, so
+ * TypeScript resolved the import and Node failed at runtime with
+ * ERR_MODULE_NOT_FOUND. The provider seam must export it (mirroring
+ * createBaseRuntimeInstance on the SDK provider seam).
+ */
+describe("@manifesto-ai/lineage/provider exports (#491)", () => {
+  it("exports createLineageRuntimeInstance as a function", () => {
+    expect(typeof provider.createLineageRuntimeInstance).toBe("function");
+  });
+
+  it("keeps the established provider seam surface", () => {
+    for (const name of [
+      "attachLineageDecoration",
+      "createLineageRuntimeController",
+      "getLineageDecoration",
+      "createLineageService",
+      "createInMemoryLineageStore",
+    ]) {
+      expect(typeof provider[name as keyof typeof provider]).toBe("function");
+    }
+  });
+});

--- a/packages/lineage/src/provider.ts
+++ b/packages/lineage/src/provider.ts
@@ -41,4 +41,8 @@ export {
   DefaultLineageService,
   createLineageService,
 } from "./service/lineage-service.js";
+// Mirrors createBaseRuntimeInstance on the SDK provider seam: decorator and
+// provider authors can compose a lineage runtime around a pre-built kernel
+// (#491 — the declaration shipped in dist types without a JS export).
+export { createLineageRuntimeInstance } from "./lineage-runtime.js";
 export { InMemoryLineageStore, createInMemoryLineageStore } from "./store/in-memory-lineage-store.js";


### PR DESCRIPTION
## Summary

Fixes #491. `dist/lineage-runtime.d.ts` declared `createLineageRuntimeInstance` but the implementation was bundled into an internal chunk with no JS export — TypeScript resolved the import, Node failed with `ERR_MODULE_NOT_FOUND`.

Took resolution option 1 from the issue: export it from `@manifesto-ai/lineage/provider`, mirroring `createBaseRuntimeInstance` on the SDK provider seam (`packages/sdk/src/provider.ts:27`), so decorator/provider authors can compose a lineage runtime around a pre-built kernel.

Verified `dist/provider.js` now exposes the function after build; `check-public-surface` (main entry) unaffected. New `provider-exports.test.ts` pins the seam.

Part of milestone **M1 — Critical Correctness & Contract Fixes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)