### PR TITLE
fix(codegen): sanitize emitted identifiers and preserve context typing

### DIFF
--- a/docs/api/public-surface.md
+++ b/docs/api/public-surface.md
@@ -17,9 +17,16 @@ _Source: `packages/codegen/src/index.ts`_
 - `createCompilerCodegen`
 - `createDomainPlugin`
 - `createTsPlugin`
+- `createTypeNameAliasMap`
 - `createZodPlugin`
 - `generate`
 - `generateHeader`
+- `isBindingIdentifier`
+- `isIdentifierName`
+- `isTypeDeclarationName`
+- `renderPropertyKey`
+- `sanitizeIdentifier`
+- `sanitizeParameterNames`
 - `stableHash`
 - `validatePath`
 
@@ -38,6 +45,7 @@ _Source: `packages/codegen/src/index.ts`_
 - `GenerateOptions`
 - `GenerateResult`
 - `HeaderOptions`
+- `IdentifierAliasMap`
 - `PathValidationResult`
 - `TsPluginArtifacts`
 - `TsPluginOptions`

--- a/packages/codegen/src/__tests__/domain-plugin.test.ts
+++ b/packages/codegen/src/__tests__/domain-plugin.test.ts
@@ -600,6 +600,130 @@ describe("createDomainPlugin", () => {
     });
   }, 60_000);
 
