### PR TITLE
refactor(compiler): type scope analyzer path validation explicitly

### DIFF
--- a/packages/compiler/src/analyzer/scope.ts
+++ b/packages/compiler/src/analyzer/scope.ts
@@ -14,6 +14,7 @@ import type {
   ExprNode,
   GuardedStmtNode,
   InnerStmtNode,
+  PathNode,
 } from "../parser/ast.js";
 import type { Diagnostic } from "../diagnostics/types.js";
 import type { SourceLocation } from "../lexer/source-location.js";
@@ -229,10 +230,12 @@ export class ScopeAnalyzer {
 
       case "effect":
         for (const arg of stmt.args) {
-          if (arg.isPath) {
-            this.validatePath(arg.value as any);
+          // kind narrows the ExprNode | PathNode union without casts;
+          // isPath only mirrors which one the parser produced.
+          if (arg.value.kind === "path") {
+            this.validatePath(arg.value);
           } else {
-            this.analyzeExpr(arg.value as ExprNode, "action");
+            this.analyzeExpr(arg.value, "action");
           }
         }
         break;
@@ -391,7 +394,7 @@ export class ScopeAnalyzer {
     );
   }
 
-  private validatePath(path: any): void {
+  private validatePath(path: PathNode | null | undefined): void {
     if (!path || !path.segments) return;
 
     // Check first segment is a valid identifier


### PR DESCRIPTION
## Summary

Audit finding C-3: `packages/compiler/src/analyzer/scope.ts` — `validatePath(path: any)` plus an `arg.value as any` cast at the effect-arg call site disabled type checking inside semantic path validation.

- `validatePath` now takes `PathNode | null | undefined`.
- The effect-arg site narrows the `ExprNode | PathNode` union on `kind === "path"` — no casts at all (`isPath` only mirrored which node the parser produced).

Compiler suite green (39 test files).

Part of milestone **M1 — Critical Correctness & Contract Fixes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)