### PR TITLE
refactor(host,sdk): isolate host-owned state accessors behind a tooling seam

### DIFF
--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -982,6 +982,21 @@ _Source: `packages/host/src/index.ts`_
 - `TraceEvent`
 - `TraceGraph`
 
+### @manifesto-ai/host/tooling
+
+_Source: `packages/host/src/tooling.ts`_
+
+#### Values
+
+- `getHostState`
+- `getIntentSlot`
+- `getLegacyDataRootHostState`
+
+#### Types
+
+- `HostOwnedState`
+- `IntentSlot`
+
 ## @manifesto-ai/lineage
 
 ### @manifesto-ai/lineage

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -28,6 +28,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./tooling": {
+      "types": "./dist/tooling.d.ts",
+      "import": "./dist/tooling.js"
     }
   },
   "scripts": {

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -47,8 +47,12 @@ export {
 export type { TraceEvent } from "./types/trace.js";
 
 // Host-owned state namespace (v2.0.2)
-export type { HostOwnedState, IntentSlot } from "./types/host-state.js";
-export { getHostState, getIntentSlot, getLegacyDataRootHostState } from "./types/host-state.js";
+// Deprecated on the main entry: these expose Host's internal execution
+// bookkeeping and belong to the explicit tooling seam. Import from
+// "@manifesto-ai/host/tooling" instead; the main-entry re-exports will be
+// removed in the next major release.
+export type { HostOwnedState, IntentSlot } from "./tooling.js";
+export { getHostState, getIntentSlot, getLegacyDataRootHostState } from "./tooling.js";
 
 // Mailbox
 export {

--- a/packages/host/src/tooling.ts
+++ b/packages/host/src/tooling.ts
@@ -1,0 +1,19 @@
+/**
+ * Tooling seam for Host-owned execution state.
+ *
+ * These accessors read the Host-owned namespace (`snapshot.namespaces.host`)
+ * — internal execution representation, not application state. They exist for
+ * runtime tooling (SDK simulation, inspectors, studio) that must observe
+ * Host execution bookkeeping. Application code should never need them; the
+ * projected snapshot is the app-facing read model.
+ *
+ * Keeping them on an explicit subpath makes the coupling legible: consumers
+ * of this seam accept that the Host-owned state layout may change with Host
+ * minor releases.
+ */
+export type { HostOwnedState, IntentSlot } from "./types/host-state.js";
+export {
+  getHostState,
+  getIntentSlot,
+  getLegacyDataRootHostState,
+} from "./types/host-state.js";

--- a/packages/host/tsup.config.ts
+++ b/packages/host/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsup";
 const release = process.env.MANIFESTO_RELEASE === "1";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/tooling.ts"],
   format: "esm",
   tsconfig: "tsconfig.build.json",
   dts: false,

--- a/packages/sdk/src/runtime/simulation.ts
+++ b/packages/sdk/src/runtime/simulation.ts
@@ -9,10 +9,15 @@ import {
   type TraceGraph,
 } from "@manifesto-ai/core";
 import {
-  getHostState,
   type HostContextProvider,
-  type IntentSlot,
 } from "@manifesto-ai/host";
+// Host-owned execution state is read through the explicit tooling seam:
+// simulation must observe Host bookkeeping, and the subpath makes that
+// coupling legible instead of widening the main host surface.
+import {
+  getHostState,
+  type IntentSlot,
+} from "@manifesto-ai/host/tooling";
 
 import {
   ManifestoError,


### PR DESCRIPTION
## Summary

Audit finding A-2 (and #467-adjacent): `getHostState`/`getIntentSlot`/`IntentSlot` read Host's internal execution bookkeeping (`snapshot.namespaces.host`) but were exported from the main entry, making the SDK simulation's coupling to Host's slot layout look like ordinary public-API use — a semver trap when Host changes its internal representation.

### Change
- New `@manifesto-ai/host/tooling` subpath (package.json exports + tsup entry) owns the accessors, with docs stating the contract: tooling consumers accept that Host-owned state layout may change with Host minors.
- Main-entry re-exports remain for compat, marked deprecated for v6 removal.
- `packages/sdk/src/runtime/simulation.ts` (the only internal consumer, verified by grep) imports through the seam.

### Verification
host build + 22 test files green, sdk build + 7 test files green; `dist/tooling.js` verified to expose the three accessors.

Part of milestone **M3 — Polish & Structural Cleanup**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)