+  it("emits a typed context block when the schema declares a context contract", () => {
+    const plugin = createDomainPlugin();
+    const out = plugin.generate(
+      makeCtx({
+        meta: { name: "CtxDomain" },
+        types: {
+          Settings: {
+            name: "Settings",
+            definition: {
+              kind: "object",
+              fields: {
+                darkMode: { type: { kind: "primitive", type: "boolean" }, optional: false },
+                scale: { type: { kind: "primitive", type: "number" }, optional: true },
+              },
+            },
+          },
+        },
+        context: {
+          fields: {
+            locale: { type: "string", required: true },
+            maxItems: { type: "number", required: true },
+            theme: { type: "string", required: false },
+            settings: { type: "object", required: true, fields: {} },
+          },
+          fieldTypes: {
+            locale: { kind: "primitive", type: "string" },
+            maxItems: { kind: "primitive", type: "number" },
+            settings: { kind: "ref", name: "Settings" },
+          },
+        },
+        actions: {
+          refresh: { flow: { kind: "seq", steps: [] } },
+        },
+      })
+    );
+
+    const content = out.patches[0].content;
+    expect(out.diagnostics).toEqual([]);
+    expect(content).toContain("  readonly context: {");
+    expect(content).toContain("    locale: string");
+    expect(content).toContain("    maxItems: number");
+    // Optional context fields are encoded as `T | null`, never `?`, because
+    // the SDK external-context contract has no `undefined` members.
+    expect(content).toContain("    theme: string | null");
+    expect(content).not.toContain("theme?");
+    // Named refs are inlined structurally so the context block stays
+    // assignable to the external-context record contract; optional fields of
+    // the referenced type are normalized to `| null`.
+    expect(content).toContain("    settings: { darkMode: boolean; scale: number | null }");
+    expect(content).toContain('export type CtxExternalContext = CtxDomain["context"];');
+
+    assertTypechecks({
+      "ctx.domain.ts": content,
+      "consumer.ts": `
+        import type { CtxApp, CtxDomain, CtxExternalContext } from "./ctx.domain.js";
+
+        declare const app: CtxApp<"base">;
+        const context: CtxExternalContext = app.context();
+        const locale: string = context.locale;
+        const theme: string | null = context.theme;
+        app.injectContext({
+          locale: "ko",
+          maxItems: 3,
+          theme: null,
+          settings: { darkMode: true, scale: null },
+        });
+        app.updateContext((current) => ({ ...current, maxItems: 5 }));
+        app.injectContext({
+          // @ts-expect-error number is not assignable to the declared locale type
+          locale: 42,
+          maxItems: 3,
+          theme: null,
+          settings: { darkMode: true, scale: null },
+        });
+
+        type Domain = CtxDomain;
+        declare const shape: Domain["context"];
+        // @ts-expect-error context fields are statically typed, not widened
+        const widened: boolean = shape.locale;
+
+        void locale;
+        void theme;
+        void widened;
+      `,
+    });
+  }, 60_000);
+
+  it("degrades non-JSON-safe context fields to JsonValue with a warning", () => {
+    const plugin = createDomainPlugin();
+    const out = plugin.generate(
+      makeCtx({
+        meta: { name: "DegradedDomain" },
+        context: {
+          fields: {
+            payload: { type: "object", required: true, fields: {} },
+            count: { type: "number", required: true },
+          },
+          fieldTypes: {
+            payload: { kind: "primitive", type: "integer" },
+            count: { kind: "primitive", type: "number" },
+          },
+        },
+      })
+    );
+
+    const content = out.patches[0].content;
+    expect(content).toContain("  JsonValue,");
+    expect(content).toContain("    payload: JsonValue");
+    expect(content).toContain("    count: number");
+    expect(out.diagnostics).toContainEqual(expect.objectContaining({
+      level: "warn",
+      message: expect.stringContaining('Context field "payload"'),
+    }));
+  });
+
+  it("does not emit a context block or context alias without a schema context contract", () => {
+    const plugin = createDomainPlugin();
+    const out = plugin.generate(makeCtx({ meta: { name: "PlainDomain" } }));
+
+    expect(out.patches[0].content).not.toContain("readonly context:");
+    expect(out.patches[0].content).not.toContain("ExternalContext");
+    expect(out.patches[0].content).not.toContain("JsonValue");
+  });
+
   it("emits named schema types referenced by state fieldTypes into a self-contained facade", () => {
     const plugin = createDomainPlugin();
     const out = plugin.generate(
@@ -753,6 +877,128 @@ describe("createDomainPlugin", () => {
     expect(out.patches[0].content).toContain("firstItemCount: number");
     expect(out.patches[0].content).toContain("itemIds: string[]");
     expect(out.patches[0].content).toContain("foundItem: { count: number; id: string } | null");
+  });
+
+  it("emits valid TypeScript for schema keys that are not valid identifiers", () => {
+    const plugin = createDomainPlugin();
+    const out = plugin.generate(
+      makeCtx({
+        meta: { name: "KeyDomain" },
+        types: {
+          "My-Type": {
+            name: "My-Type",
+            definition: {
+              kind: "object",
+              fields: {
+                "nested-key": { type: { kind: "primitive", type: "string" }, optional: false },
+              },
+            },
+          },
+          My_Type: {
+            name: "My_Type",
+            definition: { kind: "primitive", type: "number" },
+          },
+        },
+        state: {
+          fields: {
+            "my-field": { type: "string", required: true, default: "" },
+            "2nd": { type: "number", required: true, default: 0 },
+            "has space": { type: "boolean", required: true, default: false },
+            class: { type: "string", required: true, default: "" },
+            linked: { type: "object", required: true, fields: {} },
+          },
+          fieldTypes: {
+            linked: { kind: "ref", name: "My-Type" },
+          },
+        },
+        computed: {
+          fields: {
+            "derived-flag": {
+              deps: ["2nd"],
+              expr: {
+                kind: "gt",
+                left: { kind: "get", path: "2nd" },
+                right: { kind: "lit", value: 0 },
+              },
+            },
+          },
+        },
+        actions: {
+          "do-thing": {
+            flow: { kind: "seq", steps: [] },
+            params: ["new-value"],
+            inputType: {
+              kind: "object",
+              fields: {
+                "new-value": { type: { kind: "primitive", type: "string" }, optional: false },
+              },
+            },
+          },
+        },
+      })
+    );
+
+    const content = out.patches[0].content;
+    expect(content).toContain('    "my-field": string');
+    expect(content).toContain('    "2nd": number');
+    expect(content).toContain('    "has space": boolean');
+    expect(content).toContain("    class: string");
+    expect(content).toContain('    "derived-flag": boolean');
+    expect(content).toContain('    "do-thing": (new_value: string) => void');
+    expect(content).toContain("export interface My_Type_2 {");
+    expect(content).toContain('  "nested-key": string;');
+    expect(content).toContain("export type My_Type = number;");
+    expect(content).toContain("linked: My_Type_2");
+    expect(content).not.toContain("My-Type");
+    expect(out.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        level: "warn",
+        message: expect.stringContaining('"My-Type"'),
+      }),
+      expect.objectContaining({
+        level: "warn",
+        message: expect.stringContaining('parameter "new-value"'),
+      }),
+    ]));
+
+    assertTypechecks({
+      "keys.domain.ts": content,
+      "consumer.ts": `
+        import type { KeyApp, KeyDomain, My_Type_2 } from "./keys.domain.js";
+
+        declare const state: KeyDomain["state"];
+        const myField: string = state["my-field"];
+        const second: number = state["2nd"];
+        const spaced: boolean = state["has space"];
+        const klass: string = state.class;
+        const linked: My_Type_2 = state.linked;
+        const nested: string = linked["nested-key"];
+
+        type ActionNames = keyof KeyDomain["actions"] & string;
+        const actionName: ActionNames = "do-thing";
+
+        declare const app: KeyApp<"base">;
+        app.action["do-thing"].submit("next");
+
+        void myField;
+        void second;
+        void spaced;
+        void klass;
+        void nested;
+        void actionName;
+      `,
+    });
+  }, 60_000);
+
+  it("sanitizes a derived interface name that is not a valid TypeScript identifier", () => {
+    const plugin = createDomainPlugin();
+    const out = plugin.generate(makeCtx({ meta: { name: "Hello Domain" } }));
+
+    expect(out.patches[0].content).toContain("export interface Hello_Domain {");
+    expect(out.diagnostics).toContainEqual(expect.objectContaining({
+      level: "warn",
+      message: expect.stringContaining('"Hello Domain"'),
+    }));
   });
 
   it("falls back to unknown with a warning for unsupported expressions", () => {

--- a/packages/codegen/src/__tests__/identifier-safety.test.ts
+++ b/packages/codegen/src/__tests__/identifier-safety.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  createTypeNameAliasMap,
+  isBindingIdentifier,
+  isIdentifierName,
+  isTypeDeclarationName,
+  renderPropertyKey,
+  sanitizeIdentifier,
+  sanitizeParameterNames,
+} from "../identifier-safety.js";
+
+describe("identifier-safety", () => {
+  describe("isIdentifierName", () => {
+    it("accepts plain, dollar, underscore, and Unicode identifiers", () => {
+      expect(isIdentifierName("count")).toBe(true);
+      expect(isIdentifierName("$mel")).toBe(true);
+      expect(isIdentifierName("_private")).toBe(true);
+      expect(isIdentifierName("café")).toBe(true);
+      expect(isIdentifierName("名前")).toBe(true);
+    });
+
+    it("accepts reserved words (valid in property-key position)", () => {
+      expect(isIdentifierName("class")).toBe(true);
+      expect(isIdentifierName("while")).toBe(true);
+    });
+
+    it("rejects hyphens, spaces, dots, leading digits, and empty keys", () => {
+      expect(isIdentifierName("my-key")).toBe(false);
+      expect(isIdentifierName("has space")).toBe(false);
+      expect(isIdentifierName("a.b")).toBe(false);
+      expect(isIdentifierName("2nd")).toBe(false);
+      expect(isIdentifierName("")).toBe(false);
+    });
+  });
+
+  describe("isBindingIdentifier / isTypeDeclarationName", () => {
+    it("rejects reserved words in binding position", () => {
+      expect(isBindingIdentifier("class")).toBe(false);
+      expect(isBindingIdentifier("await")).toBe(false);
+      expect(isBindingIdentifier("name")).toBe(true);
+    });
+
+    it("rejects predefined type names in type declaration position", () => {
+      expect(isTypeDeclarationName("string")).toBe(false);
+      expect(isTypeDeclarationName("unknown")).toBe(false);
+      expect(isTypeDeclarationName("Todo")).toBe(true);
+    });
+  });
+
+  describe("renderPropertyKey", () => {
+    it("keeps valid identifier names unquoted", () => {
+      expect(renderPropertyKey("count")).toBe("count");
+      expect(renderPropertyKey("while")).toBe("while");
+      expect(renderPropertyKey("名前")).toBe("名前");
+    });
+
+    it("quotes keys that are not valid identifier names", () => {
+      expect(renderPropertyKey("my-key")).toBe('"my-key"');
+      expect(renderPropertyKey("has space")).toBe('"has space"');
+      expect(renderPropertyKey("2nd")).toBe('"2nd"');
+      expect(renderPropertyKey("")).toBe('""');
+    });
+  });
+
+  describe("sanitizeIdentifier", () => {
+    it("replaces invalid characters and prefixes invalid starts", () => {
+      expect(sanitizeIdentifier("my-key")).toBe("my_key");
+      expect(sanitizeIdentifier("has space")).toBe("has_space");
+      expect(sanitizeIdentifier("2nd")).toBe("_2nd");
+      expect(sanitizeIdentifier("")).toBe("_");
+    });
+
+    it("prefixes reserved words", () => {
+      expect(sanitizeIdentifier("class")).toBe("_class");
+    });
+
+    it("is deterministic", () => {
+      expect(sanitizeIdentifier("a-b c")).toBe(sanitizeIdentifier("a-b c"));
+    });
+  });
+
+  describe("createTypeNameAliasMap", () => {
+    it("maps valid names to themselves", () => {
+      const aliases = createTypeNameAliasMap(["Todo", "User"]);
+      expect(aliases.get("Todo")).toBe("Todo");
+      expect(aliases.get("User")).toBe("User");
+    });
+
+    it("sanitizes invalid names without colliding with valid names", () => {
+      const aliases = createTypeNameAliasMap(["My-Type", "My_Type"]);
+      expect(aliases.get("My_Type")).toBe("My_Type");
+      expect(aliases.get("My-Type")).toBe("My_Type_2");
+    });
+
+    it("resolves collisions between sanitized aliases deterministically", () => {
+      const aliases = createTypeNameAliasMap(["a-b", "a b", "a.b"]);
+      expect(new Set(aliases.values()).size).toBe(3);
+      const again = createTypeNameAliasMap(["a.b", "a-b", "a b"]);
+      expect(again).toEqual(aliases);
+    });
+
+    it("avoids reserved names", () => {
+      const aliases = createTypeNameAliasMap(["My-Type"], ["My_Type"]);
+      expect(aliases.get("My-Type")).toBe("My_Type_2");
+    });
+  });
+
+  describe("sanitizeParameterNames", () => {
+    it("keeps valid names and sanitizes invalid ones", () => {
+      expect(sanitizeParameterNames(["title", "new-value"])).toEqual([
+        "title",
+        "new_value",
+      ]);
+    });
+
+    it("avoids collisions with valid names regardless of order", () => {
+      expect(sanitizeParameterNames(["a-b", "a_b"])).toEqual(["a_b_2", "a_b"]);
+    });
+
+    it("sanitizes reserved words", () => {
+      expect(sanitizeParameterNames(["class"])).toEqual(["_class"]);
+    });
+  });
+});

--- a/packages/codegen/src/__tests__/ts-plugin.test.ts
+++ b/packages/codegen/src/__tests__/ts-plugin.test.ts
@@ -145,4 +145,81 @@ describe("createTsPlugin", () => {
       expect(artifacts.typeImportPath).toBe("./types");
     });
   });
