### PR TITLE
fix(host): serialize the stateful dispatch critical section

### DIFF
--- a/packages/host/src/__tests__/unit/dispatch-serialization.test.ts
+++ b/packages/host/src/__tests__/unit/dispatch-serialization.test.ts
@@ -1,0 +1,85 @@
+import { semanticPathToPatchPath } from "@manifesto-ai/core";
+import { describe, it, expect } from "vitest";
+
+import { createHost } from "../../host.js";
+import {
+  createTestSchema,
+  createTestIntentWithId,
+  stripHostState,
+} from "../helpers/index.js";
+
+const pp = semanticPathToPatchPath;
+
+/**
+ * Regression tests for #476: the dispatch critical section (read baseline
+ * from the stateful head -> execute -> write final snapshot back) must be
+ * serialized. Concurrent dispatches used to clone the same stale baseline
+ * at the first await point, so the last writer silently discarded every
+ * other dispatch's state transition.
+ */
+function createIncrementHost() {
+  const schema = createTestSchema({
+    actions: {
+      increment: {
+        flow: {
+          kind: "patch",
+          op: "set",
+          path: pp("count"),
+          value: {
+            kind: "add",
+            left: {
+              kind: "coalesce",
+              args: [{ kind: "get", path: "count" }, { kind: "lit", value: 0 }],
+            },
+            right: { kind: "lit", value: 1 },
+          },
+        },
+      },
+    },
+  });
+  return createHost(schema, { initialData: { count: 0 } });
+}
+
+describe("stateful dispatch head serialization (#476)", () => {
+  it("does not lose updates across two concurrent dispatches", async () => {
+    const host = createIncrementHost();
+
+    const [first, second] = await Promise.all([
+      host.dispatch(createTestIntentWithId("increment", "inc-1")),
+      host.dispatch(createTestIntentWithId("increment", "inc-2")),
+    ]);
+
+    expect(first.status).toBe("complete");
+    expect(second.status).toBe("complete");
+    expect(stripHostState(host.getSnapshot()?.state)).toEqual({ count: 2 });
+  });
+
+  it("does not lose updates across many concurrent dispatches", async () => {
+    const host = createIncrementHost();
+    const total = 25;
+
+    const results = await Promise.all(
+      Array.from({ length: total }, (_, index) =>
+        host.dispatch(createTestIntentWithId("increment", `inc-${index}`)),
+      ),
+    );
+
+    for (const result of results) {
+      expect(result.status).toBe("complete");
+    }
+    expect(stripHostState(host.getSnapshot()?.state)).toEqual({ count: total });
+  });
+
+  it("keeps dispatch results ordered against the head they observed", async () => {
+    const host = createIncrementHost();
+
+    const [first, second] = await Promise.all([
+      host.dispatch(createTestIntentWithId("increment", "inc-a")),
+      host.dispatch(createTestIntentWithId("increment", "inc-b")),
+    ]);
+
+    // The serialized second dispatch must observe the first one's write.
+    expect(stripHostState(first.snapshot.state)).toEqual({ count: 1 });
+    expect(stripHostState(second.snapshot.state)).toEqual({ count: 2 });
+  });
+});

--- a/packages/host/src/host.ts
+++ b/packages/host/src/host.ts
@@ -188,6 +188,15 @@ export class ManifestoHost {
   // Current snapshot (managed in memory, caller is responsible for persistence)
   private currentSnapshot: Snapshot | null = null;
 
+  /**
+   * Serializes the stateful dispatch critical section (#476): from reading
+   * the baseline off currentSnapshot to writing the final snapshot back.
+   * Without it, concurrent dispatches each clone the same stale baseline at
+   * the first await point and the last writer silently discards the other's
+   * state transition.
+   */
+  private dispatchGate: Promise<unknown> = Promise.resolve();
+
   private cloneSnapshot(snapshot: Snapshot): Snapshot {
     return structuredClone(snapshot);
   }
@@ -345,11 +354,31 @@ export class ManifestoHost {
   /**
    * Dispatch an intent using v2.0.1 Mailbox + Runner + Job model
    *
+   * Dispatches against the stateful head are serialized: each dispatch
+   * reads its baseline only after the previous dispatch has written its
+   * final snapshot back (#476). Per-key mailbox serialization alone does
+   * not protect the head, because two concurrent dispatches create
+   * independent execution contexts from the same stale baseline.
+   *
    * @param intent - Intent to dispatch
    * @param options - Optional dispatch options (routing key override)
    * @returns Host result with final snapshot and traces
    */
   async dispatch(
+    intent: Intent,
+    options?: HostDispatchOptions
+  ): Promise<HostResult> {
+    const run = this.dispatchGate.then(() =>
+      this.dispatchSerialized(intent, options)
+    );
+    this.dispatchGate = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
+  private async dispatchSerialized(
     intent: Intent,
     options?: HostDispatchOptions
   ): Promise<HostResult> {


### PR DESCRIPTION
## Summary

Fixes #476.

Concurrent `dispatch()` calls raced on the stateful head: each cloned `currentSnapshot` as its baseline (host.ts, read at the top of the critical section), suspended at `await processMailbox(...)`, and wrote its final snapshot back independently — last writer wins, prior transitions silently lost. Two concurrent increments settled at `count=1`. The per-key mailbox (RUN-1) only serializes job execution within one execution context; it cannot protect the head because each dispatch creates an independent context from the stale baseline.

### Fix
`dispatch()` chains the entire read-baseline → execute → write-head section on a private `dispatchGate` promise chain (the same pattern the SDK state-store already uses for its dispatch queue). The body moved to `dispatchSerialized()` unchanged. Host remains execute-only — no policy added.

### Tests
New `dispatch-serialization.test.ts`: 2 concurrent increments → 2; 25 concurrent → 25; result snapshots observe serialized order. Verified red without the fix (3/3 fail, count=1 lost-update reproduced) and green with it. Suites green: host 23 files, sdk 7, activation-cts 5.

Part of milestone **M1 — Critical Correctness & Contract Fixes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)