### PR TITLE
fix(governance,lineage): enforce scope, pending, and recovery safety at governed settlement

### DIFF
--- a/packages/governance/src/governance-scope.ts
+++ b/packages/governance/src/governance-scope.ts
@@ -1,0 +1,124 @@
+import type { IntentScope } from "./types.js";
+
+/**
+ * Approved-scope enforcement (#477).
+ *
+ * `IntentScope.allowedPaths` entries are domain-state-rooted dot paths.
+ * A trailing `.*` segment allows the whole subtree ("todos.*"), a bare "*"
+ * allows everything, and a plain path allows that path and its subtree
+ * ("todos" allows "todos.abc.title").
+ */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function joinPath(base: string, segment: string): string {
+  return base.length === 0 ? segment : `${base}.${segment}`;
+}
+
+function collectInto(
+  before: unknown,
+  after: unknown,
+  path: string,
+  out: Set<string>,
+): void {
+  if (Object.is(before, after)) {
+    return;
+  }
+
+  const beforeIsRecord = isRecord(before);
+  const afterIsRecord = isRecord(after);
+
+  if (beforeIsRecord && afterIsRecord) {
+    const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+    for (const key of keys) {
+      collectInto(before[key], after[key], joinPath(path, key), out);
+    }
+    return;
+  }
+
+  const beforeIsArray = Array.isArray(before);
+  const afterIsArray = Array.isArray(after);
+  if (beforeIsArray && afterIsArray) {
+    const length = Math.max(before.length, after.length);
+    for (let index = 0; index < length; index += 1) {
+      collectInto(before[index], after[index], joinPath(path, String(index)), out);
+    }
+    return;
+  }
+
+  if (path.length > 0 && JSON.stringify(before) !== JSON.stringify(after)) {
+    out.add(path);
+  }
+}
+
+/**
+ * Collect dot paths of leaf-level differences between two domain states.
+ */
+export function collectChangedStatePaths(
+  before: unknown,
+  after: unknown,
+): readonly string[] {
+  const out = new Set<string>();
+  collectInto(before, after, "", out);
+  return Object.freeze([...out].sort());
+}
+
+export function isPathAllowed(
+  path: string,
+  allowedPaths: readonly string[],
+): boolean {
+  for (const allowed of allowedPaths) {
+    if (allowed === "*") {
+      return true;
+    }
+
+    const prefix = allowed.endsWith(".*") ? allowed.slice(0, -2) : allowed;
+    if (path === prefix || path.startsWith(`${prefix}.`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns the changed paths that fall outside the approved scope. An empty
+ * result means the settlement stayed within what the authority approved.
+ */
+export function findScopeViolations(
+  changedPaths: readonly string[],
+  scope: IntentScope | null | undefined,
+): readonly string[] {
+  const allowedPaths = scope?.allowedPaths;
+  if (!allowedPaths || allowedPaths.length === 0) {
+    return Object.freeze([]);
+  }
+
+  return Object.freeze(
+    changedPaths.filter((path) => !isPathAllowed(path, allowedPaths)),
+  );
+}
+
+/**
+ * Narrow the persisted (unknown-typed) approvedScope back to IntentScope.
+ */
+export function toIntentScope(value: unknown): IntentScope | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const allowedPaths = value.allowedPaths;
+  if (allowedPaths === undefined) {
+    return value as IntentScope;
+  }
+
+  if (
+    Array.isArray(allowedPaths)
+    && allowedPaths.every((entry) => typeof entry === "string")
+  ) {
+    return value as IntentScope;
+  }
+
+  return null;
+}

--- a/packages/governance/src/settlement-safety.test.ts
+++ b/packages/governance/src/settlement-safety.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import {
+  hashSchemaSync,
+  semanticPathToPatchPath,
+  type DomainSchema,
+} from "@manifesto-ai/core";
+import { createManifesto } from "@manifesto-ai/sdk";
+import {
+  createInMemoryLineageStore,
+  withLineage,
+} from "@manifesto-ai/lineage";
+
+import { withGovernance } from "./with-governance.js";
+import { createInMemoryGovernanceStore } from "./store/in-memory-governance-store.js";
+import type { ActorAuthorityBinding } from "./types.js";
+
+const pp = semanticPathToPatchPath;
+
+type CounterDomain = {
+  actions: {
+    increment: () => void;
+    load: () => void;
+  };
+  state: {
+    count: number;
+    status: string;
+  };
+  computed: {};
+};
+
+function withHash(schema: Omit<DomainSchema, "hash">): DomainSchema {
+  return { ...schema, hash: hashSchemaSync(schema) };
+}
+
+function createCounterSchema(): DomainSchema {
+  return withHash({
+    id: "manifesto:governance-settlement-safety",
+    version: "1.0.0",
+    types: {},
+    state: {
+      fields: {
+        count: { type: "number", required: false, default: 0 },
+        status: { type: "string", required: false, default: "idle" },
+      },
+    },
+    computed: { fields: {} },
+    actions: {
+      increment: {
+        flow: {
+          kind: "patch",
+          op: "set",
+          path: pp("count"),
+          value: {
+            kind: "add",
+            left: { kind: "get", path: "count" },
+            right: { kind: "lit", value: 1 },
+          },
+        },
+      },
+      load: {
+        flow: {
+          kind: "causalGuard",
+          guardId: "load",
+          body: {
+            kind: "seq",
+            steps: [
+              {
+                kind: "patch",
+                op: "set",
+                path: pp("status"),
+                value: { kind: "lit", value: "loading" },
+              },
+              { kind: "effect", type: "api.fetch", params: {} },
+            ],
+          },
+        },
+      },
+    },
+  });
+}
+
+function createHitlBinding(): ActorAuthorityBinding {
+  return {
+    actorId: "actor:auto",
+    authorityId: "authority:hitl",
+    policy: {
+      mode: "hitl",
+      delegate: {
+        actorId: "delegate:human",
+        kind: "human",
+        name: "Reviewer",
+      },
+    },
+  };
+}
+
+function createAutoBinding(): ActorAuthorityBinding {
+  return {
+    actorId: "actor:auto",
+    authorityId: "authority:auto",
+    policy: { mode: "auto_approve" },
+  };
+}
+
+const EXECUTION = {
+  projectionId: "proj:settlement-safety",
+  deriveActor: () => ({ actorId: "actor:auto", kind: "agent" as const }),
+  deriveSource: () => ({ kind: "agent" as const, eventId: "evt:safety" }),
+};
+
+function activateGoverned(options: {
+  bindings: ActorAuthorityBinding[];
+  effects?: Record<string, (params: unknown) => Promise<never[]>>;
+  lineageStore?: ReturnType<typeof createInMemoryLineageStore>;
+  governanceStore?: ReturnType<typeof createInMemoryGovernanceStore>;
+}) {
+  return withGovernance(
+    withLineage(
+      createManifesto<CounterDomain>(createCounterSchema(), {
+        "api.fetch": async () => [],
+        ...options.effects,
+      }),
+      { store: options.lineageStore ?? createInMemoryLineageStore() },
+    ),
+    {
+      bindings: options.bindings,
+      execution: EXECUTION,
+      ...(options.governanceStore
+        ? { governanceStore: options.governanceStore }
+        : {}),
+    },
+  ).activate();
+}
+
+describe("approved scope enforcement before settlement (#477)", () => {
+  it("fails settlement when changes escape the approved scope", async () => {
+    const governed = activateGoverned({ bindings: [createHitlBinding()] });
+
+    const pending = await governed.action.increment.submit();
+    expect(pending.ok).toBe(true);
+    if (!pending.ok) return;
+
+    // The authority approves only "status"; increment patches "count".
+    // The violation surfaces as a governance failure on the approval /
+    // settlement observation path.
+    let observedError: unknown = null;
+    try {
+      await governed.approve(pending.proposal, { allowedPaths: ["status"] });
+      await pending.waitForSettlement();
+    } catch (error) {
+      observedError = error;
+    }
+    expect(String(observedError)).toMatch(/approved scope/);
+
+    const proposal = await governed.getProposal(pending.proposal);
+    expect(proposal?.status).toBe("failed");
+    // The out-of-scope change must not become the visible state.
+    expect(governed.snapshot().state.count).toBe(0);
+
+    governed.dispose();
+  });
+
+  it("settles normally when changes stay inside the approved scope", async () => {
+    const governed = activateGoverned({ bindings: [createHitlBinding()] });
+
+    const pending = await governed.action.increment.submit();
+    expect(pending.ok).toBe(true);
+    if (!pending.ok) return;
+
+    await governed.approve(pending.proposal, { allowedPaths: ["count"] });
+    await pending.waitForSettlement();
+
+    const proposal = await governed.getProposal(pending.proposal);
+    expect(proposal?.status).toBe("completed");
+    expect(governed.snapshot().state.count).toBe(1);
+
+    governed.dispose();
+  });
+
+  it("wildcard scope allows subtree changes", async () => {
+    const governed = activateGoverned({ bindings: [createHitlBinding()] });
+
+    const pending = await governed.action.increment.submit();
+    expect(pending.ok).toBe(true);
+    if (!pending.ok) return;
+
+    await governed.approve(pending.proposal, { allowedPaths: ["*"] });
+    await pending.waitForSettlement();
+
+    const proposal = await governed.getProposal(pending.proposal);
+    expect(proposal?.status).toBe("completed");
+
+    governed.dispose();
+  });
+});
+
+describe("effect-safe activation recovery (#479)", () => {
+  it("does not re-execute effects for proposals recovered in executing state", async () => {
+    const lineageStore = createInMemoryLineageStore();
+    const governanceStore = createInMemoryGovernanceStore();
+
+    let firstRuntimeCalls = 0;
+    let recoveredRuntimeCalls = 0;
+
+    // First runtime: the effect starts (external IO happens) and never
+    // settles — the crash analog leaves the proposal durably "executing".
+    const first = activateGoverned({
+      bindings: [createAutoBinding()],
+      lineageStore,
+      governanceStore,
+      effects: {
+        "api.fetch": () => {
+          firstRuntimeCalls += 1;
+          return new Promise<never[]>(() => {});
+        },
+      },
+    });
+
+    const pending = await first.action.load.submit();
+    expect(pending.ok).toBe(true);
+    if (!pending.ok) return;
+
+    // Wait until the proposal is durably executing (effect in flight).
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const executing = await governanceStore.getProposal(pending.proposal);
+    expect(executing?.status).toBe("executing");
+    expect(firstRuntimeCalls).toBe(1);
+
+    first.dispose();
+
+    // Second runtime shares the durable stores; activation recovery must
+    // not re-dispatch the effect.
+    const recovered = activateGoverned({
+      bindings: [createAutoBinding()],
+      lineageStore,
+      governanceStore,
+      effects: {
+        "api.fetch": async () => {
+          recoveredRuntimeCalls += 1;
+          return [];
+        },
+      },
+    });
+
+    // Recovery is queued on the kernel; a subsequent settled submission
+    // guarantees it has drained.
+    const probe = await recovered.action.increment.submit();
+    expect(probe.ok).toBe(true);
+    if (probe.ok) {
+      await probe.waitForSettlement();
+    }
+
+    expect(recoveredRuntimeCalls).toBe(0);
+    const terminal = await governanceStore.getProposal(pending.proposal);
+    expect(terminal?.status).toBe("failed");
+
+    recovered.dispose();
+  });
+});

--- a/packages/governance/src/with-governance.ts
+++ b/packages/governance/src/with-governance.ts
@@ -41,6 +41,11 @@ import {
 
 import { createAuthorityEvaluator, type AuthorityEvaluator } from "./authority/evaluator.js";
 import { createGovernanceEventDispatcher } from "./event-dispatcher.js";
+import {
+  collectChangedStatePaths,
+  findScopeViolations,
+  toIntentScope,
+} from "./governance-scope.js";
 import { createGovernanceRuntimeInstance } from "./governance-runtime.js";
 import { createIntentInstance } from "./intent-instance.js";
 import { createGovernanceService } from "./service/governance-service.js";
@@ -231,6 +236,10 @@ function activateGovernanceRuntime<T extends ManifestoDomainShape>(
         executionKey: executingProposal.executionKey,
         publishOnCompleted: false,
         assumeEnqueued: true,
+        // A genuinely unsettled host result must never cross the governed
+        // seal boundary (#478). "unless-failed" keeps the existing contract
+        // that a failed effect execution seals as a failed world.
+        rejectPendingBeforeSeal: "unless-failed",
         context: executingProposal.computeEnvelope.context,
       });
       if (
@@ -241,6 +250,27 @@ function activateGovernanceRuntime<T extends ManifestoDomainShape>(
           "GOVERNANCE_LINEAGE_TARGET_MISMATCH",
           `Governance proposal "${executingProposal.proposalId}" sealed on a different lineage target`,
         );
+      }
+
+      // The authority approved a constrained scope; settlement must stay
+      // inside it. Changed paths are diffed base-world -> terminal snapshot
+      // and validated before the governance commit is finalized (#477).
+      const approvedScope = toIntentScope(executingProposal.approvedScope);
+      if (approvedScope?.allowedPaths && approvedScope.allowedPaths.length > 0) {
+        const baseSnapshot = await lineage.getWorldSnapshot(
+          executingProposal.baseWorld,
+        );
+        const changedPaths = collectChangedStatePaths(
+          baseSnapshot?.state ?? {},
+          (sealed.hostResult.snapshot as CanonicalSnapshot<T["state"]>).state,
+        );
+        const violations = findScopeViolations(changedPaths, approvedScope);
+        if (violations.length > 0) {
+          throw new ManifestoError(
+            "GOVERNANCE_SCOPE_VIOLATION",
+            `Governance proposal "${executingProposal.proposalId}" settled outside its approved scope: ${violations.join(", ")}`,
+          );
+        }
       }
 
       const governanceCommit = await governanceService.finalize(
@@ -498,15 +528,34 @@ function activateGovernanceRuntime<T extends ManifestoDomainShape>(
         return;
       }
 
+      // Effect-safe recovery (#479): an "executing" proposal carries no
+      // durable evidence of whether host effects already ran before the
+      // crash. Re-dispatching could duplicate external side effects, so
+      // recovery never re-executes. If the seal completed (a world
+      // referencing this proposal exists in lineage), that world is recorded
+      // on the failed proposal for explicit reconciliation; otherwise the
+      // proposal fails as unverifiable. Proposals recovered in "approved"
+      // state are safe to execute above: execution begins only after the
+      // "executing" transition is durably persisted.
       const executingProposal = proposal as Proposal & { readonly status: "executing" };
+      let sealedWorldId: string | undefined;
       try {
-        await finalizeApprovedExecution(
-          executingProposal,
-          toTypedComputeIntent<T>(executingProposal),
+        const attempts = await lineageConfig.service.getAttemptsByBranch(
+          executingProposal.branchId,
         );
+        sealedWorldId = attempts.find(
+          (attempt) => attempt.proposalRef === executingProposal.proposalId,
+        )?.worldId;
       } catch {
-        await compensateSettlementFailure(executingProposal.proposalId, executingProposal);
+        // Lineage lookup is best-effort evidence gathering; recovery still
+        // refuses to re-execute below.
       }
+
+      await compensateSettlementFailure(
+        executingProposal.proposalId,
+        executingProposal,
+        sealedWorldId,
+      );
     } finally {
       activeSettlementTasks.delete(proposal.proposalId);
     }

--- a/packages/lineage/src/internal.ts
+++ b/packages/lineage/src/internal.ts
@@ -72,7 +72,15 @@ export type SealIntentOptions = {
   readonly context?: HostDispatchOptions["context"];
   readonly publishOnCompleted?: boolean;
   readonly assumeEnqueued?: boolean;
-  readonly rejectPendingBeforeSeal?: boolean;
+  /**
+   * Reject a non-terminal host result before sealing.
+   *
+   * `true` rejects every pending result. `"unless-failed"` rejects only
+   * pending results that carry no recorded failure evidence — a failed
+   * effect execution legitimately leaves the snapshot pending while the
+   * failure itself is the terminal outcome to seal.
+   */
+  readonly rejectPendingBeforeSeal?: boolean | "unless-failed";
 };
 
 type LineageControllerKernel<T extends ManifestoDomainShape> = Pick<
@@ -401,10 +409,15 @@ export function createLineageRuntimeController<T extends ManifestoDomainShape>(
         throw createLineageSealRuntimeFailure<T>(error, "host");
       }
 
-      if (
+      const pendingResult =
+        result.status === "pending" || result.snapshot.system.status === "pending";
+      const rejectPending =
         options?.rejectPendingBeforeSeal === true
-        && (result.status === "pending" || result.snapshot.system.status === "pending")
-      ) {
+          ? pendingResult
+          : options?.rejectPendingBeforeSeal === "unless-failed"
+            ? pendingResult && !hasRecordedFailureEvidence(result)
+            : false;
+      if (rejectPending) {
         restoreSealView();
         throw createLineageSealRuntimeFailure<T>(
           new ManifestoError(
@@ -637,6 +650,37 @@ function shouldAdvanceLineageHead(
   }
 
   return result.traces.every((trace) => trace.terminatedBy === "complete");
+}
+
+/**
+ * Structural check for failure evidence on a host result: a host-level
+ * error, a system lastError, or a host-owned lastError under
+ * snapshot.namespaces.host. Lineage reads the snapshot as data only; it
+ * does not import Host internals.
+ */
+function hasRecordedFailureEvidence(
+  result: Awaited<ReturnType<LineageControllerKernel<ManifestoDomainShape>["executeHost"]>>,
+): boolean {
+  if (result.error !== undefined && result.error !== null) {
+    return true;
+  }
+
+  if (result.snapshot.system.lastError !== null) {
+    return true;
+  }
+
+  const hostNamespace = (
+    result.snapshot.namespaces as Record<string, unknown> | undefined
+  )?.host;
+  if (
+    hostNamespace !== null
+    && typeof hostNamespace === "object"
+    && (hostNamespace as { readonly lastError?: unknown }).lastError
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 function toError(error: unknown): Error {


### PR DESCRIPTION
## Summary

Closes #477, #478, #479 — the governed settlement-safety cluster, implemented as one coherent change because the three gaps sit on the same seal path (`finalizeApprovedExecution` / `resumeStoredSettlement` in `with-governance.ts`).

### #477 — approved scope enforced before settlement
`approvedScope` was persisted on approval but never compared against what actually settled. Now: changed paths are diffed base-world → terminal snapshot (`governance-scope.ts`: pure path-diff + wildcard matching; `allowedPaths` are state-rooted dot paths, `x.*`/`x` allow subtrees, `*` allows all) and validated before `governanceService.finalize`. Violations throw `GOVERNANCE_SCOPE_VIOLATION`; the existing compensation path fails the proposal and the out-of-scope change never becomes visible state.

### #478 — pending results rejected at the governed seal
Base lineage passed `rejectPendingBeforeSeal: true` but the governed seal passed nothing. A blanket `true` breaks the existing contract that a **failed effect execution seals as a failed world** (host leaves the snapshot pending while recording the failure) — caught by 3 existing tests during development. So `SealIntentOptions` gains an `"unless-failed"` mode: pending results are rejected only when they carry no recorded failure evidence (host error, `system.lastError`, or host-owned `namespaces.host.lastError`, read structurally — no Host import).

### #479 — effect-safe activation recovery
Recovery used to re-run `finalizeApprovedExecution` for proposals stuck in `"executing"` — re-dispatching host effects that may already have run. Recovery now never re-executes: it gathers evidence from lineage seal attempts (`proposalRef` match → sealed world recorded on the failed proposal for explicit reconciliation) and otherwise fails the proposal as unverifiable. `"approved"`-state recovery still executes, which is safe because execution begins only after the `"executing"` transition is durably persisted.

### Tests
New `settlement-safety.test.ts` (4 cases): scope violation fails the proposal & preserves visible state; in-scope and wildcard scopes settle; crash-recovery with shared durable stores proves the effect handler runs exactly once across runtimes. Suites green: governance 11 files, lineage 11, activation-cts 5.

Part of milestone **M1 — Critical Correctness & Contract Fixes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)