### PR TITLE
feat(core,sdk): route legality evaluation errors through the admission value channel

### DIFF
--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -453,10 +453,13 @@ _Source: `packages/core/src/index.ts`_
 - `EqExpr`
 - `err`
 - `ErrorValue`
+- `evaluateActionAvailability`
+- `evaluateAvailableActions`
 - `evaluateComputed`
 - `evaluateExpr`
 - `evaluateFlow`
 - `evaluateFlowSync`
+- `evaluateIntentDispatchability`
 - `evaluateSingleComputed`
 - `EveryExpr`
 - `explain`
@@ -616,11 +619,17 @@ _Source: `packages/core/src/index.ts`_
 #### Types
 
 - `AbsExpr`
+- `ActionAvailabilityErrorCode`
+- `ActionAvailabilityEvaluation`
+- `ActionDispatchabilityErrorCode`
+- `ActionDispatchabilityEvaluation`
 - `ActionSpec`
 - `AddExpr`
 - `AndExpr`
 - `AppendExpr`
 - `AtExpr`
+- `AvailableActionError`
+- `AvailableActionsEvaluation`
 - `CallFlow`
 - `CausalGuardFlow`
 - `CeilExpr`
@@ -1086,6 +1095,7 @@ _Source: `packages/sdk/src/index.ts`_
 - `ActionSurface`
 - `ActivatedInstance`
 - `Admission`
+- `AdmissionBlocker`
 - `AdmissionFailure`
 - `AdmissionOk`
 - `AvailableActionDelta`
@@ -1123,6 +1133,7 @@ _Source: `packages/sdk/src/index.ts`_
 - `ExecutionFailureInfo`
 - `ExecutionOutcome`
 - `ExecutionView`
+- `ExplanationBlocker`
 - `ExternalContext`
 - `FieldRef`
 - `GetAction`
@@ -1241,6 +1252,7 @@ _Source: `packages/sdk/src/provider.ts`_
 - `GovernanceRuntimeKernel`
 - `GovernanceRuntimeKernelFactory`
 - `HostDispatchOptions`
+- `KernelSimulateResult`
 - `LineageRuntimeKernel`
 - `LineageRuntimeKernelFactory`
 - `RuntimeKernel`

--- a/packages/core/src/core/action-availability.ts
+++ b/packages/core/src/core/action-availability.ts
@@ -6,8 +6,8 @@ import { evaluateComputed } from "../evaluator/computed.js";
 import { evaluateExpr } from "../evaluator/expr.js";
 import { isErr } from "../schema/common.js";
 
-type ActionAvailabilityErrorCode = "UNKNOWN_ACTION" | "INTERNAL_ERROR" | "TYPE_MISMATCH";
-type ActionDispatchabilityErrorCode = "UNKNOWN_ACTION" | "INTERNAL_ERROR" | "TYPE_MISMATCH";
+export type ActionAvailabilityErrorCode = "UNKNOWN_ACTION" | "INTERNAL_ERROR" | "TYPE_MISMATCH";
+export type ActionDispatchabilityErrorCode = "UNKNOWN_ACTION" | "INTERNAL_ERROR" | "TYPE_MISMATCH";
 
 export type ActionAvailabilityEvaluation =
   | { kind: "ok"; available: boolean }
