### PR TITLE
fix(sdk): validate canonical snapshot shape at the hydration seam

### DIFF
--- a/packages/sdk/src/__tests__/snapshot-shape-validation.test.ts
+++ b/packages/sdk/src/__tests__/snapshot-shape-validation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  createHost,
+  createHostContextProvider,
+  defaultRuntime,
+} from "@manifesto-ai/host";
+import {
+  createSnapshot,
+  extractDefaults,
+  type Snapshot as CoreSnapshot,
+} from "@manifesto-ai/core";
+
+import { createRuntimeStateStore } from "../runtime/state-store.js";
+import { createCounterSchema, type CounterDomain } from "./helpers/schema.js";
+
+/**
+ * Regression tests for #492: setVisibleSnapshot silently accepted snapshots
+ * with unknown top-level keys. A v4-era "data" key next to the real "state"
+ * disabled state preservation with no error, warning, or log. Hydration
+ * inputs are external data; the seam now validates the canonical top-level
+ * shape.
+ */
+function createStore() {
+  const schema = createCounterSchema();
+  const contextProvider = createHostContextProvider(defaultRuntime);
+  const initial = createSnapshot(
+    extractDefaults(schema.state),
+    schema.hash,
+    contextProvider.createInitialContext(),
+  );
+  const host = createHost(schema, {
+    initialSnapshot: initial,
+    runtime: defaultRuntime,
+  });
+
+  return {
+    initial,
+    store: createRuntimeStateStore<CounterDomain>({
+      host,
+      initialCanonicalSnapshot: initial,
+      projectSnapshotFromCanonical: (snapshot) =>
+        structuredClone(snapshot) as never,
+    }),
+  };
+}
+
+describe("setVisibleSnapshot canonical shape validation (#492)", () => {
+  it("accepts a well-formed canonical snapshot", () => {
+    const { store, initial } = createStore();
+
+    expect(() =>
+      store.setVisibleSnapshot(structuredClone(initial), { notify: false }),
+    ).not.toThrow();
+  });
+
+  it("rejects a snapshot carrying the v4 'data' key with a rename hint", () => {
+    const { store, initial } = createStore();
+    const v4Shaped = {
+      ...structuredClone(initial),
+      data: { count: 42 },
+    } as unknown as CoreSnapshot;
+
+    expect(() => store.setVisibleSnapshot(v4Shaped, { notify: false })).toThrow(
+      /unknown top-level key\(s\): data.*"state" since v5/s,
+    );
+  });
+
+  it("rejects arbitrary unknown top-level keys", () => {
+    const { store, initial } = createStore();
+    const stray = {
+      ...structuredClone(initial),
+      ghost: true,
+    } as unknown as CoreSnapshot;
+
+    expect(() => store.setVisibleSnapshot(stray, { notify: false })).toThrow(
+      /unknown top-level key\(s\): ghost/,
+    );
+  });
+
+  it("rejects snapshots missing required top-level objects", () => {
+    const { store, initial } = createStore();
+    const broken = structuredClone(initial) as unknown as Record<string, unknown>;
+    delete broken.state;
+
+    expect(() =>
+      store.setVisibleSnapshot(broken as unknown as CoreSnapshot, {
+        notify: false,
+      }),
+    ).toThrow(/missing the required "state" object/);
+  });
+
+  it("rejects non-object snapshots", () => {
+    const { store } = createStore();
+
+    expect(() =>
+      store.setVisibleSnapshot(null as unknown as CoreSnapshot, {
+        notify: false,
+      }),
+    ).toThrow(/must be a canonical snapshot object/);
+  });
+});

--- a/packages/sdk/src/runtime/state-store.ts
+++ b/packages/sdk/src/runtime/state-store.ts
@@ -1,6 +1,7 @@
 import type { Snapshot as CoreSnapshot } from "@manifesto-ai/core";
 import type { ManifestoHost } from "@manifesto-ai/host";
 
