### PR TITLE
build: route workspace tool invocation through root-owned wrappers and gate the example build

### DIFF
--- a/cts/activation-cts/package.json
+++ b/cts/activation-cts/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "rm -rf dist && mkdir -p dist && printf 'activation-cts\\n' > dist/.build-stamp",
     "lint": "echo 'lint not configured'",
-    "test": "node ../../node_modules/vitest/vitest.mjs run --config vitest.config.ts && node ../../node_modules/typescript/bin/tsc -p tsconfig.types.json --noEmit",
-    "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --config vitest.config.ts --coverage && node ../../node_modules/typescript/bin/tsc -p tsconfig.types.json --noEmit"
+    "test": "node ../../scripts/run-vitest.mjs run --config vitest.config.ts && node ../../scripts/run-tsc.mjs -p tsconfig.types.json --noEmit",
+    "test:coverage": "node ../../scripts/run-vitest.mjs run --config vitest.config.ts --coverage && node ../../scripts/run-tsc.mjs -p tsconfig.types.json --noEmit"
   },
   "dependencies": {
     "@manifesto-ai/core": "workspace:*",

--- a/examples/todo-react/package.json
+++ b/examples/todo-react/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node ../../scripts/run-tsc.mjs -p tsconfig.json --noEmit && vite build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "preview": "vite preview"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "build": "turbo run build --filter=@manifesto-ai/core --filter=@manifesto-ai/cts-kit --filter=@manifesto-ai/activation-cts --filter=@manifesto-ai/host --filter=@manifesto-ai/governance --filter=@manifesto-ai/lineage --filter=@manifesto-ai/compiler --filter=@manifesto-ai/sdk --filter=@manifesto-ai/codegen",
+    "build": "turbo run build --filter=@manifesto-ai/example-todo-react --filter=@manifesto-ai/core --filter=@manifesto-ai/cts-kit --filter=@manifesto-ai/activation-cts --filter=@manifesto-ai/host --filter=@manifesto-ai/governance --filter=@manifesto-ai/lineage --filter=@manifesto-ai/compiler --filter=@manifesto-ai/sdk --filter=@manifesto-ai/codegen",
     "dev": "turbo run dev",
     "lint": "turbo run lint --filter=@manifesto-ai/core --filter=@manifesto-ai/cts-kit --filter=@manifesto-ai/activation-cts --filter=@manifesto-ai/host --filter=@manifesto-ai/governance --filter=@manifesto-ai/lineage --filter=@manifesto-ai/compiler --filter=@manifesto-ai/sdk --filter=@manifesto-ai/codegen",
     "test": "turbo run test --filter=@manifesto-ai/core --filter=@manifesto-ai/cts-kit --filter=@manifesto-ai/activation-cts --filter=@manifesto-ai/host --filter=@manifesto-ai/governance --filter=@manifesto-ai/lineage --filter=@manifesto-ai/compiler --filter=@manifesto-ai/sdk --filter=@manifesto-ai/codegen",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -37,9 +37,9 @@
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "lint": "echo 'lint not configured'",
-    "test": "node ../../node_modules/vitest/vitest.mjs run",
-    "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage",
-    "test:watch": "node ../../node_modules/vitest/vitest.mjs"
+    "test": "node ../../scripts/run-vitest.mjs run",
+    "test:coverage": "node ../../scripts/run-vitest.mjs run --coverage",
+    "test:watch": "node ../../scripts/run-vitest.mjs"
   },
   "peerDependencies": {
     "@manifesto-ai/core": "^5.0.0"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -63,9 +63,9 @@
     "build": "rm -rf dist && tsup && tsc -p tsconfig.build.json --emitDeclarationOnly --declarationMap false --outDir dist",
     "clean": "rm -rf dist",
     "lint": "echo 'lint not configured'",
-    "test": "node ../../node_modules/vitest/vitest.mjs run",
-    "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage",
-    "test:watch": "node ../../node_modules/vitest/vitest.mjs",
+    "test": "node ../../scripts/run-vitest.mjs run",
+    "test:coverage": "node ../../scripts/run-vitest.mjs run --coverage",
+    "test:watch": "node ../../scripts/run-vitest.mjs",
     "example": "npx tsx examples/simple-compile.ts",
     "cli": "node ./dist/cli/index.js"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,8 +39,8 @@
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "lint": "echo 'lint not configured'",
-    "test": "node ../../node_modules/vitest/vitest.mjs run",
-    "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage"
+    "test": "node ../../scripts/run-vitest.mjs run",
+    "test:coverage": "node ../../scripts/run-vitest.mjs run --coverage"
   },
   "peerDependencies": {
     "zod": "^4.3.6"

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -38,10 +38,10 @@
     "clean": "rm -rf dist",
     "lint": "echo 'lint not configured'",
     "test": "pnpm run test:runtime && pnpm run test:types",
-    "test:runtime": "node ../../node_modules/vitest/vitest.mjs run",
-    "test:types": "node ../../node_modules/typescript/bin/tsc -p tsconfig.types.json --noEmit",
-    "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage",
-    "test:watch": "node ../../node_modules/vitest/vitest.mjs"
+    "test:runtime": "node ../../scripts/run-vitest.mjs run",
+    "test:types": "node ../../scripts/run-tsc.mjs -p tsconfig.types.json --noEmit",
+    "test:coverage": "node ../../scripts/run-vitest.mjs run --coverage",
+    "test:watch": "node ../../scripts/run-vitest.mjs"
   },
   "peerDependencies": {
     "@manifesto-ai/core": "^5.0.0"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -34,9 +34,9 @@
     "build": "rm -rf dist && tsup && tsc -p tsconfig.build.json --emitDeclarationOnly --declarationMap false --outDir dist",
     "clean": "rm -rf dist",
     "lint": "echo 'lint not configured'",
-    "test": "node ../../node_modules/vitest/vitest.mjs run",
-    "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage",
-    "test:watch": "node ../../node_modules/vitest/vitest.mjs"
+    "test": "node ../../scripts/run-vitest.mjs run",
+    "test:coverage": "node ../../scripts/run-vitest.mjs run --coverage",
+    "test:watch": "node ../../scripts/run-vitest.mjs"
   },
   "peerDependencies": {
     "@manifesto-ai/core": "^5.0.0"

--- a/packages/lineage/package.json
+++ b/packages/lineage/package.json
@@ -38,10 +38,10 @@
     "clean": "rm -rf dist",
     "lint": "echo 'lint not configured'",
     "test": "pnpm run test:runtime && pnpm run test:types",
-    "test:runtime": "node ../../node_modules/vitest/vitest.mjs run",
-    "test:types": "node ../../node_modules/typescript/bin/tsc -p tsconfig.types.json --noEmit",
-    "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage",
-    "test:watch": "node ../../node_modules/vitest/vitest.mjs"
+    "test:runtime": "node ../../scripts/run-vitest.mjs run",
+    "test:types": "node ../../scripts/run-tsc.mjs -p tsconfig.types.json --noEmit",
+    "test:coverage": "node ../../scripts/run-vitest.mjs run --coverage",
+    "test:watch": "node ../../scripts/run-vitest.mjs"
   },
   "peerDependencies": {
     "@manifesto-ai/core": "^5.0.0"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -52,9 +52,9 @@
     "clean": "rm -rf dist",
     "lint": "echo 'lint not configured'",
     "test": "pnpm run test:runtime && pnpm run test:types",
-    "test:runtime": "node ../../node_modules/vitest/vitest.mjs run",
-    "test:types": "node ../../node_modules/typescript/bin/tsc -p tsconfig.types.json --noEmit",
-    "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage"
+    "test:runtime": "node ../../scripts/run-vitest.mjs run",
+    "test:types": "node ../../scripts/run-tsc.mjs -p tsconfig.types.json --noEmit",
+    "test:coverage": "node ../../scripts/run-vitest.mjs run --coverage"
   },
   "dependencies": {
     "@manifesto-ai/compiler": "workspace:*",

--- a/scripts/run-tsc.mjs
+++ b/scripts/run-tsc.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Root-owned tsc invocation (#423).
+ *
+ * Package scripts delegate here instead of resolving the tool through
+ * relative node_modules paths, so the workspace owns exactly one contract
+ * for which TypeScript compiles/typechecks regardless of execution root.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const tsc = path.join(root, "node_modules", "typescript", "bin", "tsc");
+
+const result = spawnSync(
+  process.execPath,
+  [tsc, ...process.argv.slice(2)],
+  { stdio: "inherit" },
+);
+
+process.exit(result.status ?? 1);

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Root-owned vitest invocation (#423).
+ *
+ * Package scripts delegate here instead of resolving the tool through
+ * relative node_modules paths, so the workspace owns exactly one contract
+ * for which toolchain executes tests regardless of execution root.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const vitest = path.join(root, "node_modules", "vitest", "vitest.mjs");
+
+const result = spawnSync(
+  process.execPath,
+  [vitest, ...process.argv.slice(2)],
+  { stdio: "inherit" },
+);
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

Closes #423, and brings `examples/todo-react` under CI (audit finding T-3).

### Root-owned tool wrappers (#423)
- New `scripts/run-vitest.mjs` / `scripts/run-tsc.mjs`: thin spawns of the root toolchain, the one explicit workspace contract the issue asks for.
- All 11 package-script call sites that previously did `node ../../node_modules/{vitest,typescript}/...` now delegate to the wrappers. Package-local `pnpm test`, root `pnpm test`, and `pnpm test:hardening` all verified working.
- Note: the biome lint scripts added in #504 still use the relative-path pattern; normalizing them through a `run-biome.mjs` wrapper is a small follow-up once both PRs land (kept out of here to avoid cross-PR conflicts).

### Example in CI
- `@manifesto-ai/example-todo-react` added to the root build filter — CI's existing `pnpm build` step now builds it.
- The example's build typechecks first (`run-tsc.mjs --noEmit && vite build`), so SDK surface drift that breaks the first code users run fails CI instead of shipping.

### Verification
`pnpm build` 10/10 tasks (example included), `pnpm test` 18/18.

Part of milestone **M2 — Quality Gates & High-Leverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)