@@ -119,6 +119,10 @@ export function evaluateActionAvailability(
 
 /**
  * Check whether an action is available for a new invocation.
+ *
+ * @deprecated Use {@link evaluateActionAvailability}: this wrapper throws on
+ * evaluation errors, violating the errors-are-values contract. It will be
+ * removed in the next major release.
  */
 export function isActionAvailable(
   schema: DomainSchema,
@@ -208,6 +212,10 @@ export function evaluateIntentDispatchability(
 
 /**
  * Check whether a specific bound intent is dispatchable.
+ *
+ * @deprecated Use {@link evaluateIntentDispatchability}: this wrapper throws
+ * on evaluation errors, violating the errors-are-values contract. It will be
+ * removed in the next major release.
  */
 export function isIntentDispatchable(
   schema: DomainSchema,
@@ -221,8 +229,71 @@ export function isIntentDispatchable(
   return result.dispatchable;
 }
 
+export type AvailableActionError = {
+  readonly actionName: string;
+  readonly code: ActionAvailabilityErrorCode;
+  readonly message: string;
+};
+
+export type AvailableActionsEvaluation =
+  | {
+    kind: "ok";
+    /** Action names whose availability evaluated to true, in schema key order. */
+    actions: readonly string[];
+    /**
+     * Actions whose availability expression failed to evaluate. They are
+     * excluded from `actions` (an action whose legality cannot be evaluated
+     * is not available), but the failure stays observable as a value so one
+     * broken expression cannot poison the whole legality query.
+     */
+    errors: readonly AvailableActionError[];
+  }
+  | { kind: "error"; code: "INTERNAL_ERROR"; message: string };
+
+/**
+ * Evaluate availability for every action without re-entry semantics.
+ *
+ * Per-action evaluation failures are reported as values alongside the
+ * available list; only a snapshot-level preparation failure (computed
+ * evaluation) makes the whole query fail.
+ */
+export function evaluateAvailableActions(
+  schema: DomainSchema,
+  snapshot: Snapshot
+): AvailableActionsEvaluation {
+  const prepared = prepareQuerySnapshot(schema, snapshot);
+  if (prepared.kind === "error") {
+    return prepared;
+  }
+
+  const actions: string[] = [];
+  const errors: AvailableActionError[] = [];
+
+  for (const actionName of Object.keys(schema.actions)) {
+    const result = evaluateAvailabilityAgainstPreparedSnapshot(
+      schema,
+      prepared.snapshot,
+      actionName,
+      snapshot.meta.timestamp
+    );
+    if (result.kind === "error") {
+      errors.push({ actionName, code: result.code, message: result.message });
+      continue;
+    }
+    if (result.available) {
+      actions.push(actionName);
+    }
+  }
+
+  return { kind: "ok", actions, errors };
+}
+
 /**
  * Return all currently available actions in schema key order.
+ *
+ * @deprecated Use {@link evaluateAvailableActions}: this wrapper throws on
+ * evaluation errors, violating the errors-are-values contract. It will be
+ * removed in the next major release.
  */
 export function getAvailableActions(
   schema: DomainSchema,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,23 @@ import {
   isIntentDispatchable,
 } from "./core/action-availability.js";
 
+// Value-returning legality evaluators (errors-are-values channel). The
+// throwing is*/getAvailableActions wrappers below are deprecated in favor
+// of these.
+export {
+  evaluateActionAvailability,
+  evaluateAvailableActions,
+  evaluateIntentDispatchability,
+} from "./core/action-availability.js";
+export type {
+  ActionAvailabilityErrorCode,
+  ActionAvailabilityEvaluation,
+  ActionDispatchabilityErrorCode,
+  ActionDispatchabilityEvaluation,
+  AvailableActionError,
+  AvailableActionsEvaluation,
+} from "./core/action-availability.js";
+
 /**
  * ManifestoCore interface
  */

--- a/packages/sdk/src/__tests__/admission-error-paths.test.ts
+++ b/packages/sdk/src/__tests__/admission-error-paths.test.ts
@@ -22,17 +22,13 @@ type BrokenLegalityDomain = {
 };
 
 /**
- * Characterization tests for the legality-evaluation ERROR path.
+ * Legality-evaluation ERROR path contract (#493 legality-channel workstream).
  *
- * These pin the current behavior at the seam the #493 legality-channel
- * workstream will rework: when an `available` / `dispatchable` expression
- * itself fails to evaluate (here: TYPE_MISMATCH from a non-boolean result),
- * the core query wrappers throw and the exception escapes through the SDK
- * action-candidate surface instead of becoming an admission value.
- *
- * When the workstream lands (core evaluate* exports + kernel rewiring),
- * update these assertions to the new value-based contract — that diff is
- * the point of this file.
+ * When an `available` / `dispatchable` expression itself fails to evaluate
+ * (here: TYPE_MISMATCH from a non-boolean result), the failure is a VALUE on
+ * the admission channel: the action is not legal, check() reports a blocked
+ * admission whose blocker message carries the evaluation error, and no
+ * exception escapes the action-candidate surface.
  */
 function createBrokenLegalitySchema(): DomainSchema {
   const incrementFlow = {
@@ -74,67 +70,75 @@ function createBrokenLegalitySchema(): DomainSchema {
   });
 }
 
+function activate() {
+  return createManifesto<BrokenLegalityDomain>(
+    createBrokenLegalitySchema(),
+    {},
+  ).activate();
+}
+
 describe("admission error paths (legality evaluation failures)", () => {
-  it("available() currently throws when the availability expression is non-boolean", () => {
-    const app = createManifesto<BrokenLegalityDomain>(
-      createBrokenLegalitySchema(),
-      {},
-    ).activate();
+  it("available() returns false when the availability expression is non-boolean", () => {
+    const app = activate();
 
-    expect(() => app.action.badAvailability.available()).toThrow(
-      /Availability condition must return boolean/,
-    );
+    expect(app.action.badAvailability.available()).toBe(false);
   });
 
-  it("check() currently throws instead of returning a blocked admission when availability evaluation fails", () => {
-    const app = createManifesto<BrokenLegalityDomain>(
-      createBrokenLegalitySchema(),
-      {},
-    ).activate();
+  it("check() returns a blocked admission carrying the availability evaluation error", () => {
+    const app = activate();
 
-    expect(() => app.action.badAvailability.check()).toThrow(
-      /Availability condition must return boolean/,
-    );
+    const admission = app.action.badAvailability.check();
+    expect(admission).toMatchObject({
+      ok: false,
+      layer: "availability",
+      code: "ACTION_UNAVAILABLE",
+    });
+    if (!admission.ok) {
+      expect(admission.blockers.length).toBeGreaterThan(0);
+      expect(
+        admission.blockers.some((blocker) =>
+          blocker.message.includes("must return boolean"),
+        ),
+      ).toBe(true);
+    }
   });
 
-  it("check() currently throws instead of returning a blocked admission when dispatchability evaluation fails", () => {
-    const app = createManifesto<BrokenLegalityDomain>(
-      createBrokenLegalitySchema(),
-      {},
-    ).activate();
+  it("check() reports dispatchability evaluation failures as blocked admissions", () => {
+    const app = activate();
 
-    expect(() => app.action.badDispatchability.check()).toThrow(
-      /Dispatchability condition must return boolean|must return boolean/,
-    );
+    const admission = app.action.badDispatchability.check();
+    expect(admission).toMatchObject({
+      ok: false,
+      layer: "dispatchability",
+      code: "INTENT_NOT_DISPATCHABLE",
+    });
+    if (!admission.ok) {
+      expect(
+        admission.blockers.some((blocker) =>
+          blocker.message.includes("must return boolean"),
+        ),
+      ).toBe(true);
+    }
   });
 
-  it("inspect.availableActions() currently throws when any action has a broken availability expression", () => {
-    const app = createManifesto<BrokenLegalityDomain>(
-      createBrokenLegalitySchema(),
-      {},
-    ).activate();
+  it("inspect.availableActions() excludes broken actions instead of throwing", () => {
+    const app = activate();
 
-    expect(() => app.inspect.availableActions()).toThrow(
-      /must return boolean/,
-    );
+    const available = app.inspect.availableActions().map((info) => info.name);
+    expect(available).not.toContain("badAvailability");
+    expect(available).toContain("increment");
+    // badDispatchability has no available clause, so it stays available.
+    expect(available).toContain("badDispatchability");
   });
 
-  it("a healthy action admits, but its submit() is currently poisoned by a broken sibling action", async () => {
-    const app = createManifesto<BrokenLegalityDomain>(
-      createBrokenLegalitySchema(),
-      {},
-    ).activate();
+  it("a broken sibling action no longer poisons healthy dispatches", async () => {
+    const app = activate();
 
-    // Admission of the healthy action itself works…
     expect(app.action.increment.available()).toBe(true);
     expect(app.action.increment.check()).toMatchObject({ ok: true });
 
-    // …but the post-dispatch execution report derives newAvailableActions by
-    // evaluating EVERY action's availability, so one broken expression in the
-    // domain currently fails every dispatch (blast radius of the throwing
-    // legality queries).
-    await expect(app.action.increment.submit()).rejects.toThrow(
-      /Availability condition must return boolean/,
-    );
+    const result = await app.action.increment.submit();
+    expect(result.ok).toBe(true);
+    expect(app.snapshot().state.count).toBe(1);
   });
 });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -33,14 +33,15 @@ export type {
   BaseSubmissionResult,
   DynamicActionHandle,
   DynamicBoundAction,
-  DispatchReport,
   DispatchExecutionOutcome,
   DispatchProjectedDiff,
   DispatchCanonicalOutcome,
   ActionObjectBindingArgs,
+  AdmissionBlocker,
   Blocker,
   BoundAction,
   DispatchBlocker,
+  ExplanationBlocker,
   AvailableActionDelta,
   TypedActionMetadata,
   TypedGetActionMetadata,
@@ -69,8 +70,6 @@ export type {
   GovernanceSettlementSurface,
   GovernanceSubmissionResult,
   GetAction,
-  IntentAdmission,
-  IntentAdmissionFailure,
   IntentExplanation,
   InvalidInputInfo,
   JsonValue,
@@ -120,6 +119,22 @@ export type {
   TypedSubscribe,
   Unsubscribe,
   WorldRecord,
+} from "./types.js";
+
+/**
+ * v3-era intent-centric result types. Their public producers
+ * (dispatchAsyncWithReport / the intent-centric base instance) were retired
+ * by the v5 activation-first surface; these exports remain only so existing
+ * type-level consumers keep compiling.
+ *
+ * @deprecated Scheduled for removal in the next major release. Use the
+ * action-candidate surface (Admission / AdmissionFailure / SubmissionResult)
+ * instead.
+ */
+export type {
+  DispatchReport,
+  IntentAdmission,
+  IntentAdmissionFailure,
 } from "./types.js";
 
 export {

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -12,9 +12,29 @@ export type {
   LineageRuntimeKernelFactory,
   RuntimeKernel,
   RuntimeKernelFactory,
-  SimulateResult,
   WaitForProposalRuntimeKernel,
 } from "./compat/internal.js";
+
+// The kernel-level simulation result (canonical snapshot + patches +
+// systemDelta). Distinct from the projected SimulateResult exported by the
+// main entry; the stage-explicit name avoids alias-import collisions for
+// decorator authors who touch both entrypoints (#493).
+export type { SimulateResult as KernelSimulateResult } from "./compat/internal.js";
+
+import type {
+  SimulateResult as InternalKernelSimulateResult,
+} from "./compat/internal.js";
+import type { ManifestoDomainShape } from "./types.js";
+
+/**
+ * @deprecated Renamed to {@link KernelSimulateResult}: this provider-seam
+ * type shares its name with the projected `SimulateResult` on the main
+ * entry while having a different (canonical) shape. The alias will be
+ * removed in the next major release.
+ */
+export type SimulateResult<
+  T extends ManifestoDomainShape = ManifestoDomainShape,
+> = InternalKernelSimulateResult<T>;
 export {
   activateComposable,
   assertComposableNotActivated,

--- a/packages/sdk/src/runtime/admission.ts
+++ b/packages/sdk/src/runtime/admission.ts
@@ -1,5 +1,7 @@
 import {
   validateIntentInput as queryIntentInputValidation,
+  type ActionAvailabilityEvaluation,
+  type ActionDispatchabilityEvaluation,
   type DomainSchema,
   type Snapshot as CoreSnapshot,
 } from "@manifesto-ai/core";
@@ -38,6 +40,14 @@ type RuntimeAdmissionOptions<T extends ManifestoDomainShape> = {
     snapshot: CanonicalSnapshot<T["state"]>,
     intent: TypedIntent<T>,
   ) => boolean;
+  readonly evaluateActionAvailabilityFor: (
+    snapshot: CanonicalSnapshot<T["state"]>,
+    name: keyof T["actions"],
+  ) => ActionAvailabilityEvaluation;
+  readonly evaluateIntentDispatchabilityFor: (
+    snapshot: CanonicalSnapshot<T["state"]>,
+    intent: TypedIntent<T>,
+  ) => ActionDispatchabilityEvaluation;
   readonly projectSnapshotFromCanonical: (
     snapshot: CoreSnapshot,
   ) => ProjectedSnapshot<T>;
@@ -50,6 +60,8 @@ export function createRuntimeAdmission<T extends ManifestoDomainShape>({
   getAvailableActionsFor,
   isActionAvailableFor,
   isIntentDispatchableFor,
+  evaluateActionAvailabilityFor,
+  evaluateIntentDispatchabilityFor,
   projectSnapshotFromCanonical,
   getSimulateSync,
 }: RuntimeAdmissionOptions<T>): RuntimeAdmission<T> {
@@ -76,7 +88,19 @@ export function createRuntimeAdmission<T extends ManifestoDomainShape>({
       return Object.freeze([]);
     }
 
-    if (!isActionAvailableFor(snapshot, actionName)) {
+    // Legality evaluation errors are blockers, not exceptions: an action
+    // whose available/dispatchable expression cannot be evaluated is not
+    // legal, and the failure reason rides the blocker description (#493).
+    const availability = evaluateActionAvailabilityFor(snapshot, actionName);
+    if (availability.kind === "error") {
+      return Object.freeze(
+        action.available
+          ? [buildDispatchBlocker("available", action.available, availability.message)]
+          : [],
+      );
+    }
+
+    if (!availability.available) {
       return Object.freeze(
         action.available
           ? [buildDispatchBlocker("available", action.available, action.description)]
@@ -84,7 +108,16 @@ export function createRuntimeAdmission<T extends ManifestoDomainShape>({
       );
     }
 
-    if (!isIntentDispatchableFor(snapshot, intent)) {
+    const dispatchability = evaluateIntentDispatchabilityFor(snapshot, intent);
+    if (dispatchability.kind === "error") {
+      return Object.freeze(
+        action.dispatchable
+          ? [buildDispatchBlocker("dispatchable", action.dispatchable, dispatchability.message)]
+          : [],
+      );
+    }
+
+    if (!dispatchability.dispatchable) {
       return Object.freeze(
         action.dispatchable
           ? [buildDispatchBlocker("dispatchable", action.dispatchable, action.description)]

--- a/packages/sdk/src/runtime/kernel.ts
+++ b/packages/sdk/src/runtime/kernel.ts
@@ -1,9 +1,11 @@
 import {
   evaluateComputed,
-  getAvailableActions as queryAvailableActions,
+  evaluateActionAvailability,
+  evaluateAvailableActions,
+  evaluateIntentDispatchability,
   isErr,
-  isActionAvailable as queryActionAvailable,
-  isIntentDispatchable as queryIntentDispatchable,
+  type ActionAvailabilityEvaluation,
+  type ActionDispatchabilityEvaluation,
   type DomainSchema,
   type Snapshot as CoreSnapshot,
 } from "@manifesto-ai/core";
@@ -221,13 +223,33 @@ export function createRuntimeKernel<T extends ManifestoDomainShape>({
     actionNames.map((name) => actionMetadataByName[name]),
   ) as readonly TypedActionMetadata<T>[];
 
+  // Legality queries ride the errors-are-values channel: an action whose
+  // availability/dispatchability expression fails to evaluate is treated as
+  // not legal instead of throwing, so one broken expression cannot poison
+  // dispatches or the available-actions projection (#493).
+  function evaluateActionAvailabilityFor(
+    snapshot: CanonicalSnapshot<T["state"]>,
+    name: keyof T["actions"],
+  ): ActionAvailabilityEvaluation {
+    return evaluateActionAvailability(schema, snapshot as CoreSnapshot, String(name));
+  }
+
+  function evaluateIntentDispatchabilityFor(
+    snapshot: CanonicalSnapshot<T["state"]>,
+    intent: TypedIntent<T>,
+  ): ActionDispatchabilityEvaluation {
+    return evaluateIntentDispatchability(schema, snapshot as CoreSnapshot, intent);
+  }
+
   function getAvailableActionsFor(
     snapshot: CanonicalSnapshot<T["state"]>,
   ): readonly (keyof T["actions"])[] {
+    const evaluation = evaluateAvailableActions(schema, snapshot as CoreSnapshot);
+    if (evaluation.kind === "error") {
+      return Object.freeze([]);
+    }
     return Object.freeze(
-      [
-        ...queryAvailableActions(schema, snapshot as CoreSnapshot),
-      ] as Array<keyof T["actions"]>,
+      [...evaluation.actions] as Array<keyof T["actions"]>,
     );
   }
 
@@ -252,7 +274,8 @@ export function createRuntimeKernel<T extends ManifestoDomainShape>({
     snapshot: CanonicalSnapshot<T["state"]>,
     name: keyof T["actions"],
   ): boolean {
-    return queryActionAvailable(schema, snapshot as CoreSnapshot, String(name));
+    const evaluation = evaluateActionAvailabilityFor(snapshot, name);
+    return evaluation.kind === "ok" && evaluation.available;
   }
 
   function isActionAvailable(name: keyof T["actions"]): boolean {
@@ -263,7 +286,8 @@ export function createRuntimeKernel<T extends ManifestoDomainShape>({
     snapshot: CanonicalSnapshot<T["state"]>,
     intent: TypedIntent<T>,
   ): boolean {
-    return queryIntentDispatchable(schema, snapshot as CoreSnapshot, intent);
+    const evaluation = evaluateIntentDispatchabilityFor(snapshot, intent);
+    return evaluation.kind === "ok" && evaluation.dispatchable;
   }
 
   const isIntentDispatchable: TypedIsIntentDispatchable<T> = ((
@@ -361,6 +385,8 @@ export function createRuntimeKernel<T extends ManifestoDomainShape>({
     getAvailableActionsFor,
     isActionAvailableFor,
     isIntentDispatchableFor,
+    evaluateActionAvailabilityFor,
+    evaluateIntentDispatchabilityFor,
     projectSnapshotFromCanonical,
     getSimulateSync: () => {
       if (!simulateSyncRef) {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -164,12 +164,25 @@ export type ActionInfo<Name extends string = string> = {
   readonly annotations?: ActionAnnotation;
 };
 
+/**
+ * Coarse admission-stage blocker riding on {@link AdmissionFailure}.
+ *
+ * Admission stays cheap: a Blocker says THAT a candidate is blocked and at
+ * which layer. To learn WHY in domain terms (the MEL expressions involved),
+ * re-query the explanation seam — that richer stage uses
+ * {@link ExplanationBlocker} (`DispatchBlocker`) on `IntentExplanation`.
+ */
 export type Blocker = {
   readonly path: ReadonlyArray<string | number>;
   readonly code: string;
   readonly message: string;
   readonly detail?: Readonly<Record<string, unknown>>;
 };
+
+/**
+ * Stage-explicit name for {@link Blocker}: the admission-stage vocabulary.
+ */
+export type AdmissionBlocker = Blocker;
 
 export type AdmissionOk<Name extends string = string> = {
   readonly ok: true;
@@ -760,12 +773,26 @@ export type TypedGetActionMetadata<T extends ManifestoDomainShape> = {
   <K extends keyof T["actions"]>(name: K): TypedActionMetadata<T, K>;
 };
 
+/**
+ * Rich explanation-stage blocker riding on `IntentExplanation`.
+ *
+ * Carries the MEL expression behind the block. This is the upgrade target
+ * when a UI showing "why is this blocked" needs more than the coarse
+ * admission-stage {@link Blocker}: re-query the explanation seam to move
+ * from one vocabulary to the other.
+ */
 export type DispatchBlocker = {
   readonly layer: "available" | "dispatchable";
   readonly expression: ExprNode;
   readonly evaluatedResult: unknown;
   readonly description?: string;
 };
+
+/**
+ * Stage-explicit name for {@link DispatchBlocker}: the explanation-stage
+ * vocabulary.
+ */
+export type ExplanationBlocker = DispatchBlocker;
 
 export type TypedIsIntentDispatchable<T extends ManifestoDomainShape> = <
   K extends keyof T["actions"],
@@ -902,6 +929,14 @@ export type ManifestoApp<
       ? GovernanceSettlementSurface<T>
       : EmptySurface);
 
+/**
+ * v3-era intent-centric instance shape, retired from the public surface by
+ * the v5 activation-first design. It is intentionally NOT exported from the
+ * package entrypoints; it remains only as the internal compat seam's view.
+ *
+ * @deprecated Scheduled for removal in the next major release together with
+ * the deprecated DispatchReport / IntentAdmission result types.
+ */
 export type ManifestoBaseInstance<T extends ManifestoDomainShape> = {
   readonly createIntent: TypedCreateIntent<T>;
   readonly dispatchAsync: TypedDispatchAsync<T>;


### PR DESCRIPTION
## Summary

Closes #493. Anchor workstream of milestone M1 — the audit's C-1 finding (core public API throwing on business-logic errors, `packages/core/src/core/action-availability.ts:130,219,233,244`) and the #493 surface items, resolved together without breaking changes.

### Core (additive)
- Exports the value-returning evaluators: `evaluateActionAvailability`, `evaluateIntentDispatchability`, new `evaluateAvailableActions` (+ evaluation types). They already existed internally; they are now the public legality channel.
- `evaluateAvailableActions` reports per-action evaluation failures as values **alongside** the available list, so one broken expression cannot poison the whole query.
- Throwing `isActionAvailable` / `isIntentDispatchable` / `getAvailableActions` wrappers are `@deprecated` (removal in v6); the boundary-guard allowlist entry documents this.

### SDK kernel rewiring
- `kernel.ts` consumes the evaluators; evaluation error ⇒ not legal (no throw).
- `admission.ts` blockers carry the evaluation error message (`blocker.message`), so `check()` explains *why* ("Availability condition must return boolean, got number").
- Previously (characterized in #494's `admission-error-paths.test.ts`, updated here): `available()`/`check()` threw, and **a single broken availability expression failed every dispatch in the domain** via the post-dispatch `newAvailableActions` report.

### #493 surface items
1. Producer-less v3-era types (`DispatchReport`, `IntentAdmission`, `IntentAdmissionFailure`, `ManifestoBaseInstance`) — deprecated with explicit v6-removal notes.
2. Duplicate `SimulateResult` — provider seam's renamed to `KernelSimulateResult\`; deprecated alias kept for compat.
3. Two blocker vocabularies — stage-explicit aliases `AdmissionBlocker`/`ExplanationBlocker` + JSDoc encoding the admission→explanation upgrade path.

### Verification
Boundary guard green; suites green: core 23, host 22, sdk 8 (83 tests), lineage 11, governance 10, activation-cts 5.

**Depends on #494** (branch is stacked on it — contains the boundary guard and the characterization tests this PR updates). Merge #494 first.

Part of milestone **M1 — Critical Correctness & Contract Fixes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)