+
+  describe("identifier safety", () => {
+    it("sanitizes type names that are not valid TypeScript identifiers", () => {
+      const ctx = makeCtx({
+        "My-Type": createTypeSpec(
+          "My-Type",
+          objectType({ id: { type: primitiveType("string"), optional: false } })
+        ),
+        My_Type: createTypeSpec("My_Type", primitiveType("number")),
+        Holder: createTypeSpec(
+          "Holder",
+          objectType({ linked: { type: refType("My-Type"), optional: false } })
+        ),
+      });
+      const out = plugin.generate(ctx);
+      const content = out.patches[0].content;
+
+      expect(content).toContain("export interface My_Type_2 {");
+      expect(content).toContain("export type My_Type = number;");
+      expect(content).toContain("linked: My_Type_2;");
+      expect(content).not.toContain("My-Type");
+      const artifacts = out.artifacts as Record<string, unknown>;
+      expect(artifacts.typeNames).toEqual(["Holder", "My_Type_2", "My_Type"]);
+      expect(out.diagnostics).toContainEqual(expect.objectContaining({
+        level: "warn",
+        message: expect.stringContaining('"My-Type"'),
+      }));
+    });
+
+    it("quotes object field keys that are not valid identifier names", () => {
+      const ctx = makeCtx({
+        Foo: createTypeSpec(
+          "Foo",
+          objectType({
+            "my-key": { type: primitiveType("string"), optional: false },
+            "2nd": { type: primitiveType("number"), optional: true },
+          })
+        ),
+      });
+      const out = plugin.generate(ctx);
+      const content = out.patches[0].content;
+      expect(content).toContain('  "my-key": string;');
+      expect(content).toContain('  "2nd"?: number;');
+    });
+
+    it("sanitizes action input type names derived from invalid action names", () => {
+      const ctx: CodegenContext = {
+        schema: createTestSchema({
+          actions: {
+            "2nd-step": {
+              flow: { kind: "seq", steps: [] },
+              input: {
+                type: "object",
+                required: true,
+                fields: {
+                  "step name": { type: "string", required: true },
+                },
+              },
+            },
+          },
+        }),
+        outDir: "/tmp/out",
+        artifacts: {},
+        helpers: { stableHash },
+      };
+      const out = plugin.generate(ctx);
+      const actionsPatch = out.patches.find((p) => p.path === "actions.ts");
+      expect(actionsPatch).toBeDefined();
+      const content = (actionsPatch as { content: string }).content;
+      expect(content).toContain("export type _2ndStepInput = ");
+      expect(content).toContain('"step name": string');
+      expect(out.diagnostics).toContainEqual(expect.objectContaining({
+        level: "warn",
+        message: expect.stringContaining('"2ndStepInput"'),
+      }));
+    });
+  });
 });

--- a/packages/codegen/src/__tests__/zod-plugin.test.ts
+++ b/packages/codegen/src/__tests__/zod-plugin.test.ts
@@ -158,6 +158,57 @@ describe("createZodPlugin", () => {
       expect(getContent(out)).toContain('import { z } from "zod"');
     });
   });
