### PR TITLE
refactor(sdk,lineage,governance): single-source the blocked-admission mapping

### DIFF
--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -1234,6 +1234,8 @@ _Source: `packages/sdk/src/provider.ts`_
 - `createRuntimeKernel`
 - `getActivationState`
 - `getRuntimeKernelFactory`
+- `mapBlockedAdmission`
+- `toBlocker`
 
 #### Types
 

--- a/packages/governance/src/governance-runtime.ts
+++ b/packages/governance/src/governance-runtime.ts
@@ -46,6 +46,7 @@ import {
 import {
   attachExtensionKernel,
   type GovernanceRuntimeKernel,
+  mapBlockedAdmission,
 } from "@manifesto-ai/sdk/provider";
 import type {
   LineageRuntimeController,
@@ -725,53 +726,6 @@ export function createGovernanceRuntimeInstance<T extends ManifestoDomainShape>(
     }
   }
 
-  function mapBlockedAdmission<Name extends ActionName<T>>(
-    actionName: Name,
-    admission: { readonly failure: { readonly kind: string } },
-    fallbackMessage?: string,
-  ): AdmissionFailure<Name> {
-    if (admission.failure.kind === "invalid_input") {
-      const failure = admission.failure as unknown as {
-        readonly error: { readonly message: string };
-      };
-      return Object.freeze({
-        ok: false,
-        action: actionName,
-        layer: "input",
-        code: "INVALID_INPUT",
-        message: failure.error.message,
-        blockers: Object.freeze([]),
-      }) as AdmissionFailure<Name>;
-    }
-
-    if (admission.failure.kind === "not_dispatchable") {
-      const failure = admission.failure as unknown as {
-        readonly blockers: readonly DispatchBlocker[];
-      };
-      return Object.freeze({
-        ok: false,
-        action: actionName,
-        layer: "dispatchability",
-        code: "INTENT_NOT_DISPATCHABLE",
-        message: fallbackMessage
-          ?? `Action "${actionName}" is not dispatchable against the current visible snapshot`,
-        blockers: failure.blockers.map((blocker) => toBlocker(blocker, "INTENT_NOT_DISPATCHABLE")),
-      }) as AdmissionFailure<Name>;
-    }
-
-    const failure = admission.failure as unknown as {
-      readonly blockers?: readonly DispatchBlocker[];
-    };
-    return Object.freeze({
-      ok: false,
-      action: actionName,
-      layer: "availability",
-      code: "ACTION_UNAVAILABLE",
-      message: fallbackMessage
-        ?? `Action "${actionName}" is unavailable against the current visible snapshot`,
-      blockers: (failure.blockers ?? []).map((blocker) => toBlocker(blocker, "ACTION_UNAVAILABLE")),
-    }) as AdmissionFailure<Name>;
-  }
 
   function getAvailabilityBlockers<Name extends ActionName<T>>(
     candidate: Candidate<T, Name>,
@@ -983,17 +937,6 @@ function fieldTypeToString(type: unknown): string {
   return "unknown";
 }
 
-function toBlocker(blocker: DispatchBlocker, code: Blocker["code"]): Blocker {
-  return Object.freeze({
-    path: Object.freeze([]),
-    code,
-    message: blocker.description ?? code,
-    detail: Object.freeze({
-      layer: blocker.layer,
-      expression: blocker.expression,
-    }),
-  });
-}
 
 function toErrorValue<T extends ManifestoDomainShape>(
   error: Error,

--- a/packages/lineage/src/lineage-runtime.ts
+++ b/packages/lineage/src/lineage-runtime.ts
@@ -49,6 +49,7 @@ import {
 import {
   attachExtensionKernel,
   type LineageRuntimeKernel,
+  mapBlockedAdmission,
 } from "@manifesto-ai/sdk/provider";
 
 import {
@@ -601,53 +602,6 @@ export function createLineageRuntimeInstance<T extends ManifestoDomainShape>(
     };
   }
 
-  function mapBlockedAdmission<Name extends ActionName<T>>(
-    actionName: Name,
-    admission: { readonly failure: { readonly kind: string } },
-    fallbackMessage?: string,
-  ): AdmissionFailure<Name> {
-    if (admission.failure.kind === "invalid_input") {
-      const failure = admission.failure as unknown as {
-        readonly error: { readonly message: string };
-      };
-      return Object.freeze({
-        ok: false,
-        action: actionName,
-        layer: "input",
-        code: "INVALID_INPUT",
-        message: failure.error.message,
-        blockers: Object.freeze([]),
-      }) as AdmissionFailure<Name>;
-    }
-
-    if (admission.failure.kind === "not_dispatchable") {
-      const failure = admission.failure as unknown as {
-        readonly blockers: readonly DispatchBlocker[];
-      };
-      return Object.freeze({
-        ok: false,
-        action: actionName,
-        layer: "dispatchability",
-        code: "INTENT_NOT_DISPATCHABLE",
-        message: fallbackMessage
-          ?? `Action "${actionName}" is not dispatchable against the current visible snapshot`,
-        blockers: failure.blockers.map((blocker) => toBlocker(blocker, "INTENT_NOT_DISPATCHABLE")),
-      }) as AdmissionFailure<Name>;
-    }
-
-    const failure = admission.failure as unknown as {
-      readonly blockers?: readonly DispatchBlocker[];
-    };
-    return Object.freeze({
-      ok: false,
-      action: actionName,
-      layer: "availability",
-      code: "ACTION_UNAVAILABLE",
-      message: fallbackMessage
-        ?? `Action "${actionName}" is unavailable against the current visible snapshot`,
-      blockers: (failure.blockers ?? []).map((blocker) => toBlocker(blocker, "ACTION_UNAVAILABLE")),
-    }) as AdmissionFailure<Name>;
-  }
 
   function getAvailabilityBlockers<Name extends ActionName<T>>(
     candidate: Candidate<T, Name>,
@@ -817,17 +771,6 @@ function fieldTypeToString(type: unknown): string {
   return "unknown";
 }
 
-function toBlocker(blocker: DispatchBlocker, code: Blocker["code"]): Blocker {
-  return Object.freeze({
-    path: Object.freeze([]),
-    code,
-    message: blocker.description ?? code,
-    detail: Object.freeze({
-      layer: blocker.layer,
-      expression: blocker.expression,
-    }),
-  });
-}
 
 function createLineageReport(
   reportMode: SubmitReportMode | undefined,

--- a/packages/sdk/src/compat/internal.ts
+++ b/packages/sdk/src/compat/internal.ts
@@ -470,3 +470,5 @@ function getExistingActivationState<
 }
 
 export { createRuntimeKernel } from "../runtime/kernel.js";
+
+export { mapBlockedAdmission, toBlocker } from "../runtime/admission-failure.js";

--- a/packages/sdk/src/provider.ts
+++ b/packages/sdk/src/provider.ts
@@ -25,3 +25,6 @@ export {
   getRuntimeKernelFactory,
 } from "./compat/internal.js";
 export { createBaseRuntimeInstance } from "./runtime/base-runtime.js";
+// Shared admission-failure mapping for decorator runtimes (single source
+// for the blocked-admission -> AdmissionFailure narrowing).
+export { mapBlockedAdmission, toBlocker } from "./runtime/admission-failure.js";

--- a/packages/sdk/src/runtime/admission-failure.ts
+++ b/packages/sdk/src/runtime/admission-failure.ts
@@ -1,0 +1,78 @@
+import type {
+  AdmissionFailure,
+  Blocker,
+  DispatchBlocker,
+} from "../types.js";
+
+/**
+ * Shared admission-failure mapping for runtime surfaces.
+ *
+ * The base, lineage, and governance runtimes expose the same
+ * action-candidate admission contract; this module is the single source
+ * for narrowing a blocked kernel admission into the public
+ * AdmissionFailure shape (previously triplicated across the three
+ * runtime files).
+ */
+
+export function toBlocker(
+  blocker: DispatchBlocker,
+  code: Blocker["code"],
+): Blocker {
+  return Object.freeze({
+    path: Object.freeze([]),
+    code,
+    message: blocker.description ?? code,
+    detail: Object.freeze({
+      layer: blocker.layer,
+      expression: blocker.expression,
+    }),
+  });
+}
+
+export function mapBlockedAdmission<Name extends string>(
+  actionName: Name,
+  admission: { readonly failure: { readonly kind: string } },
+  fallbackMessage?: string,
+): AdmissionFailure<Name> {
+  if (admission.failure.kind === "invalid_input") {
+    const failure = admission.failure as unknown as {
+      readonly error: { readonly message: string };
+    };
+    return Object.freeze({
+      ok: false,
+      action: actionName,
+      layer: "input",
+      code: "INVALID_INPUT",
+      message: failure.error.message,
+      blockers: Object.freeze([]),
+    }) as AdmissionFailure<Name>;
+  }
+
+  if (admission.failure.kind === "not_dispatchable") {
+    const failure = admission.failure as unknown as {
+      readonly blockers: readonly DispatchBlocker[];
+    };
+    return Object.freeze({
+      ok: false,
+      action: actionName,
+      layer: "dispatchability",
+      code: "INTENT_NOT_DISPATCHABLE",
+      message: fallbackMessage
+        ?? `Action "${actionName}" is not dispatchable against the current visible snapshot`,
+      blockers: failure.blockers.map((blocker) => toBlocker(blocker, "INTENT_NOT_DISPATCHABLE")),
+    }) as AdmissionFailure<Name>;
+  }
+
+  const failure = admission.failure as unknown as {
+    readonly blockers?: readonly DispatchBlocker[];
+  };
+  return Object.freeze({
+    ok: false,
+    action: actionName,
+    layer: "availability",
+    code: "ACTION_UNAVAILABLE",
+    message: fallbackMessage
+      ?? `Action "${actionName}" is unavailable against the current visible snapshot`,
+    blockers: (failure.blockers ?? []).map((blocker) => toBlocker(blocker, "ACTION_UNAVAILABLE")),
+  }) as AdmissionFailure<Name>;
+}

--- a/packages/sdk/src/runtime/base-runtime.ts
+++ b/packages/sdk/src/runtime/base-runtime.ts
@@ -54,6 +54,7 @@ import {
 import {
   runBaseDispatchAttempt,
 } from "./base-dispatch.js";
+import { mapBlockedAdmission } from "./admission-failure.js";
 import {
   cloneAndFreezeActionPayload,
   tryCloneAndFreezeActionPayload,
@@ -608,53 +609,6 @@ export function createBaseRuntimeInstance<T extends ManifestoDomainShape>(
     };
   }
 
-  function mapBlockedAdmission<Name extends ActionName<T>>(
-    actionName: Name,
-    admission: { readonly failure: { readonly kind: string } },
-    fallbackMessage?: string,
-  ): AdmissionFailure<Name> {
-    if (admission.failure.kind === "invalid_input") {
-      const failure = admission.failure as unknown as {
-        readonly error: { readonly message: string };
-      };
-      return Object.freeze({
-        ok: false,
-        action: actionName,
-        layer: "input",
-        code: "INVALID_INPUT",
-        message: failure.error.message,
-        blockers: Object.freeze([]),
-      }) as AdmissionFailure<Name>;
-    }
-
-    if (admission.failure.kind === "not_dispatchable") {
-      const failure = admission.failure as unknown as {
-        readonly blockers: readonly DispatchBlocker[];
-      };
-      return Object.freeze({
-        ok: false,
-        action: actionName,
-        layer: "dispatchability",
-        code: "INTENT_NOT_DISPATCHABLE",
-        message: fallbackMessage
-          ?? `Action "${actionName}" is not dispatchable against the current visible snapshot`,
-        blockers: failure.blockers.map((blocker) => toBlocker(blocker, "INTENT_NOT_DISPATCHABLE")),
-      }) as AdmissionFailure<Name>;
-    }
-
-    const failure = admission.failure as unknown as {
-      readonly blockers?: readonly DispatchBlocker[];
-    };
-    return Object.freeze({
-      ok: false,
-      action: actionName,
-      layer: "availability",
-      code: "ACTION_UNAVAILABLE",
-      message: fallbackMessage
-        ?? `Action "${actionName}" is unavailable against the current visible snapshot`,
-      blockers: (failure.blockers ?? []).map((blocker) => toBlocker(blocker, "ACTION_UNAVAILABLE")),
-    }) as AdmissionFailure<Name>;
-  }
 
   function getAvailabilityBlockers<Name extends ActionName<T>>(
     candidate: Candidate<T, Name>,
@@ -852,17 +806,6 @@ function fieldTypeToString(type: unknown): string {
   return "unknown";
 }
 
-function toBlocker(blocker: DispatchBlocker, code: Blocker["code"]): Blocker {
-  return Object.freeze({
-    path: Object.freeze([]),
-    code,
-    message: blocker.description ?? code,
-    detail: Object.freeze({
-      layer: blocker.layer,
-      expression: blocker.expression,
-    }),
-  });
-}
 
 function toExecutionOutcome<T extends ManifestoDomainShape>(
   dispatchOutcome: DispatchExecutionOutcome<T>,


### PR DESCRIPTION
## Summary

Audit finding C-2: `mapBlockedAdmission` (+ its `toBlocker` helper) was byte-identical across `sdk/runtime/base-runtime.ts`, `lineage/lineage-runtime.ts`, and `governance/governance-runtime.ts` (verified by diff before extraction) — ~50 duplicated lines and 9 `as unknown as` casts total, where a fix in one copy would not propagate.

### Change
- New `packages/sdk/src/runtime/admission-failure.ts` owns the narrowing (generic over `Name extends string`; the `T` domain param was only used through `ActionName<T>` and was not inferable, so the shared signature drops it).
- Exported through `@manifesto-ai/sdk/provider` (and the compat seam) for decorator runtimes; lineage and governance import it from there — consistent with the boundary matrix (decorators consume sdk public seams).
- The three local copies are deleted; call sites unchanged.

### Verification
Builds green (sdk/lineage/governance); suites green: sdk 7 files, lineage 11, governance 10, activation-cts 5.

Note: will need a trivial rebase against #499 (which touches `base-runtime.ts` imports) — whichever lands second.

Part of milestone **M2 — Quality Gates & High-Leverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)