+import { ManifestoError } from "../errors.js";
 import type {
   CanonicalSnapshot,
   ManifestoDomainShape,
@@ -17,6 +18,58 @@ import {
 import type {
   RuntimeStateStore,
 } from "./facets.js";
+
+const SNAPSHOT_TOP_LEVEL_KEYS = new Set([
+  "state",
+  "computed",
+  "system",
+  "input",
+  "meta",
+  "namespaces",
+]);
+
+const SNAPSHOT_REQUIRED_OBJECT_KEYS = ["state", "system", "meta"] as const;
+
+/**
+ * Hydration inputs are external data by definition (restore files, persisted
+ * stores, cross-version tooling), so the visible-snapshot seam validates the
+ * canonical top-level shape instead of silently dropping unknown keys (#492:
+ * a v4-era "data" key next to the real "state" disabled state preservation
+ * with no error, warning, or log).
+ */
+function assertCanonicalSnapshotShape(snapshot: CoreSnapshot): void {
+  if (snapshot === null || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    throw new ManifestoError(
+      "INVALID_SNAPSHOT_SHAPE",
+      "Visible snapshot must be a canonical snapshot object",
+    );
+  }
+
+  const record = snapshot as unknown as Record<string, unknown>;
+  const unknownKeys = Object.keys(record).filter(
+    (key) => !SNAPSHOT_TOP_LEVEL_KEYS.has(key),
+  );
+  if (unknownKeys.length > 0) {
+    const dataHint = unknownKeys.includes("data")
+      ? ' Domain state lives under "state" since v5; the v4 "data" key was renamed.'
+      : "";
+    throw new ManifestoError(
+      "INVALID_SNAPSHOT_SHAPE",
+      `Visible snapshot has unknown top-level key(s): ${unknownKeys.join(", ")}.${dataHint}` +
+        " Expected only: state, computed, system, input, meta, namespaces.",
+    );
+  }
+
+  for (const key of SNAPSHOT_REQUIRED_OBJECT_KEYS) {
+    const value = record[key];
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      throw new ManifestoError(
+        "INVALID_SNAPSHOT_SHAPE",
+        `Visible snapshot is missing the required "${key}" object`,
+      );
+    }
+  }
+}
 
 interface Subscriber<TState, TComputed, R> {
   readonly selector: Selector<TState, R, TComputed>;
@@ -125,6 +178,7 @@ export function createRuntimeStateStore<T extends ManifestoDomainShape>({
     snapshot: CoreSnapshot,
     options?: { readonly notify?: boolean },
   ): Snapshot<T["state"], T["computed"]> {
+    assertCanonicalSnapshotShape(snapshot);
     visibleCanonicalSnapshot = structuredClone(snapshot);
     host.reset(structuredClone(visibleCanonicalSnapshot));
     visibleCanonicalReadSnapshot = cloneAndDeepFreeze(


### PR DESCRIPTION
## Summary

Fixes #492 (option 2 from the issue — validate and reject).

`setVisibleSnapshot` is the seam every restore/hydration path goes through, and it silently accepted snapshots shaped for the v4 contract: a stale `data` key was ignored, `state` fell back to defaults, and state preservation was disabled with no signal (the studio incident in the issue).

### Change
`packages/sdk/src/runtime/state-store.ts` now validates the canonical top-level shape before accepting a visible snapshot:
- unknown top-level keys are rejected — `data` specifically gets a v5 rename hint ("Domain state lives under \"state\" since v5")
- `state` / `system` / `meta` must be present objects
- non-object snapshots are rejected

Errors are `ManifestoError("INVALID_SNAPSHOT_SHAPE", …)` matching the seam's existing error style.

### Tests
New `snapshot-shape-validation.test.ts` (5 cases) exercises the store directly with a real host. Full suites green: sdk 8 files, lineage 11, governance 10, activation-cts 5 (covers lineage restore→setVisibleSnapshot path).

Part of milestone **M1 — Critical Correctness & Contract Fixes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)