+
+  describe("identifier safety", () => {
+    it("sanitizes schema constant names for invalid type names and keeps refs consistent", () => {
+      const tsArtifacts: TsPluginArtifacts = {
+        typeNames: ["Holder", "My_Type_2", "My_Type"],
+        typeImportPath: "./types",
+      };
+      const ctx = makeCtx(
+        {
+          "My-Type": createTypeSpec(
+            "My-Type",
+            objectType({ id: { type: primitiveType("string"), optional: false } })
+          ),
+          My_Type: createTypeSpec("My_Type", primitiveType("number")),
+          Holder: createTypeSpec(
+            "Holder",
+            objectType({ linked: { type: refType("My-Type"), optional: false } })
+          ),
+        },
+        tsArtifacts
+      );
+      const out = plugin.generate(ctx);
+      const content = getContent(out);
+
+      expect(content).toContain("export const My_Type_2Schema: z.ZodType<My_Type_2> = ");
+      expect(content).toContain("export const My_TypeSchema: z.ZodType<My_Type> = ");
+      expect(content).toContain("z.lazy(() => My_Type_2Schema)");
+      expect(content).toContain('import type { Holder, My_Type_2, My_Type } from "./types"');
+      expect(content).not.toContain("My-Type");
+      expect(out.diagnostics).toContainEqual(expect.objectContaining({
+        level: "warn",
+        message: expect.stringContaining('"My-Type"'),
+      }));
+    });
+
+    it("quotes z.object keys that are not valid identifier names", () => {
+      const ctx = makeCtx({
+        Foo: createTypeSpec(
+          "Foo",
+          objectType({
+            "my-key": { type: primitiveType("string"), optional: false },
+            valid: { type: primitiveType("number"), optional: false },
+          })
+        ),
+      });
+      const out = plugin.generate(ctx);
+      const content = getContent(out);
+      expect(content).toContain('  "my-key": z.string(),');
+      expect(content).toContain("  valid: z.number(),");
+    });
+  });
 });
 
 function getContent(out: { patches: readonly { op: string; path: string; content?: string }[] }): string {

--- a/packages/codegen/src/identifier-safety.ts
+++ b/packages/codegen/src/identifier-safety.ts
@@ -1,0 +1,154 @@
+// Identifier safety helpers for generated TypeScript output.
+//
+// Schema keys are arbitrary strings. Generated TypeScript must stay valid for
+// every legal schema key, so emission sites use these helpers to:
+// - quote property keys that are not valid identifier names
+// - sanitize binding positions (parameter names, declaration names)
+// - allocate deterministic collision-free aliases for sanitized names
+//
+// Original schema keys are always preserved at the property-key level via
+// quoting; sanitized aliases are only used where TypeScript syntactically
+// requires an identifier.
+
+/** ECMAScript IdentifierName syntax (reserved words allowed). */
+const IDENTIFIER_NAME_PATTERN = /^[$_\p{ID_Start}][$\u200C\u200D\p{ID_Continue}]*$/u;
+const IDENTIFIER_START_PATTERN = /^[$_\p{ID_Start}]$/u;
+const IDENTIFIER_PART_PATTERN = /^[$\u200C\u200D\p{ID_Continue}]$/u;
+
+/** Reserved words (including strict-mode reserved words) that cannot be binding identifiers. */
+const RESERVED_WORDS = new Set([
+  "arguments", "await", "break", "case", "catch", "class", "const",
+  "continue", "debugger", "default", "delete", "do", "else", "enum",
+  "eval", "export", "extends", "false", "finally", "for", "function",
+  "if", "implements", "import", "in", "instanceof", "interface", "let",
+  "new", "null", "package", "private", "protected", "public", "return",
+  "static", "super", "switch", "this", "throw", "true", "try", "typeof",
+  "var", "void", "while", "with", "yield",
+]);
+
+/** Predefined type names that TypeScript rejects as declaration names. */
+const FORBIDDEN_TYPE_DECLARATION_NAMES = new Set([
+  "any", "bigint", "boolean", "never", "number", "object",
+  "string", "symbol", "undefined", "unknown",
+]);
+
+/**
+ * True when `name` is a valid ECMAScript IdentifierName and may be emitted
+ * unquoted in property-key position (reserved words are allowed there).
+ */
+export function isIdentifierName(name: string): boolean {
+  return IDENTIFIER_NAME_PATTERN.test(name);
+}
+
+/**
+ * True when `name` may be emitted in a binding position
+ * (parameter name, variable name).
+ */
+export function isBindingIdentifier(name: string): boolean {
+  return isIdentifierName(name) && !RESERVED_WORDS.has(name);
+}
+
+/**
+ * True when `name` may be emitted as a type/interface declaration name.
+ */
+export function isTypeDeclarationName(name: string): boolean {
+  return isBindingIdentifier(name) && !FORBIDDEN_TYPE_DECLARATION_NAMES.has(name);
+}
+
+/**
+ * Render a schema key in property-key position. Keys that are not valid
+ * identifier names are emitted as quoted string properties, preserving the
+ * original key for runtime lookup.
+ */
+export function renderPropertyKey(name: string): string {
+  return isIdentifierName(name) ? name : JSON.stringify(name);
+}
+
+/**
+ * Deterministically rewrite `name` into a valid binding identifier:
+ * invalid characters become "_", a leading character that cannot start an
+ * identifier is prefixed with "_", and reserved words are prefixed with "_".
+ */
+export function sanitizeIdentifier(name: string): string {
+  const chars = Array.from(name);
+  let base = chars
+    .map((ch) => (IDENTIFIER_PART_PATTERN.test(ch) ? ch : "_"))
+    .join("");
+  const first = Array.from(base)[0];
+  if (first === undefined || !IDENTIFIER_START_PATTERN.test(first)) {
+    base = `_${base}`;
+  }
+  if (RESERVED_WORDS.has(base)) {
+    base = `_${base}`;
+  }
+  return base;
+}
+
+export type IdentifierAliasMap = ReadonlyMap<string, string>;
+
+/**
+ * Build a deterministic alias map for type declaration names.
+ *
+ * Valid names map to themselves. Invalid names are sanitized; sanitized
+ * aliases never collide with valid original names, `reserved` names, or each
+ * other — collisions are resolved with deterministic `_2`, `_3`, ... suffixes
+ * in lexicographic key order.
+ */
+export function createTypeNameAliasMap(
+  names: readonly string[],
+  reserved: readonly string[] = []
+): IdentifierAliasMap {
+  const sorted = [...names].sort();
+  const used = new Set(reserved);
+  const aliases = new Map<string, string>();
+
+  for (const name of sorted) {
+    if (isTypeDeclarationName(name)) {
+      aliases.set(name, name);
+      used.add(name);
+    }
+  }
+
+  for (const name of sorted) {
+    if (aliases.has(name)) {
+      continue;
+    }
+    let base = sanitizeIdentifier(name);
+    while (!isTypeDeclarationName(base)) {
+      base = `_${base}`;
+    }
+    let candidate = base;
+    let suffix = 2;
+    while (used.has(candidate)) {
+      candidate = `${base}_${suffix}`;
+      suffix += 1;
+    }
+    used.add(candidate);
+    aliases.set(name, candidate);
+  }
+
+  return aliases;
+}
+
+/**
+ * Deterministically rewrite an ordered parameter-name list so every entry is
+ * a valid binding identifier. Sanitized names never collide with valid
+ * original names or earlier sanitized names.
+ */
+export function sanitizeParameterNames(params: readonly string[]): string[] {
+  const used = new Set(params.filter((name) => isBindingIdentifier(name)));
+  return params.map((name) => {
+    if (isBindingIdentifier(name)) {
+      return name;
+    }
+    const base = sanitizeIdentifier(name);
+    let candidate = base;
+    let suffix = 2;
+    while (used.has(candidate)) {
+      candidate = `${base}_${suffix}`;
+      suffix += 1;
+    }
+    used.add(candidate);
+    return candidate;
+  });
+}

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -39,6 +39,16 @@ export type {
 } from "./plugins/index.js";
 
 // Utilities (for custom plugin authors)
+export {
+  createTypeNameAliasMap,
+  isBindingIdentifier,
+  isIdentifierName,
+  isTypeDeclarationName,
+  renderPropertyKey,
+  sanitizeIdentifier,
+  sanitizeParameterNames,
+} from "./identifier-safety.js";
+export type { IdentifierAliasMap } from "./identifier-safety.js";
 export { validatePath } from "./path-safety.js";
 export type { PathValidationResult } from "./path-safety.js";
 export { stableHash } from "./stable-hash.js";

--- a/packages/codegen/src/plugins/domain-context-type.ts
+++ b/packages/codegen/src/plugins/domain-context-type.ts
@@ -1,0 +1,121 @@
+import type { TypeSpec } from "@manifesto-ai/core";
+import { typeDefinitionToDomainType } from "./domain-type-definition.js";
+import {
+  arrayType,
+  objectType,
+  primitiveType,
+  recordType,
+  tupleType,
+  unionOf,
+  type DomainType,
+  type DomainTypeField,
+} from "./domain-type-model.js";
+
+/**
+ * Rewrite a context field type into a shape that is statically assignable to
+ * the SDK external-context contract (`Readonly<Record<string, JsonValue>>`).
+ *
+ * Returns `null` when the type cannot be represented as a JSON-safe
+ * TypeScript type, in which case the caller degrades the field to `JsonValue`
+ * with a diagnostic. Rules:
+ *
+ * - `unknown` is not JSON-safe (it would break the domain-shape constraint).
+ * - Named type refs are inlined structurally: generated interfaces do not
+ *   carry implicit index signatures, so a ref would not be assignable to the
+ *   external-context record type even when its fields are JSON-safe.
+ *   Recursive refs degrade.
+ * - Optional object fields become required `T | null` fields: `undefined` is
+ *   not a `JsonValue`, so optional properties would break assignability.
+ * - Record keys must be string-typed.
+ */
+export function toContextSafeType(
+  type: DomainType,
+  schemaTypes: Readonly<Record<string, TypeSpec>>,
+  seenRefs: ReadonlySet<string> = new Set()
+): DomainType | null {
+  switch (type.kind) {
+    case "unknown":
+      return null;
+    case "primitive":
+    case "literal":
+      return type;
+    case "array": {
+      const element = toContextSafeType(type.element, schemaTypes, seenRefs);
+      return element === null ? null : arrayType(element);
+    }
+    case "tuple": {
+      const elements: DomainType[] = [];
+      for (const element of type.elements) {
+        const safe = toContextSafeType(element, schemaTypes, seenRefs);
+        if (safe === null) {
+          return null;
+        }
+        elements.push(safe);
+      }
+      return tupleType(elements);
+    }
+    case "record": {
+      if (!isStringKeyType(type.key)) {
+        return null;
+      }
+      const value = toContextSafeType(type.value, schemaTypes, seenRefs);
+      return value === null ? null : recordType(type.key, value);
+    }
+    case "object": {
+      const fields: Record<string, DomainTypeField> = {};
+      for (const name of Object.keys(type.fields)) {
+        const field = type.fields[name];
+        const safe = toContextSafeType(field.type, schemaTypes, seenRefs);
+        if (safe === null) {
+          return null;
+        }
+        fields[name] = {
+          type: field.optional
+            ? unionOf([safe, primitiveType("null")])
+            : safe,
+          optional: false,
+        };
+      }
+      return objectType(fields);
+    }
+    case "union": {
+      const members: DomainType[] = [];
+      for (const member of type.types) {
+        const safe = toContextSafeType(member, schemaTypes, seenRefs);
+        if (safe === null) {
+          return null;
+        }
+        members.push(safe);
+      }
+      return unionOf(members);
+    }
+    case "ref": {
+      if (seenRefs.has(type.name)) {
+        return null;
+      }
+      const spec = schemaTypes[type.name];
+      if (!spec) {
+        return null;
+      }
+      const resolved = typeDefinitionToDomainType(spec.definition, {
+        resolveRef: (name) => Object.hasOwn(schemaTypes, name),
+      });
+      const nextSeen = new Set(seenRefs);
+      nextSeen.add(type.name);
+      return toContextSafeType(resolved, schemaTypes, nextSeen);
+    }
+  }
+}
+
+function isStringKeyType(key: DomainType): boolean {
+  switch (key.kind) {
+    case "primitive":
+      return key.type === "string";
+    case "literal":
+      return typeof key.value === "string";
+    case "union":
+      return key.types.every((member) => isStringKeyType(member));
+    default:
+      return false;
+  }
+}

--- a/packages/codegen/src/plugins/domain-plugin.ts
+++ b/packages/codegen/src/plugins/domain-plugin.ts
@@ -1,14 +1,26 @@
 import type { CodegenContext, CodegenOutput, CodegenPlugin, Diagnostic } from "../types.js";
-import type { ActionSpec, FieldSpec, TypeDefinition, TypeSpec } from "@manifesto-ai/core";
+import type { ActionSpec, ContextSpec, FieldSpec, TypeDefinition, TypeSpec } from "@manifesto-ai/core";
 import { createInferenceContext, inferComputedType } from "./domain-type-inference.js";
 import {
   fieldSpecToDomainField,
   fieldSpecToDomainType,
+  primitiveType,
+  refType,
   renderDomainType,
+  unionOf,
   unknownType,
   type DomainTypeField,
 } from "./domain-type-model.js";
 import { typeDefinitionToDomainType } from "./domain-type-definition.js";
+import { toContextSafeType } from "./domain-context-type.js";
+import {
+  createTypeNameAliasMap,
+  isTypeDeclarationName,
+  renderPropertyKey,
+  sanitizeIdentifier,
+  sanitizeParameterNames,
+  type IdentifierAliasMap,
+} from "../identifier-safety.js";
 
 const PLUGIN_NAME = "codegen-plugin-domain";
 const RESERVED_PUBLIC_ACTION_NAMES = new Set([
@@ -31,14 +43,36 @@ export function createDomainPlugin(options?: DomainPluginOptions): CodegenPlugin
       const diagnostics: Diagnostic[] = [];
       const inference = createInferenceContext(ctx.schema, diagnostics, PLUGIN_NAME);
 
-      const interfaceName = options?.interfaceName
+      const requestedInterfaceName = options?.interfaceName
         ?? deriveInterfaceName(ctx)
         ?? "Domain";
+      const interfaceName = ensureTypeDeclarationName(requestedInterfaceName);
+      if (interfaceName !== requestedInterfaceName) {
+        diagnostics.push({
+          level: "warn",
+          plugin: PLUGIN_NAME,
+          message: `Domain interface name "${requestedInterfaceName}" is not a valid TypeScript identifier. Emitting sanitized name "${interfaceName}".`,
+        });
+      }
       const facadePrefix = deriveFacadePrefix(interfaceName);
       const fileName = options?.fileName ?? deriveFileName(ctx.sourceId);
       const schemaTypes = ctx.schema.types;
+      const typeAliases = createTypeNameAliasMap(
+        Object.keys(schemaTypes),
+        [interfaceName]
+      );
+      for (const [name, alias] of typeAliases) {
+        if (alias !== name) {
+          diagnostics.push({
+            level: "warn",
+            plugin: PLUGIN_NAME,
+            message: `Schema type name "${name}" is not a valid TypeScript type name. Emitting sanitized alias "${alias}".`,
+          });
+        }
+      }
       const namedTypeDeclarations = renderNamedTypeDeclarations(
         schemaTypes,
+        typeAliases,
         diagnostics
       );
 
@@ -50,6 +84,7 @@ export function createDomainPlugin(options?: DomainPluginOptions): CodegenPlugin
           spec,
           ctx.schema.state.fieldTypes,
           schemaTypes,
+          typeAliases,
           diagnostics
         )
       );
@@ -82,16 +117,25 @@ export function createDomainPlugin(options?: DomainPluginOptions): CodegenPlugin
       }
       const actionLines = actionNames.map((name) => {
         const action = ctx.schema.actions[name];
-        return `    ${name}: ${renderActionSignature(action, schemaTypes, diagnostics)}`;
+        return `    ${renderPropertyKey(name)}: ${renderActionSignature(name, action, schemaTypes, typeAliases, diagnostics)}`;
       });
