### PR TITLE
test(compiler,host): port compliance suites onto the shared cts-kit framework

### DIFF
--- a/cts/cts-kit/package.json
+++ b/cts/cts-kit/package.json
@@ -2,7 +2,7 @@
   "name": "@manifesto-ai/cts-kit",
   "version": "5.0.0",
   "private": true,
-  "description": "Internal compliance test kit shared by LGW CTS suites",
+  "description": "Internal compliance test kit shared by all Manifesto CTS suites",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/cts/cts-kit/src/assertions.ts
+++ b/cts/cts-kit/src/assertions.ts
@@ -9,7 +9,7 @@ export function noteEvidence(summary: string, details?: unknown): ComplianceEvid
   return { kind: "note", summary, details };
 }
 
-export function passRule<TSuite extends string, TEvidence extends ComplianceEvidence>(
+export function passRule<TSuite extends string, TEvidence extends ComplianceEvidence<string> = ComplianceEvidence>(
   rule: ComplianceRule<TSuite>,
   message?: string,
   evidence?: TEvidence[]
@@ -24,7 +24,7 @@ export function passRule<TSuite extends string, TEvidence extends ComplianceEvid
   };
 }
 
-export function failRule<TSuite extends string, TEvidence extends ComplianceEvidence>(
+export function failRule<TSuite extends string, TEvidence extends ComplianceEvidence<string> = ComplianceEvidence>(
   rule: ComplianceRule<TSuite>,
   message?: string,
   evidence?: TEvidence[]
@@ -39,7 +39,7 @@ export function failRule<TSuite extends string, TEvidence extends ComplianceEvid
   };
 }
 
-export function warnRule<TSuite extends string, TEvidence extends ComplianceEvidence>(
+export function warnRule<TSuite extends string, TEvidence extends ComplianceEvidence<string> = ComplianceEvidence>(
   rule: ComplianceRule<TSuite>,
   message?: string,
   evidence?: TEvidence[]
@@ -54,7 +54,7 @@ export function warnRule<TSuite extends string, TEvidence extends ComplianceEvid
   };
 }
 
