### PR TITLE
docs(core): define onceIntent causal guard scope

### DIFF
--- a/packages/compiler/docs/SPEC-v1.2.0.md
+++ b/packages/compiler/docs/SPEC-v1.2.0.md
@@ -224,6 +224,10 @@ Normative rules:
 - The compiler MUST emit Core `causalGuard` and MUST NOT emit a MEL namespace
   read/write path for `onceIntent`.
 - The Core `causalGuard` primitive owns any runtime bookkeeping it needs.
+- `onceIntent` inherits `causalGuard` scope: it is a runtime re-entry guard for
+  the current causal transition attempt, not a durable idempotency key for
+  lineage-global, branch-global, restore-stable, or governance proposal-global
+  deduplication.
 - Adding another compiler-owned runtime construct requires a new ADR before it
   becomes current SPEC behavior.
 

--- a/packages/compiler/src/__tests__/compliance/suite/actions-and-control.spec.ts
+++ b/packages/compiler/src/__tests__/compliance/suite/actions-and-control.spec.ts
@@ -129,7 +129,7 @@ describe("CCTS Actions and Control Suite", () => {
   it(
     caseTitle(
       CCTS_CASES.ACTIONS_ONCE_INTENT_DESUGARING,
-      "(COMPILER-MEL-1) onceIntent lowers to Core intent guards",
+      "(COMPILER-MEL-1) onceIntent lowers to transition-scoped Core intent guards",
     ),
     () => {
       const result = adapter.compile(`
@@ -153,7 +153,8 @@ describe("CCTS Actions and Control Suite", () => {
 
       expectAllCompliance([
         evaluateRule(getRuleOrThrow("COMPILER-MEL-1"), satisfied, {
-          passMessage: "onceIntent lowers to a Core-owned generic intent guard.",
+          passMessage:
+            "onceIntent lowers to a Core-owned runtime re-entry guard, not a durable global idempotency key.",
           failMessage: "onceIntent no longer lowers to the expected Core intent guard.",
           evidence: [noteEvidence("Observed flow", flow)],
         }),

--- a/packages/core/docs/core-SPEC.md
+++ b/packages/core/docs/core-SPEC.md
@@ -1500,7 +1500,11 @@ In this specification, domain-owned mutable state is stored under `snapshot.stat
 | `causalGuard` | Core | Core-owned per-causal-intent bookkeeping | Core |
 
 Compiler `onceIntent` lowers to Core `causalGuard`. Core MUST NOT know MEL
-namespace names or MEL-owned storage shape.
+namespace names or MEL-owned storage shape. `causalGuard` is a runtime
+re-entry primitive: it prevents the guarded block from executing more than once
+for the same causal intent id against the current canonical Snapshot
+bookkeeping. It is not a lineage-global, branch-global, restore-stable, or
+governance proposal-global idempotency mechanism.
 
 ### 13.5 Requirements
 

--- a/packages/core/src/core/compute.test.ts
+++ b/packages/core/src/core/compute.test.ts
@@ -1148,6 +1148,103 @@ describe("compute", () => {
     });
   });
 
+  describe("causalGuard scope", () => {
+    function createCausalGuardSchema(): DomainSchema {
+      return createTestSchema({
+        state: {
+          fields: {
+            count: { type: "number", required: true },
+            lastIntentId: { type: "string", required: true },
+          },
+        },
+        actions: {
+          record: {
+            flow: {
+              kind: "causalGuard",
+              guardId: "record-once-intent",
+              body: {
+                kind: "seq",
+                steps: [
+                  {
+                    kind: "patch",
+                    op: "set",
+                    path: pp("count"),
+                    value: {
+                      kind: "add",
+                      left: { kind: "get", path: "count" },
+                      right: { kind: "lit", value: 1 },
+                    },
+                  },
+                  {
+                    kind: "patch",
+                    op: "set",
+                    path: pp("lastIntentId"),
+                    value: { kind: "get", path: "$runtime.intent.id" },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+    }
+
+    it("skips repeated block for the same causal intent in the same canonical snapshot", async () => {
+      const schema = createCausalGuardSchema();
+      const initial = createTestSnapshot({ count: 0, lastIntentId: "" }, schema.hash);
+      const intent = createIntent("record", "intent-same");
+
+      const first = await compute(schema, initial, intent, HOST_CONTEXT);
+      const second = await compute(schema, first.snapshot, intent, HOST_CONTEXT);
+
+      expect(first.snapshot.state).toMatchObject({
+        count: 1,
+        lastIntentId: "intent-same",
+      });
+      expect(first.snapshot.namespaces).toMatchObject({
+        core: {
+          causalGuards: {
+            "record-once-intent": "intent-same",
+          },
+        },
+      });
+      expect(second.snapshot.state).toMatchObject({
+        count: 1,
+        lastIntentId: "intent-same",
+      });
+      expect(second.patches).toEqual([]);
+      expect(second.namespaceDelta ?? []).toEqual([]);
+    });
+
+    it("does not imply restore-stable global dedupe", async () => {
+      const schema = createCausalGuardSchema();
+      const initial = createTestSnapshot({ count: 0, lastIntentId: "" }, schema.hash);
+      const intent = createIntent("record", "intent-same");
+
+      const first = await compute(schema, initial, intent, HOST_CONTEXT);
+      const restoreLikeSnapshot = {
+        ...first.snapshot,
+        namespaces: {
+          host: {},
+          mel: {},
+        },
+      };
+      const second = await compute(schema, restoreLikeSnapshot, intent, HOST_CONTEXT);
+
+      expect(second.snapshot.state).toMatchObject({
+        count: 2,
+        lastIntentId: "intent-same",
+      });
+      expect(second.snapshot.namespaces).toMatchObject({
+        core: {
+          causalGuards: {
+            "record-once-intent": "intent-same",
+          },
+        },
+      });
+    });
+  });
+
   describe("Availability on Re-Entry (#134)", () => {
     it("should keep action valid when re-entering after effect mutates available fields", async () => {
       const schema = createTestSchema({

--- a/packages/governance/docs/governance-SPEC.md
+++ b/packages/governance/docs/governance-SPEC.md
@@ -351,7 +351,9 @@ type GovernanceSettlementResult<
 
 `settled` is used only when authority permits execution and the runtime reaches
 a sealed world result. Rejected, superseded, expired, and cancelled proposals are
-governance lifecycle outcomes, not execution outcomes.
+governance lifecycle outcomes, not execution outcomes. They do not run the
+SDK/Host/Core execution path and therefore do not consume runtime re-entry
+guards such as Core `causalGuard` / compiler `onceIntent`.
 
 For `settled` results, `before` MUST be the projected snapshot at
 `proposal.baseWorld` and `after` MUST be the projected snapshot of the sealed

--- a/packages/governance/src/with-governance.test.ts
+++ b/packages/governance/src/with-governance.test.ts
@@ -965,7 +965,7 @@ describe("@manifesto-ai/governance decorator runtime", () => {
     expect(restarted.snapshot().state.count).toBe(1);
   });
 
-  it("returns evaluating proposals for HITL and resolves them through approve/reject", async () => {
+  it("returns evaluating proposals for HITL and does not consume runtime guards on reject", async () => {
     const governed = withGovernance(
       withLineage(createManifesto<CounterDomain>(createCounterSchema(), {}), {
         store: createInMemoryLineageStore(),
@@ -1015,6 +1015,21 @@ describe("@manifesto-ai/governance decorator runtime", () => {
       },
     });
     expect(governed.snapshot().state.count).toBe(1);
+
+    const acceptedAfterRejection = await submitAdd(governed, 2);
+    const proposalAfterRejection = await getStoredProposal(
+      governed,
+      acceptedAfterRejection.proposal,
+    );
+    const approvedAfterRejection = await governed.approve(proposalAfterRejection.proposalId);
+    const settledAfterRejection = await governed.waitForSettlement(acceptedAfterRejection.proposal);
+
+    expect(approvedAfterRejection.status).toBe("completed");
+    expect(settledAfterRejection).toMatchObject({
+      ok: true,
+      status: "settled",
+      after: { state: { count: 3 } },
+    });
   });
 
   it("fails terminal observation when a referenced decision record is missing", async () => {

--- a/packages/lineage/docs/lineage-SPEC.md
+++ b/packages/lineage/docs/lineage-SPEC.md
@@ -418,6 +418,10 @@ ADR-025 separates stored canonical lookup from execution restore:
 - runtime restore MUST normalize `snapshot.namespaces` structurally without
   interpreting owner-specific namespace shapes. Namespace owners define any
   owner-specific restore semantics outside Lineage.
+- Operational guard bookkeeping, including Core `causalGuard` state used by
+  compiler `onceIntent`, is restore residue rather than lineage identity.
+  Restore and branch switching therefore do not provide global deduplication
+  for a reused raw intent id.
 
 | Rule ID | Level | Description |
 |---------|-------|-------------|

--- a/packages/lineage/src/lineage-service.test.ts
+++ b/packages/lineage/src/lineage-service.test.ts
@@ -207,7 +207,7 @@ describe("@manifesto-ai/lineage service", () => {
     expect(await service.getAttempts(failed.worldId)).toHaveLength(1);
   });
 
-  it("supports branch creation, branch switching, idempotent reuse, and snapshot restore normalization", async () => {
+  it("supports branch switching, idempotent reuse, and operational guard restore normalization", async () => {
     const store = createInMemoryLineageStore();
     const service = createLineageService(store);
     const genesis = await service.prepareSealGenesis({
@@ -236,6 +236,7 @@ describe("@manifesto-ai/lineage service", () => {
           namespaces: {
             host: { trace: "first" },
             mel: { guards: { intent: { stale: "true" } } },
+            core: { causalGuards: { "record-once-intent": "intent-canonical" } },
           },
         },
       ),
@@ -268,6 +269,7 @@ describe("@manifesto-ai/lineage service", () => {
           namespaces: {
             host: { trace: "second" },
             mel: { guards: { intent: { stale: "false" } } },
+            core: { causalGuards: { "record-once-intent": "intent-reused" } },
           },
         },
       ),
@@ -299,6 +301,7 @@ describe("@manifesto-ai/lineage service", () => {
         schemaHash: "schema-hash",
       },
       namespaces: {
+        core: {},
         host: {},
         mel: {},
       },


### PR DESCRIPTION
## Summary

- Defines #394 as a spec/conformance gap, not a runtime bug.
- Clarifies that compiler `onceIntent` lowers to Core `causalGuard` and is scoped to runtime re-entry / the current causal transition attempt.
- Documents that `onceIntent` / `causalGuard` is not lineage-global, branch-global, restore-stable, or governance proposal-global deduplication.

## Changes

- Adds Core/Compiler/Lineage/Governance spec language for the guard scope contract.
- Adds Core regression coverage for repeated same-intent execution against the same canonical snapshot and restore-like namespace reset.
- Extends Lineage restore normalization coverage to include Core guard bookkeeping.
- Extends Governance HITL rejection coverage to show rejected proposals do not consume execution guard scope.

## Validation

- `pnpm --filter @manifesto-ai/core test -- src/core/compute.test.ts -t "causalGuard scope"`
- `pnpm --filter @manifesto-ai/compiler test -- src/__tests__/compliance/suite/actions-and-control.spec.ts -t "onceIntent"`
- `pnpm --filter @manifesto-ai/lineage test:runtime -- src/lineage-service.test.ts -t "operational guard restore normalization"`
- `pnpm --filter @manifesto-ai/governance test:runtime -- src/with-governance.test.ts -t "does not consume runtime guards on reject"`
- `pnpm --filter @manifesto-ai/core lint`
- `pnpm --filter @manifesto-ai/compiler lint`
- `pnpm --filter @manifesto-ai/lineage lint`
- `pnpm --filter @manifesto-ai/governance lint`
- `node scripts/check-package-boundaries.mjs`
- `node scripts/check-doc-snippets.mjs`
- `pnpm docs:check`

Closes #394