+
+      const contextBlock = ctx.schema.context
+        ? renderContextFieldBlock(ctx.schema.context, schemaTypes, diagnostics)
+        : null;
+
+      const sdkImports = [
+        "ActionArgs",
+        "ActionHandle",
+        "ActionInput",
+        ...(contextBlock?.usesJsonValue ? ["JsonValue"] : []),
+        "ManifestoApp",
+        "RuntimeMode",
+      ];
 
       const sections = [
         "import type {",
-        "  ActionArgs,",
-        "  ActionHandle,",
-        "  ActionInput,",
-        "  ManifestoApp,",
-        "  RuntimeMode,",
+        ...sdkImports.map((name) => `  ${name},`),
         "} from \"@manifesto-ai/sdk\";",
         "",
         ...(namedTypeDeclarations.length > 0
@@ -104,11 +148,20 @@ export function createDomainPlugin(options?: DomainPluginOptions): CodegenPlugin
         "  readonly computed: {",
         computedFields,
         "  }",
+        ...(contextBlock
+          ? ["  readonly context: {", contextBlock.fields, "  }"]
+          : []),
         "  readonly actions: {",
         actionLines.join("\n"),
         "  }",
         "}",
         "",
+        ...(contextBlock
+          ? [
+              `export type ${facadePrefix}ExternalContext = ${interfaceName}["context"];`,
+              "",
+            ]
+          : []),
         `export type ${facadePrefix}ActionInput<Name extends keyof ${interfaceName}["actions"] & string> =`,
         `  ActionInput<${interfaceName}, Name>;`,
         "",
@@ -152,7 +205,7 @@ function renderFieldBlock<T>(
     .map((name) => {
       const field = mapField(name, source[name]);
       const optional = field.optional ? "?" : "";
-      return `    ${name}${optional}: ${renderDomainType(field.type)}`;
+      return `    ${renderPropertyKey(name)}${optional}: ${renderDomainType(field.type)}`;
     })
     .join("\n");
 }
@@ -162,6 +215,7 @@ function stateFieldToDomainField(
   spec: FieldSpec,
   fieldTypes: Readonly<Record<string, TypeDefinition>> | undefined,
   schemaTypes: Readonly<Record<string, TypeSpec>>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): DomainTypeField {
   const fieldType = fieldTypes?.[name];
@@ -174,15 +228,90 @@ function stateFieldToDomainField(
       diagnostics,
       plugin: PLUGIN_NAME,
       path: `state.fieldTypes.${name}`,
-      resolveRef: createTypeRefResolver(schemaTypes),
+      ...createTypeRefOptions(schemaTypes, typeAliases),
+    }),
+    optional: !spec.required,
+  };
+}
+
+type ContextBlock = {
+  readonly fields: string;
+  readonly usesJsonValue: boolean;
+};
+
+function renderContextFieldBlock(
+  contextSpec: ContextSpec,
+  schemaTypes: Readonly<Record<string, TypeSpec>>,
+  diagnostics: Diagnostic[]
+): ContextBlock {
+  const names = Object.keys(contextSpec.fields)
+    .filter((name) => !name.startsWith("$"))
+    .sort();
+  let usesJsonValue = false;
+
+  const lines = names.map((name) => {
+    const field = contextFieldToDomainField(
+      name,
+      contextSpec.fields[name],
+      contextSpec.fieldTypes,
+      schemaTypes,
+      diagnostics
+    );
+    // External context is `Readonly<Record<string, JsonValue>>`; optional
+    // properties would introduce `undefined`, so absence is encoded as null.
+    const declared = field.optional
+      ? unionOf([field.type, primitiveType("null")])
+      : field.type;
+    const safe = toContextSafeType(declared, schemaTypes);
+    let rendered: DomainTypeField["type"];
+    if (safe === null) {
+      usesJsonValue = true;
+      rendered = refType("JsonValue");
+      diagnostics.push({
+        level: "warn",
+        plugin: PLUGIN_NAME,
+        message: `Context field "${name}" cannot be represented as a JSON-safe TypeScript type. Emitting "JsonValue".`,
+      });
+    } else {
+      rendered = safe;
+    }
+    return `    ${renderPropertyKey(name)}: ${renderDomainType(rendered)}`;
+  });
+
+  return { fields: lines.join("\n"), usesJsonValue };
+}
+
+function contextFieldToDomainField(
+  name: string,
+  spec: FieldSpec,
+  fieldTypes: Readonly<Record<string, TypeDefinition>> | undefined,
+  schemaTypes: Readonly<Record<string, TypeSpec>>,
+  diagnostics: Diagnostic[]
+): DomainTypeField {
+  const fieldType = fieldTypes?.[name];
+  if (!fieldType) {
+    return fieldSpecToDomainField(spec);
+  }
+
+  return {
+    // Refs are intentionally not renamed here: `toContextSafeType()` inlines
+    // every ref structurally, so emitted context types never reference named
+    // declarations.
+    type: typeDefinitionToDomainType(fieldType, {
+      diagnostics,
+      plugin: PLUGIN_NAME,
+      path: `context.fieldTypes.${name}`,
+      resolveRef: (typeName) => Object.hasOwn(schemaTypes, typeName),
     }),
     optional: !spec.required,
   };
 }
 
 function renderActionSignature(
+  actionName: string,
   action: ActionSpec,
   schemaTypes: Readonly<Record<string, TypeSpec>>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string {
   const params = action.params;
@@ -191,16 +320,27 @@ function renderActionSignature(
       return "() => void";
     }
 
-    const fields = params.map((name) => resolveActionParamField(action, name, schemaTypes, diagnostics));
+    const fields = params.map((name) => resolveActionParamField(action, name, schemaTypes, typeAliases, diagnostics));
+    const paramNames = sanitizeParameterNames(params);
+    params.forEach((name, index) => {
+      if (paramNames[index] !== name) {
+        diagnostics.push({
+          level: "warn",
+          plugin: PLUGIN_NAME,
+          message: `Action "${actionName}" parameter "${name}" is not a valid TypeScript identifier. Emitting sanitized parameter name "${paramNames[index]}".`,
+        });
+      }
+    });
     const renderedParams = params.map((name, index) => {
+      const paramName = paramNames[index]!;
       const field = fields[index]!;
       const renderedType = renderDomainType(field.type);
       const hasLaterRequired = fields.slice(index + 1).some((candidate) => !candidate.optional);
       if (field.optional && hasLaterRequired) {
-        return `${name}: ${renderedType} | undefined`;
+        return `${paramName}: ${renderedType} | undefined`;
       }
       const optional = field.optional ? "?" : "";
-      return `${name}${optional}: ${renderedType}`;
+      return `${paramName}${optional}: ${renderedType}`;
     });
 
     return `(${renderedParams.join(", ")}) => void`;
@@ -212,7 +352,7 @@ function renderActionSignature(
       diagnostics,
       plugin: PLUGIN_NAME,
       path: "action.inputType",
-      resolveRef: createTypeRefResolver(schemaTypes),
+      ...createTypeRefOptions(schemaTypes, typeAliases),
     }));
     return `(input: ${renderedInput}) => void`;
   }