-export function evaluateRule<TSuite extends string, TEvidence extends ComplianceEvidence>(
+export function evaluateRule<TSuite extends string, TEvidence extends ComplianceEvidence<string> = ComplianceEvidence>(
   rule: ComplianceRule<TSuite>,
   satisfied: boolean,
   options: {
@@ -74,7 +74,7 @@ export function evaluateRule<TSuite extends string, TEvidence extends Compliance
   return warnRule(rule, options.failMessage, options.evidence);
 }
 
-function formatEvidence(evidence: ComplianceEvidence[] | undefined): string {
+function formatEvidence(evidence: readonly ComplianceEvidence<string>[] | undefined): string {
   if (!evidence || evidence.length === 0) {
     return "";
   }
@@ -82,7 +82,7 @@ function formatEvidence(evidence: ComplianceEvidence[] | undefined): string {
   return evidence.map((item) => `- [${item.kind}] ${item.summary}`).join("\n");
 }
 
-export function expectCompliance<TEvidence extends ComplianceEvidence>(
+export function expectCompliance<TEvidence extends ComplianceEvidence<string> = ComplianceEvidence>(
   result: ComplianceResult<TEvidence>
 ): void {
   if (result.status === "FAIL") {
@@ -92,7 +92,7 @@ export function expectCompliance<TEvidence extends ComplianceEvidence>(
   }
 }
 
-export function expectAllCompliance<TEvidence extends ComplianceEvidence>(
+export function expectAllCompliance<TEvidence extends ComplianceEvidence<string> = ComplianceEvidence>(
   results: readonly ComplianceResult<TEvidence>[]
 ): void {
   for (const result of results) {

--- a/cts/cts-kit/src/types.ts
+++ b/cts/cts-kit/src/types.ts
@@ -6,8 +6,8 @@ export type RuleLevel = "MUST" | "SHOULD" | "MUST_NOT" | "MAY" | "CRITICAL";
 
 export type RuleLifecycle = "active" | "superseded";
 
-export interface ComplianceEvidence {
-  kind: "note";
+export interface ComplianceEvidence<TKind extends string = "note"> {
+  kind: TKind;
   summary: string;
   details?: unknown;
 }
@@ -36,7 +36,9 @@ export interface ComplianceCoverageEntry {
   caseIds: string[];
 }
 
-export interface ComplianceResult<TEvidence extends ComplianceEvidence = ComplianceEvidence> {
+export interface ComplianceResult<
+  TEvidence extends ComplianceEvidence<string> = ComplianceEvidence,
+> {
   ruleId: string;
   specSection: string;
   mode: RuleMode;

--- a/docs/internals/test-conventions.md
+++ b/docs/internals/test-conventions.md
@@ -1,7 +1,7 @@
 # Test Conventions
 
 > **Status:** Normative
-> **Last updated:** 2026-03-24
+> **Last updated:** 2026-06-12
 
 ---
 
@@ -61,3 +61,26 @@ pnpm test --filter @manifesto-ai/core
 pnpm --filter @manifesto-ai/host exec vitest run src/__tests__/compliance/
 pnpm --filter @manifesto-ai/compiler exec vitest run src/__tests__/compliance/
 ```
+
+## CTS Taxonomy
+
+Compliance test suites (CTS) follow a two-tier taxonomy:
+
+1. **Package CTS** — `packages/*/src/__tests__/compliance/`
+   Verifies that package's own SPEC (e.g. Core CTS, Host HCTS, Compiler CCTS,
+   Lineage LCTS, Governance GCTS). Package CTS may use internal adapters and
+   package internals to observe behavior the public surface does not expose.
+2. **Cross-package activation CTS** — `cts/activation-cts/`
+   Verifies composed activation/decorator contracts (base runtime, lineage,
+   governance) against public surfaces only. It must not import package
+   internals.
+
+`@manifesto-ai/cts-kit` (`cts/cts-kit/`) is the single shared compliance
+framework for both tiers: rule/inventory/case/coverage types, the
+`evaluateRule`/`passRule`/`failRule`/`expectCompliance`/`expectAllCompliance`
+assertion helpers, and the rule-matrix validators
+(`expectUniqueRuleIds`, `expectInventoryRegistryParity`,
+`expectCoverageIntegrity`, `expectCoverageCompleteness`,
+`expectSuiteRulePresence`). New compliance suites MUST consume cts-kit rather
+than copying the skeleton; package-specific helpers (e.g. compiler diagnostic
+evidence, host trace evidence) stay in the package's compliance directory.

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -93,6 +93,7 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
     "@manifesto-ai/core": "workspace:*",
+    "@manifesto-ai/cts-kit": "workspace:*",
     "@types/node": "^25.5.2",
     "@types/react": "^19.2.14",
     "dotenv": "^17.4.2",

--- a/packages/compiler/src/__tests__/compliance/ccts-assertions.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-assertions.ts
@@ -1,14 +1,15 @@
-import { expect } from "vitest";
-import type { Diagnostic } from "../../diagnostics/types.js";
-import type {
-  CompilerComplianceResult,
-  CompilerComplianceRule,
-  CompilerEvidence,
-} from "./ccts-types.js";
+export {
+  noteEvidence,
+  passRule,
+  failRule,
+  warnRule,
+  evaluateRule,
+  expectCompliance,
+  expectAllCompliance,
+} from "@manifesto-ai/cts-kit";
 
-export function noteEvidence(summary: string, details?: unknown): CompilerEvidence {
-  return { kind: "note", summary, details };
-}
+import type { Diagnostic } from "../../diagnostics/types.js";
+import type { CompilerEvidence } from "./ccts-types.js";
 
 export function diagnosticEvidence(diagnostics: Diagnostic[]): CompilerEvidence[] {
   return diagnostics.map((diagnostic) => ({
@@ -24,108 +25,4 @@ export function hasDiagnosticCode(
 ): boolean {
   const expected = Array.isArray(codes) ? codes : [codes];
   return diagnostics.some((diagnostic) => expected.includes(diagnostic.code));
-}
-
-export function passRule(
-  rule: CompilerComplianceRule,
-  message?: string,
-  evidence?: CompilerEvidence[]
-): CompilerComplianceResult {
-  return {
-    ruleId: rule.ruleId,
-    specSection: rule.specSection,
-    mode: rule.mode,
-    status: "PASS",
-    message,
-    evidence,
-  };
-}
-
-export function failRule(
-  rule: CompilerComplianceRule,
-  message?: string,
-  evidence?: CompilerEvidence[]
-): CompilerComplianceResult {
-  return {
-    ruleId: rule.ruleId,
-    specSection: rule.specSection,
-    mode: rule.mode,
-    status: "FAIL",
-    message,
-    evidence,
-  };
-}
-
-export function warnRule(
-  rule: CompilerComplianceRule,
-  message?: string,
-  evidence?: CompilerEvidence[]
-): CompilerComplianceResult {
-  return {
-    ruleId: rule.ruleId,
-    specSection: rule.specSection,
-    mode: rule.mode,
-    status: "WARN",
-    message,
-    evidence,
-  };
-}
-
-export function skipRule(
-  rule: CompilerComplianceRule,
-  message?: string,
-  evidence?: CompilerEvidence[]
-): CompilerComplianceResult {
-  return {
-    ruleId: rule.ruleId,
-    specSection: rule.specSection,
-    mode: rule.mode,
-    status: "SKIP",
-    message,
-    evidence,
-  };
-}
-
-export function evaluateRule(
-  rule: CompilerComplianceRule,
-  satisfied: boolean,
-  options: {
-    passMessage?: string;
-    failMessage: string;
-    evidence?: CompilerEvidence[];
-  }
-): CompilerComplianceResult {
-  if (satisfied) {
-    return passRule(rule, options.passMessage, options.evidence);
-  }
-
-  if (rule.mode === "blocking") {
-    return failRule(rule, options.failMessage, options.evidence);
-  }
-
-  return warnRule(rule, options.failMessage, options.evidence);
-}
-
-function formatEvidence(evidence: CompilerEvidence[] | undefined): string {
-  if (!evidence || evidence.length === 0) {
-    return "";
-  }
-
-  return evidence
-    .map((item) => `- [${item.kind}] ${item.summary}`)
-    .join("\n");
-}
-
-export function expectCompliance(result: CompilerComplianceResult): void {
-  if (result.status === "FAIL") {
-    const message = result.message ?? `Rule ${result.ruleId} violated`;
-    const evidence = formatEvidence(result.evidence);
-    expect.fail(`${message}${evidence ? `\n\nEvidence:\n${evidence}` : ""}`);
-  }
-}
-
-export function expectAllCompliance(results: readonly CompilerComplianceResult[]): void {
-  for (const result of results) {
-    expectCompliance(result);
-  }
 }

--- a/packages/compiler/src/__tests__/compliance/ccts-matrix.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-matrix.spec.ts
@@ -1,4 +1,11 @@
 import { describe, expect, it } from "vitest";
+import {
+  expectCoverageCompleteness,
+  expectCoverageIntegrity,
+  expectInventoryRegistryParity,
+  expectSuiteRulePresence,
+  expectUniqueRuleIds,
+} from "@manifesto-ai/cts-kit";
 import { CCTS_SUITES } from "./ccts-types.js";
 import {
   COMPILER_COMPLIANCE_RULES,
@@ -9,48 +16,23 @@ import { COMPILER_COMPLIANCE_CASES, COMPILER_RULE_COVERAGE } from "./ccts-covera
 
 describe("CCTS Rule Matrix", () => {
   it("CCTS-MATRIX-001: rule ids are unique", () => {
-    const ids = COMPILER_COMPLIANCE_RULES.map((rule) => rule.ruleId);
-    expect(new Set(ids).size).toBe(ids.length);
+    expectUniqueRuleIds(COMPILER_COMPLIANCE_RULES);
   });
 
   it("CCTS-MATRIX-002: every inventory rule is registered with matching metadata", () => {
-    for (const inventoryRule of COMPILER_SPEC_INVENTORY) {
-      const rule = COMPILER_COMPLIANCE_RULES.find((candidate) => candidate.ruleId === inventoryRule.ruleId);
-      expect(rule, `Missing registry rule ${inventoryRule.ruleId}`).toBeDefined();
-      expect(rule?.suite).toBe(inventoryRule.suite);
-      expect(rule?.specSection).toBe(inventoryRule.specSection);
-      expect(rule?.level).toBe(inventoryRule.level);
-      expect(rule?.lifecycle).toBe(inventoryRule.lifecycle);
-    }
+    expectInventoryRegistryParity(COMPILER_SPEC_INVENTORY, COMPILER_COMPLIANCE_RULES);
   });
 
   it("CCTS-MATRIX-003: coverage references only registered rules and declared case ids", () => {
-    const ruleIds = new Set(COMPILER_COMPLIANCE_RULES.map((rule) => rule.ruleId));
-    const caseIds = new Set(COMPILER_COMPLIANCE_CASES.map((entry) => entry.caseId));
-
-    for (const coverage of COMPILER_RULE_COVERAGE) {
-      expect(ruleIds.has(coverage.ruleId), `Coverage references unknown rule ${coverage.ruleId}`).toBe(true);
-      expect(coverage.caseIds.length, `Coverage entry for ${coverage.ruleId} has no cases`).toBeGreaterThan(0);
-      for (const caseId of coverage.caseIds) {
-        expect(caseIds.has(caseId), `Coverage references unknown case ${caseId}`).toBe(true);
-      }
-    }
+    expectCoverageIntegrity(COMPILER_COMPLIANCE_RULES, COMPILER_COMPLIANCE_CASES, COMPILER_RULE_COVERAGE);
   });
 
   it("CCTS-MATRIX-004: every non-superseded registry rule is covered by at least one CCTS case", () => {
-    const coveredRuleIds = new Set(COMPILER_RULE_COVERAGE.map((coverage) => coverage.ruleId));
-    for (const rule of COMPILER_COMPLIANCE_RULES) {
-      if (rule.lifecycle === "superseded") {
-        continue;
-      }
-      expect(coveredRuleIds.has(rule.ruleId), `Rule ${rule.ruleId} is registered but uncovered`).toBe(true);
-    }
+    expectCoverageCompleteness(COMPILER_COMPLIANCE_RULES, COMPILER_RULE_COVERAGE);
   });
 
   it("CCTS-MATRIX-005: every suite has at least one mapped rule", () => {
-    for (const suite of CCTS_SUITES.filter((candidate) => candidate !== "matrix")) {
-      expect(getRulesBySuite(suite).length, `Suite ${suite} has no mapped rules`).toBeGreaterThan(0);
-    }
+    expectSuiteRulePresence(CCTS_SUITES, getRulesBySuite, { exclude: ["matrix"] });
   });
 
   it("CCTS-MATRIX-006: staged rule modes remain visible even when pending is empty", () => {

--- a/packages/compiler/src/__tests__/compliance/ccts-types.ts
+++ b/packages/compiler/src/__tests__/compliance/ccts-types.ts
@@ -1,3 +1,15 @@
+import type {
+  ComplianceCase,
+  ComplianceCoverageEntry,
+  ComplianceEvidence,
+  ComplianceInventoryItem,
+  ComplianceResult,
+  ComplianceRule,
+  ComplianceStatus,
+  RuleLevel,
+  RuleLifecycle,
+  RuleMode,
+} from "@manifesto-ai/cts-kit";
 import type { CompileTrace } from "../../api/compile-mel.js";
 import type { Diagnostic } from "../../diagnostics/types.js";
 import type { Token } from "../../lexer/index.js";
@@ -21,54 +33,28 @@ export const CCTS_SUITES = [
 
 export type CompilerComplianceSuite = (typeof CCTS_SUITES)[number];
 
-export type ComplianceStatus = "PASS" | "FAIL" | "SKIP" | "WARN";
-
-export type RuleMode = "blocking" | "pending" | "informational";
-
-export type RuleLevel = "MUST" | "SHOULD" | "MUST_NOT" | "MAY" | "CRITICAL";
-
-export type RuleLifecycle = "active" | "superseded";
+export type {
+  ComplianceStatus,
+  RuleLevel,
+  RuleLifecycle,
+  RuleMode,
+};
 
 export type CompilerPhase = "lex" | "parse" | "analyze" | "canonical" | "generate" | "compile" | "lower";
 
-export interface CompilerEvidence {
-  kind: "diagnostic" | "ast" | "schema" | "trace" | "note";
-  summary: string;
-  details?: unknown;
-}
+export type CompilerEvidenceKind = "diagnostic" | "ast" | "schema" | "trace" | "note";
 
-export interface CompilerComplianceInventoryItem {
-  ruleId: string;
-  specSection: string;
-  level: RuleLevel;
-  suite: CompilerComplianceSuite;
-  lifecycle: RuleLifecycle;
-  notes?: string;
-}
+export type CompilerEvidence = ComplianceEvidence<CompilerEvidenceKind>;
 
-export interface CompilerComplianceRule extends CompilerComplianceInventoryItem {
-  mode: RuleMode;
-}
+export type CompilerComplianceInventoryItem = ComplianceInventoryItem<CompilerComplianceSuite>;
 
-export interface CompilerComplianceCase {
-  caseId: string;
-  suite: CompilerComplianceSuite;
-  description: string;
-}
+export type CompilerComplianceRule = ComplianceRule<CompilerComplianceSuite>;
 
-export interface CompilerComplianceCoverageEntry {
-  ruleId: string;
-  caseIds: string[];
-}
+export type CompilerComplianceCase = ComplianceCase<CompilerComplianceSuite>;
 
-export interface CompilerComplianceResult {
-  ruleId: string;
-  specSection: string;
-  mode: RuleMode;
-  status: ComplianceStatus;
-  message?: string;
-  evidence?: CompilerEvidence[];
-}
+export type CompilerComplianceCoverageEntry = ComplianceCoverageEntry;
+
+export type CompilerComplianceResult = ComplianceResult<CompilerEvidence>;
 
 export interface CompilerPhaseSnapshot<T = unknown> {
   phase: CompilerPhase;

--- a/packages/compiler/vitest.config.ts
+++ b/packages/compiler/vitest.config.ts
@@ -1,6 +1,19 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+function fromHere(path: string): string {
+  return fileURLToPath(new URL(path, import.meta.url));
+}
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: "@manifesto-ai/cts-kit",
+        replacement: fromHere("../../cts/cts-kit/src/index.ts"),
+      },
+    ],
+  },
   test: {
     globals: true,
     environment: "node",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@manifesto-ai/core": "workspace:*",
+    "@manifesto-ai/cts-kit": "workspace:*",
     "typescript": "^5.9.3",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"

--- a/packages/host/src/__tests__/compliance/adapter-v2.ts
+++ b/packages/host/src/__tests__/compliance/adapter-v2.ts
@@ -4,6 +4,10 @@
  * Adapts the current ManifestoHost implementation to the
  * HostTestAdapter interface for compliance testing.
  *
+ * Split rationale: `hcts-adapter.ts` defines the implementation-agnostic
+ * HostTestAdapter contract plus the test effect runners; this file is the
+ * concrete adapter binding that contract to the current ManifestoHost.
+ *
  * @see host-SPEC.md
  */
 
@@ -219,7 +223,3 @@ export class V2HostAdapter implements HostTestAdapter {
 export function createV2Adapter(): HostTestAdapter {
   return new V2HostAdapter();
 }
-
-// For compatibility, also export as the default adapter
-export { createV2Adapter as createV1Adapter };
-export { V2HostAdapter as V1HostAdapter };

--- a/packages/host/src/__tests__/compliance/hcts-adapter.ts
+++ b/packages/host/src/__tests__/compliance/hcts-adapter.ts
@@ -5,6 +5,10 @@
  * to the HCTS test suite. This allows testing Host implementations
  * with the same compliance tests.
  *
+ * Split rationale: this file owns the implementation-agnostic
+ * HostTestAdapter contract and the test effect runners; the concrete
+ * adapter for the current ManifestoHost lives in `adapter-v2.ts`.
+ *
  * @see host-SPEC-compilance-test-suite.md §1.1
  */
 

--- a/packages/host/src/__tests__/compliance/hcts-assertions.ts
+++ b/packages/host/src/__tests__/compliance/hcts-assertions.ts
@@ -2,14 +2,27 @@
  * HCTS Assertion Utilities
  *
  * Provides assertion helpers for verifying SPEC compliance rules
- * based on trace events.
+ * based on trace events. Results use the shared CTS framework
+ * (`@manifesto-ai/cts-kit`); the trace analyzers themselves are
+ * Host-specific.
  *
  * @see host-SPEC-v2.0.1.md
  */
 
-import { expect } from "vitest";
-import type { TraceEvent, ExecutionKey, ComplianceResult } from "./hcts-types.js";
+export { expectCompliance, expectAllCompliance } from "@manifesto-ai/cts-kit";
+import type { TraceEvent, ExecutionKey, ComplianceResult, HostEvidence } from "./hcts-types.js";
 import type { Snapshot } from "@manifesto-ai/core";
+
+/**
+ * Wrap raw trace events as shared-framework evidence entries.
+ */
+export function traceEvidence(events: readonly TraceEvent[]): HostEvidence[] {
+  return events.map((event) => ({
+    kind: "trace",
+    summary: formatTraceEvent(event),
+    details: event,
+  }));
+}
 
 // =============================================================================
 // Runner / Liveness Assertions (RUN-1~4, LIVE-1~4)
@@ -46,14 +59,18 @@ export function assertSingleRunner(
   if (violations.length > 0) {
     return {
       ruleId: "RUN-1",
+      specSection: "RUN-1, RUN-2, INV-EX-4",
+      mode: "blocking",
       status: "FAIL",
       message: `Multiple concurrent runners detected for key "${key}"`,
-      evidence: violations,
+      evidence: traceEvidence(violations),
     };
   }
 
   return {
     ruleId: "RUN-1",
+    specSection: "RUN-1, RUN-2, INV-EX-4",
+    mode: "blocking",
     status: "PASS",
   };
 }
@@ -75,14 +92,18 @@ export function assertEmptyToNonEmptyKick(
   if (hasJob && !hasRunnerStart) {
     return {
       ruleId: "LIVE-2",
+      specSection: "LIVE-2",
+      mode: "blocking",
       status: "FAIL",
       message: "Job executed without runner being started (kick missing)",
-      evidence: keyEvents.filter((e) => e.t === "job:start"),
+      evidence: traceEvidence(keyEvents.filter((e) => e.t === "job:start")),
     };
   }
 
   return {
     ruleId: "LIVE-2",
+    specSection: "LIVE-2",
+    mode: "blocking",
     status: "PASS",
   };
 }
@@ -104,6 +125,8 @@ export function assertLostWakeupPrevention(
   if (recheckEvents.length > 0) {
     return {
       ruleId: "RUN-4/LIVE-4",
+      specSection: "RUN-4, LIVE-4",
+      mode: "informational",
       status: "PASS",
       message: "Runner recheck observed before guard release",
     };
@@ -111,6 +134,8 @@ export function assertLostWakeupPrevention(
 
   return {
     ruleId: "RUN-4/LIVE-4",
+    specSection: "RUN-4, LIVE-4",
+    mode: "informational",
     status: "WARN",
     message: "Runner recheck events not observed (may not be instrumented)",
   };
@@ -153,14 +178,18 @@ export function assertRunToCompletion(
   if (violations.length > 0) {
     return {
       ruleId: "JOB-1",
+      specSection: "JOB-1, JOB-2, INV-EX-3",
+      mode: "blocking",
       status: "FAIL",
       message: "Job interleaving detected (await in job handler?)",
-      evidence: violations,
+      evidence: traceEvidence(violations),
     };
   }
 
   return {
     ruleId: "JOB-1",
+    specSection: "JOB-1, JOB-2, INV-EX-3",
+    mode: "blocking",
     status: "PASS",
   };
 }
@@ -204,14 +233,18 @@ export function assertApplyBeforeDispatch(
   if (violations.length > 0) {
     return {
       ruleId: "COMP-REQ-INTERLOCK-1",
+      specSection: "COMP-REQ-INTERLOCK-1, INV-EX-15",
+      mode: "blocking",
       status: "FAIL",
       message: "Effect dispatch occurred before compute apply + applySystemDelta",
-      evidence: violations,
+      evidence: traceEvidence(violations),
     };
   }
 
   return {
     ruleId: "COMP-REQ-INTERLOCK-1",
+    specSection: "COMP-REQ-INTERLOCK-1, INV-EX-15",
+    mode: "blocking",
     status: "PASS",
   };
 }
@@ -235,6 +268,8 @@ export function assertRequirementCleared(
   if (isPending) {
     return {
       ruleId: "REQ-CLEAR-1",
+      specSection: "REQ-CLEAR-1, INV-RL-2",
+      mode: "blocking",
       status: "FAIL",
       message: `Requirement "${requirementId}" still in pendingRequirements after fulfillment`,
     };
@@ -242,6 +277,8 @@ export function assertRequirementCleared(
 
   return {
     ruleId: "REQ-CLEAR-1",
+    specSection: "REQ-CLEAR-1, INV-RL-2",
+    mode: "blocking",
     status: "PASS",
   };
 }
@@ -262,14 +299,18 @@ export function assertNoInfiniteLoop(
   if (dispatchEvents.length > maxExecutions) {
     return {
       ruleId: "REQ-CLEAR-1",
+      specSection: "REQ-CLEAR-1",
+      mode: "blocking",
       status: "FAIL",
       message: `Requirement "${requirementId}" executed ${dispatchEvents.length} times (infinite loop?)`,
-      evidence: dispatchEvents,
+      evidence: traceEvidence(dispatchEvents),
     };
   }
 
   return {
     ruleId: "REQ-CLEAR-1",
+    specSection: "REQ-CLEAR-1",
+    mode: "blocking",
     status: "PASS",
   };
 }
@@ -296,6 +337,8 @@ export function assertStaleFulfillmentDropped(
   if (dropEvents.length > 0) {
     return {
       ruleId: "FULFILL-0",
+      specSection: "FULFILL-0, INV-EX-13",
+      mode: "blocking",
       status: "PASS",
       message: "Stale fulfillment correctly dropped",
     };
@@ -309,14 +352,18 @@ export function assertStaleFulfillmentDropped(
   if (applyEvents.length > 0) {
     return {
       ruleId: "FULFILL-0",
+      specSection: "FULFILL-0, INV-EX-13",
+      mode: "blocking",
       status: "FAIL",
       message: "Stale fulfillment was applied instead of dropped",
-      evidence: applyEvents,
+      evidence: traceEvidence(applyEvents),
     };
   }
 
   return {
     ruleId: "FULFILL-0",
+    specSection: "FULFILL-0, INV-EX-13",
+    mode: "blocking",
     status: "WARN",
     message: "Could not verify stale fulfillment handling",
   };
@@ -338,6 +385,8 @@ export function assertClearOnApplyFailure(
   if (errorEvents.length === 0) {
     return {
       ruleId: "ERR-FE-2",
+      specSection: "ERR-FE-1, ERR-FE-2, INV-EX-12, INV-EX-14",
+      mode: "blocking",
       status: "SKIP",
       message: "No apply error occurred to test",
     };
@@ -351,9 +400,11 @@ export function assertClearOnApplyFailure(
   if (clearEvents.length === 0) {
     return {
       ruleId: "ERR-FE-2",
+      specSection: "ERR-FE-1, ERR-FE-2, INV-EX-12, INV-EX-14",
+      mode: "blocking",
       status: "FAIL",
       message: "Requirement not cleared after apply failure",
-      evidence: errorEvents,
+      evidence: traceEvidence(errorEvents),
     };
   }
 
@@ -365,6 +416,8 @@ export function assertClearOnApplyFailure(
   if (isPending) {
     return {
       ruleId: "ERR-FE-2",
+      specSection: "ERR-FE-1, ERR-FE-2, INV-EX-12, INV-EX-14",
+      mode: "blocking",
       status: "FAIL",
       message: "Requirement still pending in snapshot after apply failure",
     };
@@ -372,6 +425,8 @@ export function assertClearOnApplyFailure(
 
   return {
     ruleId: "ERR-FE-2",
+    specSection: "ERR-FE-1, ERR-FE-2, INV-EX-12, INV-EX-14",
+    mode: "blocking",
     status: "PASS",
   };
 }
@@ -389,6 +444,8 @@ export function assertContinueAfterError(
   if (errorEvents.length === 0) {
     return {
       ruleId: "ERR-FE-5",
+      specSection: "ERR-FE-5, INV-EX-17",
+      mode: "blocking",
       status: "SKIP",
       message: "No error occurred to test",
     };
@@ -402,6 +459,8 @@ export function assertContinueAfterError(
   if (continueEvents.length === 0) {
     return {
       ruleId: "ERR-FE-5",
+      specSection: "ERR-FE-5, INV-EX-17",
+      mode: "blocking",
       status: "FAIL",
       message: "ContinueCompute not enqueued after error",
     };
@@ -409,6 +468,8 @@ export function assertContinueAfterError(
 
   return {
     ruleId: "ERR-FE-5",
+    specSection: "ERR-FE-5, INV-EX-17",
+    mode: "blocking",
     status: "PASS",
   };
 }
@@ -469,9 +530,11 @@ export function assertContextFrozenPerJob(
         ) {
           return {
             ruleId: "CTX-1",
+            specSection: "CTX-1, CTX-2, INV-CTX-1, INV-CTX-2",
+            mode: "blocking",
             status: "FAIL",
             message: `Context changed during job "${jobId}"`,
-            evidence: events,
+            evidence: traceEvidence(events),
           };
         }
       }
@@ -480,6 +543,8 @@ export function assertContextFrozenPerJob(
 
   return {
     ruleId: "CTX-1",
+    specSection: "CTX-1, CTX-2, INV-CTX-1, INV-CTX-2",
+    mode: "blocking",
     status: "PASS",
   };
 }
@@ -506,51 +571,41 @@ export function getExecutionKeys(trace: TraceEvent[]): ExecutionKey[] {
 }
 
 /**
- * Extract event timeline for debugging
+ * Format a single trace event for evidence/debugging output
  */
-export function formatTimeline(trace: TraceEvent[]): string {
-  return trace
-    .map((e) => {
-      const key = e.key.substring(0, 8);
-      switch (e.t) {
-        case "runner:start":
-          return `[${key}] RUNNER START @ ${e.timestamp}`;
-        case "runner:end":
-          return `[${key}] RUNNER END @ ${e.timestamp}`;
-        case "job:start":
-          return `[${key}] JOB START: ${e.jobType} (${e.jobId})`;
-        case "job:end":
-          return `[${key}] JOB END: ${e.jobType} (${e.jobId})`;
-        case "core:compute":
-          return `[${key}] COMPUTE: ${e.intentId} iter=${e.iteration}`;
-        case "core:apply":
-          return `[${key}] APPLY: ${e.patchCount} patches (${e.source})`;
-        case "core:applyNamespaceDeltas":
-          return `[${key}] APPLY_NAMESPACE_DELTAS: ${e.namespaceCount} namespaces, ${e.patchCount} patches (${e.source})`;
-        case "core:applySystemDelta":
-          return `[${key}] APPLY_SYSTEM_DELTA: (${e.source})`;
-        case "effect:dispatch":
-          return `[${key}] DISPATCH: ${e.effectType} (${e.requirementId})`;
-        case "requirement:clear":
-          return `[${key}] CLEAR: ${e.requirementId}`;
-        case "continue:enqueue":
-          return `[${key}] CONTINUE: ${e.intentId}`;
-        default:
-          return `[${key}] ${e.t}`;
-      }
-    })
-    .join("\n");
+function formatTraceEvent(e: TraceEvent): string {
+  const key = e.key.substring(0, 8);
+  switch (e.t) {
+    case "runner:start":
+      return `[${key}] RUNNER START @ ${e.timestamp}`;
+    case "runner:end":
+      return `[${key}] RUNNER END @ ${e.timestamp}`;
+    case "job:start":
+      return `[${key}] JOB START: ${e.jobType} (${e.jobId})`;
+    case "job:end":
+      return `[${key}] JOB END: ${e.jobType} (${e.jobId})`;
+    case "core:compute":
+      return `[${key}] COMPUTE: ${e.intentId} iter=${e.iteration}`;
+    case "core:apply":
+      return `[${key}] APPLY: ${e.patchCount} patches (${e.source})`;
+    case "core:applyNamespaceDeltas":
+      return `[${key}] APPLY_NAMESPACE_DELTAS: ${e.namespaceCount} namespaces, ${e.patchCount} patches (${e.source})`;
+    case "core:applySystemDelta":
+      return `[${key}] APPLY_SYSTEM_DELTA: (${e.source})`;
+    case "effect:dispatch":
+      return `[${key}] DISPATCH: ${e.effectType} (${e.requirementId})`;
+    case "requirement:clear":
+      return `[${key}] CLEAR: ${e.requirementId}`;
+    case "continue:enqueue":
+      return `[${key}] CONTINUE: ${e.intentId}`;
+    default:
+      return `[${key}] ${e.t}`;
+  }
 }
 
 /**
- * Assert helper for easier test writing
+ * Extract event timeline for debugging
  */
-export function expectCompliance(result: ComplianceResult): void {
-  if (result.status === "FAIL") {
-    const message = result.message ?? `Rule ${result.ruleId} violated`;
-    const evidence = result.evidence
-      ? `\n\nEvidence:\n${formatTimeline(result.evidence)}`
-      : "";
-    expect.fail(`${message}${evidence}`);
-  }
+export function formatTimeline(trace: TraceEvent[]): string {
+  return trace.map(formatTraceEvent).join("\n");
 }

--- a/packages/host/src/__tests__/compliance/hcts-types.ts
+++ b/packages/host/src/__tests__/compliance/hcts-types.ts
@@ -7,6 +7,11 @@
  * @see host-SPEC-v2.0.1.md
  */
 
+import type {
+  ComplianceEvidence,
+  ComplianceResult as KitComplianceResult,
+} from "@manifesto-ai/cts-kit";
+
 /**
  * Opaque execution key for single-writer serialization.
  * @see SPEC §3.6 ExecutionKey
@@ -96,19 +101,22 @@ export type TraceEvent =
     };
 
 /**
- * Compliance result status
+ * Compliance result types come from the shared CTS framework.
+ *
+ * HCTS evidence wraps raw TraceEvents as `kind: "trace"` evidence entries
+ * so the shared `expectCompliance` reporting can render them.
  */
-export type ComplianceStatus = "PASS" | "FAIL" | "SKIP" | "WARN";
+export type { ComplianceStatus, RuleMode } from "@manifesto-ai/cts-kit";
+
+/**
+ * Trace-backed evidence entry for HCTS results.
+ */
+export type HostEvidence = ComplianceEvidence<"trace">;
 
 /**
  * Compliance result for a single rule
  */
-export interface ComplianceResult {
-  ruleId: string;
-  status: ComplianceStatus;
-  message?: string;
-  evidence?: TraceEvent[];
-}
+export type ComplianceResult = KitComplianceResult<HostEvidence>;
 
 /**
  * Effect execution policy for ordering tests

--- a/packages/host/src/__tests__/compliance/suite/context.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/context.spec.ts
@@ -16,7 +16,7 @@ const pp = semanticPathToPatchPath;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import {
   assertContextFrozenPerJob,
@@ -36,7 +36,7 @@ describe("HCTS Context Determinism Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/fulfill.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/fulfill.spec.ts
@@ -16,7 +16,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createCore, type ManifestoCore } from "@manifesto-ai/core";
 import type { TraceEvent } from "../hcts-types.js";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter, type V1HostAdapter } from "../adapter-v2.js";
+import { createV2Adapter, type V2HostAdapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import {
   assertRequirementCleared,
@@ -41,7 +41,7 @@ describe("HCTS Fulfillment Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/handler.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/handler.spec.ts
@@ -16,7 +16,7 @@ const pp = semanticPathToPatchPath;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import {
   createTestSchema,
@@ -33,7 +33,7 @@ describe("HCTS Effect Handler Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/intent.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/intent.spec.ts
@@ -13,7 +13,7 @@ const pp = semanticPathToPatchPath;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import {
   createTestSchema,
@@ -29,7 +29,7 @@ describe("HCTS Intent Processing Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/interlock.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/interlock.spec.ts
@@ -14,7 +14,7 @@ const pp = semanticPathToPatchPath;
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { TraceEvent } from "../hcts-types.js";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import type { ExecutionContext } from "../../../types/execution.js";
 import { handleStartIntent } from "../../../job-handlers/start-intent.js";
@@ -39,7 +39,7 @@ describe("HCTS Interlock Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/job.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/job.spec.ts
@@ -16,7 +16,7 @@ const pp = semanticPathToPatchPath;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import {
   assertRunToCompletion,
@@ -36,7 +36,7 @@ describe("HCTS Job Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/liveness.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/liveness.spec.ts
@@ -15,7 +15,7 @@ const pp = semanticPathToPatchPath;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import {
   assertLostWakeupPrevention,
@@ -35,7 +35,7 @@ describe("HCTS Liveness Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/mailbox.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/mailbox.spec.ts
@@ -15,7 +15,7 @@ const pp = semanticPathToPatchPath;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import {
   createTestSchema,
@@ -30,7 +30,7 @@ describe("HCTS Mailbox Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/ordering.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/ordering.spec.ts
@@ -15,7 +15,7 @@ const pp = semanticPathToPatchPath;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import type { TraceEvent } from "../hcts-types.js";
 import {
@@ -32,7 +32,7 @@ describe("HCTS Ordering Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/reinjection.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/reinjection.spec.ts
@@ -15,7 +15,7 @@ const pp = semanticPathToPatchPath;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import type { TraceEvent } from "../hcts-types.js";
 import {
@@ -32,7 +32,7 @@ describe("HCTS Reinjection Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/runner.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/runner.spec.ts
@@ -18,7 +18,7 @@ const pp = semanticPathToPatchPath;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import {
   assertSingleRunner,
@@ -39,7 +39,7 @@ describe("HCTS Runner Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/src/__tests__/compliance/suite/snapshot.spec.ts
+++ b/packages/host/src/__tests__/compliance/suite/snapshot.spec.ts
@@ -14,7 +14,7 @@ const pp = semanticPathToPatchPath;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestRuntime, type DeterministicRuntime } from "../hcts-runtime.js";
-import { createV1Adapter } from "../adapter-v2.js";
+import { createV2Adapter } from "../adapter-v2.js";
 import type { HostTestAdapter } from "../hcts-adapter.js";
 import {
   DEFAULT_HOST_CONTEXT,
@@ -34,7 +34,7 @@ describe("HCTS Snapshot Ownership Tests", () => {
 
   beforeEach(async () => {
     runtime = createTestRuntime();
-    adapter = createV1Adapter();
+    adapter = createV2Adapter();
   });
 
   afterEach(async () => {

--- a/packages/host/vitest.config.ts
+++ b/packages/host/vitest.config.ts
@@ -1,6 +1,19 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+function fromHere(path: string): string {
+  return fileURLToPath(new URL(path, import.meta.url));
+}
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: "@manifesto-ai/cts-kit",
+        replacement: fromHere("../../cts/cts-kit/src/index.ts"),
+      },
+    ],
+  },
   test: {
     include: ["src/**/*.test.ts", "src/**/*.spec.ts"],
     coverage: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@manifesto-ai/core':
         specifier: workspace:*
         version: link:../core
+      '@manifesto-ai/cts-kit':
+        specifier: workspace:*
+        version: link:../../cts/cts-kit
       '@types/node':
         specifier: ^25.5.2
         version: 25.6.0
@@ -248,6 +251,9 @@ importers:
       '@manifesto-ai/core':
         specifier: workspace:*
         version: link:../core
+      '@manifesto-ai/cts-kit':
+        specifier: workspace:*
+        version: link:../../cts/cts-kit
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

Six compliance suites exist in the monorepo; core, lineage, governance, and activation-cts already share the `@manifesto-ai/cts-kit` framework, while compiler (CCTS) and host (HCTS) carried their own parallel copies of the same skeleton. This PR unifies all six onto cts-kit.

### cts-kit
- `ComplianceEvidence` gains a `kind` type parameter (default `"note"`, so existing consumers are byte-for-byte unaffected). This lets suites with richer evidence kinds — compiler diagnostics, host trace events — reuse the shared assertion helpers instead of duplicating them.
- Package description no longer uses the retired World-era "LGW" term: "Internal compliance test kit shared by all Manifesto CTS suites".

### compiler (CCTS)
- `ccts-types.ts` now parameterizes kit types (`ComplianceRule<CompilerComplianceSuite>` etc.); only the compiler-specific phase-snapshot/adapter types remain local.
- `ccts-assertions.ts` re-exports kit builders (`evaluateRule`, `passRule`, `failRule`, `warnRule`, `noteEvidence`, `expectCompliance`, `expectAllCompliance`) and keeps only the compiler-specific `diagnosticEvidence` / `hasDiagnosticCode`. The unused local `skipRule` copy is dropped.
- `ccts-matrix.spec.ts` uses the kit matrix validators (same six test cases, same ids).
- Rules / spec-inventory / coverage content and all `suite/*.spec.ts` files are unchanged.
- Adds `@manifesto-ai/cts-kit` (workspace:*) devDependency + vitest src alias (same pattern as lineage/governance).

### host (HCTS)
- `hcts-types.ts` drops its local `ComplianceStatus`/`ComplianceResult` copies; results are now kit-shaped (`ruleId` + `specSection` + `mode`) with `kind: "trace"` evidence wrapping raw `TraceEvent`s.
- `hcts-assertions.ts` keeps all Host-specific trace analyzers and re-exports the kit `expectCompliance`/`expectAllCompliance`; failure output still renders the trace timeline via evidence summaries.
- `adapter-v2.ts` vs `hcts-adapter.ts` investigation: they are complementary, not duplicates — `hcts-adapter.ts` owns the implementation-agnostic `HostTestAdapter` contract + test effect runners, `adapter-v2.ts` is the concrete `ManifestoHost` binding. Both now document this split. The stale `createV1Adapter` / `V1HostAdapter` compat aliases are removed; suites import `createV2Adapter` directly.

### docs
- `docs/internals/test-conventions.md` documents the two-tier CTS taxonomy: package CTS (own SPEC, may use internal adapters) vs cross-package activation CTS (public surfaces only), with cts-kit as the single shared framework.

## Verification

Test counts before and after are identical — no assertions weakened:

| Suite | Before | After |
|---|---|---|
| `pnpm --filter @manifesto-ai/compiler test` | 652 tests / 39 files | 652 tests / 39 files |
| `pnpm --filter @manifesto-ai/host test` | 205 tests / 22 files | 205 tests / 22 files |
| `pnpm test` (full workspace) | — | 18/18 tasks green |

Net: −68 LOC in the compiler/host compliance directories (+205/−273), −9 LOC repo-wide excluding docs/lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)