@@ -229,6 +369,7 @@ function resolveActionParamField(
   action: ActionSpec,
   name: string,
   schemaTypes: Readonly<Record<string, TypeSpec>>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): DomainTypeField {
   const inputTypeField = getInputTypeObjectField(action.inputType, name);
@@ -238,7 +379,7 @@ function resolveActionParamField(
         diagnostics,
         plugin: PLUGIN_NAME,
         path: `action.inputType.fields.${name}`,
-        resolveRef: createTypeRefResolver(schemaTypes),
+        ...createTypeRefOptions(schemaTypes, typeAliases),
       }),
       optional: inputTypeField.optional,
     };
@@ -264,36 +405,41 @@ function resolveActionParamField(
 
 function renderNamedTypeDeclarations(
   schemaTypes: Readonly<Record<string, TypeSpec>>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string[] {
   return Object.keys(schemaTypes)
     .sort()
-    .map((name) => renderNamedTypeDeclaration(name, schemaTypes[name], schemaTypes, diagnostics));
+    .map((name) => renderNamedTypeDeclaration(name, schemaTypes[name], schemaTypes, typeAliases, diagnostics));
 }
 
 function renderNamedTypeDeclaration(
   name: string,
   spec: TypeSpec,
   schemaTypes: Readonly<Record<string, TypeSpec>>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string {
+  const declarationName = typeAliases.get(name) ?? name;
   if (spec.definition.kind === "object") {
-    return renderNamedObjectDeclaration(name, spec.definition, schemaTypes, diagnostics);
+    return renderNamedObjectDeclaration(name, declarationName, spec.definition, schemaTypes, typeAliases, diagnostics);
   }
 
   const renderedType = renderDomainType(typeDefinitionToDomainType(spec.definition, {
     diagnostics,
     plugin: PLUGIN_NAME,
     path: `types.${name}`,
-    resolveRef: createTypeRefResolver(schemaTypes),
+    ...createTypeRefOptions(schemaTypes, typeAliases),
   }));
-  return `export type ${name} = ${renderedType};`;
+  return `export type ${declarationName} = ${renderedType};`;
 }
 
 function renderNamedObjectDeclaration(
   name: string,
+  declarationName: string,
   definition: Extract<TypeDefinition, { readonly kind: "object" }>,
   schemaTypes: Readonly<Record<string, TypeSpec>>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string {
   const fieldLines = Object.keys(definition.fields)
@@ -305,22 +451,40 @@ function renderNamedObjectDeclaration(
         diagnostics,
         plugin: PLUGIN_NAME,
         path: `types.${name}.fields.${fieldName}`,
-        resolveRef: createTypeRefResolver(schemaTypes),
+        ...createTypeRefOptions(schemaTypes, typeAliases),
       }));
-      return `  ${fieldName}${optional}: ${renderedType};`;
+      return `  ${renderPropertyKey(fieldName)}${optional}: ${renderedType};`;
     });
 
   return [
-    `export interface ${name} {`,
+    `export interface ${declarationName} {`,
     ...fieldLines,
     "}",
   ].join("\n");
 }
 
-function createTypeRefResolver(
-  schemaTypes: Readonly<Record<string, TypeSpec>>
-): (name: string) => boolean {
-  return (name) => Object.hasOwn(schemaTypes, name);
+function createTypeRefOptions(
+  schemaTypes: Readonly<Record<string, TypeSpec>>,
+  typeAliases: IdentifierAliasMap
+): {
+  readonly resolveRef: (name: string) => boolean;
+  readonly renameRef: (name: string) => string;
+} {
+  return {
+    resolveRef: (name) => Object.hasOwn(schemaTypes, name),
+    renameRef: (name) => typeAliases.get(name) ?? name,
+  };
+}
+
+function ensureTypeDeclarationName(name: string): string {
+  if (isTypeDeclarationName(name)) {
+    return name;
+  }
+  let sanitized = sanitizeIdentifier(name);
+  while (!isTypeDeclarationName(sanitized)) {
+    sanitized = `_${sanitized}`;
+  }
+  return sanitized;
 }
 
 function getInputTypeObjectField(

--- a/packages/codegen/src/plugins/domain-type-definition.ts
+++ b/packages/codegen/src/plugins/domain-type-definition.ts
@@ -19,6 +19,8 @@ export type TypeDefinitionDiagnosticOptions = {
   readonly plugin?: string;
   readonly path?: string;
   readonly resolveRef?: (name: string) => boolean;
+  /** Map a schema type name to its emitted (possibly sanitized) TypeScript alias. */
+  readonly renameRef?: (name: string) => string;
 };
 
 export function typeDefinitionToDomainType(
@@ -83,7 +85,7 @@ export function typeDefinitionToDomainType(
         );
         return unknownType();
       }
-      return refType(def.name);
+      return refType(options.renameRef ? options.renameRef(def.name) : def.name);
     default: {
       const unknownKind = (def as { readonly kind?: unknown }).kind;
       warnUnknownTypeDefinition(

--- a/packages/codegen/src/plugins/domain-type-model.ts
+++ b/packages/codegen/src/plugins/domain-type-model.ts
@@ -1,4 +1,5 @@
 import type { FieldSpec } from "@manifesto-ai/core";
+import { renderPropertyKey } from "../identifier-safety.js";
 
 export type DomainPrimitive = "string" | "number" | "boolean" | "null";
 
@@ -207,7 +208,7 @@ export function renderDomainType(type: DomainType): string {
       const parts = fieldNames.map((name) => {
         const field = type.fields[name];
         const optional = field.optional ? "?" : "";
-        return `${name}${optional}: ${renderDomainType(field.type)}`;
+        return `${renderPropertyKey(name)}${optional}: ${renderDomainType(field.type)}`;
       });
       return `{ ${parts.join("; ")} }`;
     }

--- a/packages/codegen/src/plugins/ts-plugin.ts
+++ b/packages/codegen/src/plugins/ts-plugin.ts
@@ -11,6 +11,13 @@ import type {
   CodegenPlugin,
   Diagnostic,
 } from "../types.js";
+import {
+  createTypeNameAliasMap,
+  isTypeDeclarationName,
+  renderPropertyKey,
+  sanitizeIdentifier,
+  type IdentifierAliasMap,
+} from "../identifier-safety.js";
 
 const PLUGIN_NAME = "codegen-plugin-ts";
 
@@ -42,12 +49,22 @@ export function createTsPlugin(options?: TsPluginOptions): CodegenPlugin {
 
       // Generate types from schema.types (GEN-10, TS-6: lexicographic order)
       const sortedTypeNames = Object.keys(ctx.schema.types).sort();
+      const typeAliases = createTypeNameAliasMap(sortedTypeNames);
+      for (const [name, alias] of typeAliases) {
+        if (alias !== name) {
+          diagnostics.push({
+            level: "warn",
+            plugin: PLUGIN_NAME,
+            message: `Schema type name "${name}" is not a valid TypeScript type name. Emitting sanitized alias "${alias}".`,
+          });
+        }
+      }
       const typeDecls: string[] = [];
 
       for (const name of sortedTypeNames) {
         const spec = ctx.schema.types[name];
-        typeNames.push(name);
-        typeDecls.push(renderNamedType(name, spec, diagnostics));
+        typeNames.push(typeAliases.get(name) ?? name);
+        typeDecls.push(renderNamedType(name, spec, typeAliases, diagnostics));
       }
 
       const typesContent = typeDecls.join("\n\n") + "\n";
@@ -55,11 +72,20 @@ export function createTsPlugin(options?: TsPluginOptions): CodegenPlugin {
       // Generate action input types
       const sortedActionNames = Object.keys(ctx.schema.actions).sort();
       const actionDecls: string[] = [];
+      const usedInputTypeNames = new Set<string>();
 
       for (const actionName of sortedActionNames) {
         const spec = ctx.schema.actions[actionName];
         if (spec.input) {
-          const typeName = pascalCase(actionName) + "Input";
+          const preferred = pascalCase(actionName) + "Input";
+          const typeName = allocateTypeName(preferred, usedInputTypeNames);
+          if (typeName !== preferred) {
+            diagnostics.push({
+              level: "warn",
+              plugin: PLUGIN_NAME,
+              message: `Action input type name "${preferred}" for action "${actionName}" is not a valid unique TypeScript type name. Emitting sanitized name "${typeName}".`,
+            });
+          }
           actionDecls.push(renderActionInputType(typeName, spec, diagnostics));
         }
       }
@@ -88,23 +114,26 @@ export function createTsPlugin(options?: TsPluginOptions): CodegenPlugin {
 function renderNamedType(
   name: string,
   spec: TypeSpec,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string {
   const def = spec.definition;
+  const declarationName = typeAliases.get(name) ?? name;
 
   // TS-3: top-level named object -> export interface
   if (def.kind === "object") {
-    return renderInterface(name, def.fields, diagnostics);
+    return renderInterface(declarationName, def.fields, typeAliases, diagnostics);
   }
 
   // TS-3: all other named types -> export type
-  const tsType = mapTypeDefinition(def, diagnostics);
-  return `export type ${name} = ${tsType};`;
+  const tsType = mapTypeDefinition(def, typeAliases, diagnostics);
+  return `export type ${declarationName} = ${tsType};`;
 }
 
 function renderInterface(
   name: string,
   fields: Record<string, { type: TypeDefinition; optional: boolean }>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string {
   const sortedFields = Object.keys(fields).sort();
@@ -112,10 +141,10 @@ function renderInterface(
 
   for (const fieldName of sortedFields) {
     const field = fields[fieldName];
-    const tsType = mapTypeDefinition(field.type, diagnostics);
+    const tsType = mapTypeDefinition(field.type, typeAliases, diagnostics);
     // TS-5: optional -> ?
     const opt = field.optional ? "?" : "";
-    lines.push(`  ${fieldName}${opt}: ${tsType};`);
+    lines.push(`  ${renderPropertyKey(fieldName)}${opt}: ${tsType};`);
   }
 
   return `export interface ${name} {\n${lines.join("\n")}\n}`;
@@ -123,6 +152,7 @@ function renderInterface(
 
 function mapTypeDefinition(
   def: TypeDefinition,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string {
   switch (def.kind) {
@@ -133,29 +163,29 @@ function mapTypeDefinition(
       return renderLiteral(def.value);
 
     case "array":
-      return `${wrapComplex(mapTypeDefinition(def.element, diagnostics), def.element)}[]`;
+      return `${wrapComplex(mapTypeDefinition(def.element, typeAliases, diagnostics), def.element)}[]`;
 
     case "record":
-      return `Record<${mapTypeDefinition(def.key, diagnostics)}, ${mapTypeDefinition(def.value, diagnostics)}>`;
+      return `Record<${mapTypeDefinition(def.key, typeAliases, diagnostics)}, ${mapTypeDefinition(def.value, typeAliases, diagnostics)}>`;
 
     case "object": {
       const sortedFields = Object.keys(def.fields).sort();
       const parts: string[] = [];
       for (const fieldName of sortedFields) {
         const field = def.fields[fieldName];
-        const tsType = mapTypeDefinition(field.type, diagnostics);
+        const tsType = mapTypeDefinition(field.type, typeAliases, diagnostics);
         const opt = field.optional ? "?" : "";
-        parts.push(`${fieldName}${opt}: ${tsType}`);
+        parts.push(`${renderPropertyKey(fieldName)}${opt}: ${tsType}`);
       }
       return `{ ${parts.join("; ")} }`;
     }
 
     case "union":
       // TS-2: nullable uses T | null
-      return def.types.map((t) => mapTypeDefinition(t, diagnostics)).join(" | ");
+      return def.types.map((t) => mapTypeDefinition(t, typeAliases, diagnostics)).join(" | ");
 
     case "ref":
-      return def.name;
+      return typeAliases.get(def.name) ?? def.name;
 
     default: {
       // PLG-3, TS-1: unknown kind fallback
@@ -253,7 +283,7 @@ function mapFieldType(
           const field = spec.fields[name];
           const fieldType = mapFieldSpec(field, diagnostics);
           const opt = field.required ? "" : "?";
-          parts.push(`${name}${opt}: ${fieldType}`);
+          parts.push(`${renderPropertyKey(name)}${opt}: ${fieldType}`);
         }
         return `{ ${parts.join("; ")} }`;
       }
@@ -286,4 +316,22 @@ function pascalCase(str: string): string {
     .split(/[-_\s]+/)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join("");
+}
+
+function allocateTypeName(preferred: string, used: Set<string>): string {
+  let base = preferred;
+  if (!isTypeDeclarationName(base)) {
+    base = sanitizeIdentifier(base);
+    while (!isTypeDeclarationName(base)) {
+      base = `_${base}`;
+    }
+  }
+  let candidate = base;
+  let suffix = 2;
+  while (used.has(candidate)) {
+    candidate = `${base}_${suffix}`;
+    suffix += 1;
+  }
+  used.add(candidate);
+  return candidate;
 }

--- a/packages/codegen/src/plugins/zod-plugin.ts
+++ b/packages/codegen/src/plugins/zod-plugin.ts
@@ -6,6 +6,11 @@ import type {
   Diagnostic,
 } from "../types.js";
 import type { TsPluginArtifacts } from "./ts-plugin.js";
+import {
+  createTypeNameAliasMap,
+  renderPropertyKey,
+  type IdentifierAliasMap,
+} from "../identifier-safety.js";
 
 const PLUGIN_NAME = "codegen-plugin-zod";
 const TS_PLUGIN_NAME = "codegen-plugin-ts";
@@ -34,12 +39,22 @@ export function createZodPlugin(options?: ZodPluginOptions): CodegenPlugin {
       const sortedTypeNames = Object.keys(ctx.schema.types).sort();
       const schemaDecls: string[] = [];
 
-      // Collect all type names for forward declarations with z.lazy
-      const allTypeNames = new Set(sortedTypeNames);
+      // Sanitized aliases mirror the TS plugin so cross-file references and
+      // z.ZodType annotations stay consistent.
+      const typeAliases = createTypeNameAliasMap(sortedTypeNames);
+      for (const [name, alias] of typeAliases) {
+        if (alias !== name) {
+          diagnostics.push({
+            level: "warn",
+            plugin: PLUGIN_NAME,
+            message: `Schema type name "${name}" is not a valid TypeScript type name. Emitting sanitized alias "${alias}".`,
+          });
+        }
+      }
 
       for (const name of sortedTypeNames) {
         const spec = ctx.schema.types[name];
-        schemaDecls.push(renderNamedSchema(name, spec, allTypeNames, tsArtifacts, diagnostics));
+        schemaDecls.push(renderNamedSchema(name, spec, typeAliases, tsArtifacts, diagnostics));
       }
 
       // Build imports
@@ -48,7 +63,8 @@ export function createZodPlugin(options?: ZodPluginOptions): CodegenPlugin {
       // ZOD-4: Import TS types for annotations when available
       if (tsArtifacts && tsArtifacts.typeNames.length > 0) {
         const typeImports = sortedTypeNames
-          .filter((n) => tsArtifacts.typeNames.includes(n))
+          .map((n) => typeAliases.get(n) ?? n)
+          .filter((alias) => tsArtifacts.typeNames.includes(alias))
           .join(", ");
         if (typeImports) {
           imports.push(`import type { ${typeImports} } from "${tsArtifacts.typeImportPath}";`);
@@ -70,23 +86,24 @@ export function createZodPlugin(options?: ZodPluginOptions): CodegenPlugin {
 function renderNamedSchema(
   name: string,
   spec: TypeSpec,
-  allTypeNames: Set<string>,
+  typeAliases: IdentifierAliasMap,
   tsArtifacts: TsPluginArtifacts | undefined,
   diagnostics: Diagnostic[]
 ): string {
-  const schemaName = `${name}Schema`;
-  const zodExpr = mapTypeDefinition(spec.definition, allTypeNames, diagnostics);
+  const alias = typeAliases.get(name) ?? name;
+  const schemaName = `${alias}Schema`;
+  const zodExpr = mapTypeDefinition(spec.definition, typeAliases, diagnostics);
 
   // ZOD-4/ZOD-5: Type annotation when TS artifacts available
-  const hasTypeAnnotation = tsArtifacts && tsArtifacts.typeNames.includes(name);
-  const annotation = hasTypeAnnotation ? `: z.ZodType<${name}>` : "";
+  const hasTypeAnnotation = tsArtifacts && tsArtifacts.typeNames.includes(alias);
+  const annotation = hasTypeAnnotation ? `: z.ZodType<${alias}>` : "";
 
   return `export const ${schemaName}${annotation} = ${zodExpr};`;
 }
 
 function mapTypeDefinition(
   def: TypeDefinition,
-  allTypeNames: Set<string>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string {
   switch (def.kind) {
@@ -97,20 +114,20 @@ function mapTypeDefinition(
       return `z.literal(${renderLiteralValue(def.value)})`;
 
     case "array":
-      return `z.array(${mapTypeDefinition(def.element, allTypeNames, diagnostics)})`;
+      return `z.array(${mapTypeDefinition(def.element, typeAliases, diagnostics)})`;
 
     case "record":
-      return handleRecord(def, allTypeNames, diagnostics);
+      return handleRecord(def, typeAliases, diagnostics);
 
     case "object":
-      return renderZodObject(def.fields, allTypeNames, diagnostics);
+      return renderZodObject(def.fields, typeAliases, diagnostics);
 
     case "union":
-      return handleUnion(def.types, allTypeNames, diagnostics);
+      return handleUnion(def.types, typeAliases, diagnostics);
 
     case "ref":
       // ZOD-2: Always z.lazy for circular reference support
-      return `z.lazy(() => ${def.name}Schema)`;
+      return `z.lazy(() => ${typeAliases.get(def.name) ?? def.name}Schema)`;
 
     default: {
       // ZOD-1: Unknown kind fallback
@@ -151,10 +168,10 @@ function renderLiteralValue(value: string | number | boolean | null): string {
 
 function handleRecord(
   def: Extract<TypeDefinition, { kind: "record" }>,
-  allTypeNames: Set<string>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string {
-  const valueSchema = mapTypeDefinition(def.value, allTypeNames, diagnostics);
+  const valueSchema = mapTypeDefinition(def.value, typeAliases, diagnostics);
 
   // ZOD-7: Non-string record key -> degrade to z.record(z.string(), ...)
   if (def.key.kind !== "primitive" || def.key.type !== "string") {
@@ -171,7 +188,7 @@ function handleRecord(
 
 function renderZodObject(
   fields: Record<string, { type: TypeDefinition; optional: boolean }>,
-  allTypeNames: Set<string>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string {
   const sortedFields = Object.keys(fields).sort();
@@ -179,14 +196,14 @@ function renderZodObject(
 
   for (const fieldName of sortedFields) {
     const field = fields[fieldName];
-    let zodType = mapTypeDefinition(field.type, allTypeNames, diagnostics);
+    let zodType = mapTypeDefinition(field.type, typeAliases, diagnostics);
 
     // ZOD-6: optional -> .optional()
     if (field.optional) {
       zodType += ".optional()";
     }
 
-    parts.push(`  ${fieldName}: ${zodType},`);
+    parts.push(`  ${renderPropertyKey(fieldName)}: ${zodType},`);
   }
 
   return `z.object({\n${parts.join("\n")}\n})`;
@@ -194,7 +211,7 @@ function renderZodObject(
 
 function handleUnion(
   types: TypeDefinition[],
-  allTypeNames: Set<string>,
+  typeAliases: IdentifierAliasMap,
   diagnostics: Diagnostic[]
 ): string {
   // ZOD-3: 2-variant union with null -> z.nullable(T)
@@ -204,11 +221,11 @@ function handleUnion(
     );
     if (nullIdx !== -1) {
       const otherIdx = nullIdx === 0 ? 1 : 0;
-      const otherSchema = mapTypeDefinition(types[otherIdx], allTypeNames, diagnostics);
+      const otherSchema = mapTypeDefinition(types[otherIdx], typeAliases, diagnostics);
       return `z.nullable(${otherSchema})`;
     }
   }
 
-  const schemas = types.map((t) => mapTypeDefinition(t, allTypeNames, diagnostics));
+  const schemas = types.map((t) => mapTypeDefinition(t, typeAliases, diagnostics));
   return `z.union([${schemas.join(", ")}])`;
 }


### PR DESCRIPTION
## Summary

Closes #482 and #481.

### #482 — identifier sanitization
Schema keys (state fields, action names, type members) flowed into generated TypeScript identifiers unvalidated. New `packages/codegen/src/identifier-safety.ts` provides the shared validation/quoting layer, applied at every emission site in the ts, zod, and domain plugins — invalid keys are emitted as quoted properties or rejected with a clear diagnostic instead of producing broken output. Regression suite: `identifier-safety.test.ts`.

### #481 — context typing in facades
Generated domain facades dropped the schema's declared context contract. They now emit a typed context block, so `injectContext`/`updateContext` calls against generated facades are type-checked end to end — verified by a test that compiles generated output and asserts both acceptance of valid context and rejection (TS2322) of mismatched fields.

### Verification
codegen 11/11 test files (114 tests) green.

> Note: most of this change was produced by a background workstream interrupted before commit; it was reviewed, one test's `@ts-expect-error` placement corrected, and verified green before this PR.

Part of milestone **M2 — Quality Gates & High-Leverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)